### PR TITLE
Feat/price based triggers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
   },
   moduleNameMapper: {
     "^@galaxy/core-oracles$": "<rootDir>/packages/core/oracles/src/index.ts",
+    "^@galaxy-kj/core-oracles$": "<rootDir>/packages/core/oracles/src/index.ts",
     "^chalk$": "<rootDir>/tools/cli/__tests__/__mocks__/chalk.ts",
     "^ora$": "<rootDir>/tools/cli/__tests__/__mocks__/ora.ts",
     // Resolve relative .js imports to .ts (ESM-style imports in tools/cli)

--- a/packages/core/automation/package.json
+++ b/packages/core/automation/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@galaxy-kj/core-invisible-wallet": "^5.0.0",
+    "@galaxy-kj/core-oracles": "*",
     "@galaxy-kj/core-stellar-sdk": "^5.0.0",
     "@supabase/supabase-js": "^2.38.0",
     "node-cron": "^3.0.3"

--- a/packages/core/automation/src/test/automation.test.ts
+++ b/packages/core/automation/src/test/automation.test.ts
@@ -96,7 +96,7 @@ describe('AutomationService', () => {
 
     mockConditionEvaluator.evaluateConditionGroup = jest
       .fn()
-      .mockReturnValue(true);
+      .mockResolvedValue(true);
     mockConditionEvaluator.validateConditionGroup = jest
       .fn()
       .mockReturnValue({ valid: true });
@@ -274,7 +274,7 @@ describe('AutomationService', () => {
     });
 
     it('should return error if conditions not met', async () => {
-      mockConditionEvaluator.evaluateConditionGroup.mockReturnValue(false);
+      mockConditionEvaluator.evaluateConditionGroup.mockResolvedValue(false);
 
       const result = await automationService.executeRule('test-rule-1');
 
@@ -436,7 +436,7 @@ describe('AutomationService', () => {
       const listener = jest.fn();
       automationService.on('rule:conditions_not_met', listener);
 
-      mockConditionEvaluator.evaluateConditionGroup.mockReturnValue(false);
+      mockConditionEvaluator.evaluateConditionGroup.mockResolvedValue(false);
 
       await automationService.executeRule('test-rule-1');
 
@@ -692,7 +692,7 @@ describe('AutomationService', () => {
       await automationService.registerRule(rule);
     });
 
-    it('should test rule conditions', () => {
+    it('should test rule conditions', async () => {
       const context = {
         ruleId: 'test-rule-1',
         userId: 'user123',
@@ -700,9 +700,9 @@ describe('AutomationService', () => {
         marketData: { XLM: { priceUSD: 0.09 } },
       };
 
-      mockConditionEvaluator.evaluateConditionGroup.mockReturnValue(true);
+      mockConditionEvaluator.evaluateConditionGroup.mockResolvedValue(true);
 
-      const result = automationService.testRuleConditions(
+      const result = await automationService.testRuleConditions(
         'test-rule-1',
         context
       );
@@ -710,16 +710,16 @@ describe('AutomationService', () => {
       expect(mockConditionEvaluator.evaluateConditionGroup).toHaveBeenCalled();
     });
 
-    it('should throw error if rule not found', () => {
+    it('should throw error if rule not found', async () => {
       const context = {
         ruleId: 'non-existent',
         userId: 'user123',
         timestamp: new Date(),
       };
 
-      expect(() =>
+      await expect(
         automationService.testRuleConditions('non-existent', context)
-      ).toThrow('Rule not found');
+      ).rejects.toThrow('Rule not found');
     });
   });
 

--- a/packages/core/automation/src/test/condition.test.ts
+++ b/packages/core/automation/src/test/condition.test.ts
@@ -1,11 +1,14 @@
 import { ConditionEvaluator } from '../utils/condition-evaluator.js';
 import {
+  AnyCondition,
   Condition,
   ConditionGroup,
-  ConditionOperator,
   ConditionLogic,
+  ConditionOperator,
   ExecutionContext,
+  PriceTriggerCondition,
 } from '../types/automation-types.js';
+import { OracleAggregator } from '@galaxy-kj/core-oracles';
 
 describe('ConditionEvaluator', () => {
   let evaluator: ConditionEvaluator;
@@ -33,7 +36,7 @@ describe('ConditionEvaluator', () => {
   });
 
   describe('evaluateCondition', () => {
-    it('should evaluate EQUAL operator correctly', () => {
+    it('should evaluate EQUAL operator correctly', async () => {
       const condition: Condition = {
         id: 'cond-1',
         field: 'marketData.XLM.priceUSD',
@@ -41,24 +44,24 @@ describe('ConditionEvaluator', () => {
         value: 0.1,
       };
 
-      const result = evaluator.evaluateCondition(condition, createContext());
+      const result = await evaluator.evaluateCondition(condition, createContext());
       expect(result).toBe(true);
     });
 
-    it('should evaluate NOT_EQUAL operator correctly', () => {
+    it('should evaluate NOT_EQUAL operator correctly', async () => {
       const condition: Condition = {
-          
+
         id: 'cond-1',
         field: 'marketData.XLM.priceUSD',
         operator: ConditionOperator.NOT_EQUAL,
         value: 0.15,
       };
 
-      const result = evaluator.evaluateCondition(condition, createContext());
+      const result = await evaluator.evaluateCondition(condition, createContext());
       expect(result).toBe(true);
     });
 
-    it('should evaluate GREATER_THAN operator correctly', () => {
+    it('should evaluate GREATER_THAN operator correctly', async () => {
       const condition: Condition = {
         id: 'cond-1',
         field: 'marketData.XLM.priceUSD',
@@ -66,11 +69,11 @@ describe('ConditionEvaluator', () => {
         value: 0.05,
       };
 
-      const result = evaluator.evaluateCondition(condition, createContext());
+      const result = await evaluator.evaluateCondition(condition, createContext());
       expect(result).toBe(true);
     });
 
-    it('should evaluate LESS_THAN operator correctly', () => {
+    it('should evaluate LESS_THAN operator correctly', async () => {
       const condition: Condition = {
         id: 'cond-1',
         field: 'marketData.XLM.priceUSD',
@@ -78,11 +81,11 @@ describe('ConditionEvaluator', () => {
         value: 0.15,
       };
 
-      const result = evaluator.evaluateCondition(condition, createContext());
+      const result = await evaluator.evaluateCondition(condition, createContext());
       expect(result).toBe(true);
     });
 
-    it('should evaluate GREATER_THAN_OR_EQUAL operator correctly', () => {
+    it('should evaluate GREATER_THAN_OR_EQUAL operator correctly', async () => {
       const condition: Condition = {
         id: 'cond-1',
         field: 'marketData.XLM.priceUSD',
@@ -90,11 +93,11 @@ describe('ConditionEvaluator', () => {
         value: 0.1,
       };
 
-      const result = evaluator.evaluateCondition(condition, createContext());
+      const result = await evaluator.evaluateCondition(condition, createContext());
       expect(result).toBe(true);
     });
 
-    it('should evaluate LESS_THAN_OR_EQUAL operator correctly', () => {
+    it('should evaluate LESS_THAN_OR_EQUAL operator correctly', async () => {
       const condition: Condition = {
         id: 'cond-1',
         field: 'marketData.XLM.priceUSD',
@@ -102,11 +105,11 @@ describe('ConditionEvaluator', () => {
         value: 0.1,
       };
 
-      const result = evaluator.evaluateCondition(condition, createContext());
+      const result = await evaluator.evaluateCondition(condition, createContext());
       expect(result).toBe(true);
     });
 
-    it('should evaluate BETWEEN operator correctly', () => {
+    it('should evaluate BETWEEN operator correctly', async () => {
       const condition: Condition = {
         id: 'cond-1',
         field: 'marketData.XLM.priceUSD',
@@ -115,11 +118,11 @@ describe('ConditionEvaluator', () => {
         value2: 0.15,
       };
 
-      const result = evaluator.evaluateCondition(condition, createContext());
+      const result = await evaluator.evaluateCondition(condition, createContext());
       expect(result).toBe(true);
     });
 
-    it('should evaluate NOT_BETWEEN operator correctly', () => {
+    it('should evaluate NOT_BETWEEN operator correctly', async () => {
       const condition: Condition = {
         id: 'cond-1',
         field: 'marketData.XLM.priceUSD',
@@ -128,11 +131,11 @@ describe('ConditionEvaluator', () => {
         value2: 0.2,
       };
 
-      const result = evaluator.evaluateCondition(condition, createContext());
+      const result = await evaluator.evaluateCondition(condition, createContext());
       expect(result).toBe(true);
     });
 
-    it('should handle nested object paths', () => {
+    it('should handle nested object paths', async () => {
       const condition: Condition = {
         id: 'cond-1',
         field: 'marketData.XLM.volume24h',
@@ -140,11 +143,11 @@ describe('ConditionEvaluator', () => {
         value: 1000000,
       };
 
-      const result = evaluator.evaluateCondition(condition, createContext());
+      const result = await evaluator.evaluateCondition(condition, createContext());
       expect(result).toBe(true);
     });
 
-    it('should handle string comparisons', () => {
+    it('should handle string comparisons', async () => {
       const context = createContext({
         customData: { status: 'active' },
       });
@@ -156,11 +159,11 @@ describe('ConditionEvaluator', () => {
         value: 'active',
       };
 
-      const result = evaluator.evaluateCondition(condition, context);
+      const result = await evaluator.evaluateCondition(condition, context);
       expect(result).toBe(true);
     });
 
-    it('should handle numeric strings', () => {
+    it('should handle numeric strings', async () => {
       const context = createContext({
         accountData: { xlmBalance: '1000' },
       });
@@ -172,11 +175,11 @@ describe('ConditionEvaluator', () => {
         value: 500,
       };
 
-      const result = evaluator.evaluateCondition(condition, context);
+      const result = await evaluator.evaluateCondition(condition, context);
       expect(result).toBe(true);
     });
 
-    it('should return false for undefined fields', () => {
+    it('should return false for undefined fields', async () => {
       const condition: Condition = {
         id: 'cond-1',
         field: 'nonExistent.field',
@@ -184,11 +187,11 @@ describe('ConditionEvaluator', () => {
         value: 100,
       };
 
-      const result = evaluator.evaluateCondition(condition, createContext());
+      const result = await evaluator.evaluateCondition(condition, createContext());
       expect(result).toBe(false);
     });
 
-    it('should throw error for GT with non-numeric values', () => {
+    it('should throw error for GT with non-numeric values', async () => {
       const context = createContext({
         customData: { name: 'test' },
       });
@@ -200,12 +203,12 @@ describe('ConditionEvaluator', () => {
         value: 'other',
       };
 
-      expect(() => evaluator.evaluateCondition(condition, context)).toThrow();
+      await expect(evaluator.evaluateCondition(condition, context)).rejects.toThrow();
     });
   });
 
   describe('evaluateConditionGroup', () => {
-    it('should evaluate AND logic correctly - all true', () => {
+    it('should evaluate AND logic correctly - all true', async () => {
       const group: ConditionGroup = {
         logic: ConditionLogic.AND,
         conditions: [
@@ -224,11 +227,11 @@ describe('ConditionEvaluator', () => {
         ],
       };
 
-      const result = evaluator.evaluateConditionGroup(group, createContext());
+      const result = await evaluator.evaluateConditionGroup(group, createContext());
       expect(result).toBe(true);
     });
 
-    it('should evaluate AND logic correctly - one false', () => {
+    it('should evaluate AND logic correctly - one false', async () => {
       const group: ConditionGroup = {
         logic: ConditionLogic.AND,
         conditions: [
@@ -247,11 +250,11 @@ describe('ConditionEvaluator', () => {
         ],
       };
 
-      const result = evaluator.evaluateConditionGroup(group, createContext());
+      const result = await evaluator.evaluateConditionGroup(group, createContext());
       expect(result).toBe(false);
     });
 
-    it('should evaluate OR logic correctly - one true', () => {
+    it('should evaluate OR logic correctly - one true', async () => {
       const group: ConditionGroup = {
         logic: ConditionLogic.OR,
         conditions: [
@@ -270,11 +273,11 @@ describe('ConditionEvaluator', () => {
         ],
       };
 
-      const result = evaluator.evaluateConditionGroup(group, createContext());
+      const result = await evaluator.evaluateConditionGroup(group, createContext());
       expect(result).toBe(true);
     });
 
-    it('should evaluate OR logic correctly - all false', () => {
+    it('should evaluate OR logic correctly - all false', async () => {
       const group: ConditionGroup = {
         logic: ConditionLogic.OR,
         conditions: [
@@ -293,11 +296,11 @@ describe('ConditionEvaluator', () => {
         ],
       };
 
-      const result = evaluator.evaluateConditionGroup(group, createContext());
+      const result = await evaluator.evaluateConditionGroup(group, createContext());
       expect(result).toBe(false);
     });
 
-    it('should evaluate nested groups with AND logic', () => {
+    it('should evaluate nested groups with AND logic', async () => {
       const group: ConditionGroup = {
         logic: ConditionLogic.AND,
         conditions: [
@@ -329,11 +332,11 @@ describe('ConditionEvaluator', () => {
         ],
       };
 
-      const result = evaluator.evaluateConditionGroup(group, createContext());
+      const result = await evaluator.evaluateConditionGroup(group, createContext());
       expect(result).toBe(true);
     });
 
-    it('should evaluate nested groups with OR logic', () => {
+    it('should evaluate nested groups with OR logic', async () => {
       const group: ConditionGroup = {
         logic: ConditionLogic.OR,
         conditions: [
@@ -365,7 +368,7 @@ describe('ConditionEvaluator', () => {
         ],
       };
 
-      const result = evaluator.evaluateConditionGroup(group, createContext());
+      const result = await evaluator.evaluateConditionGroup(group, createContext());
       expect(result).toBe(true);
     });
   });
@@ -526,7 +529,7 @@ describe('ConditionEvaluator', () => {
   });
 
   describe('testConditions', () => {
-    it('should test conditions and return details', () => {
+    it('should test conditions and return details', async () => {
       const group: ConditionGroup = {
         logic: ConditionLogic.AND,
         conditions: [
@@ -545,7 +548,7 @@ describe('ConditionEvaluator', () => {
         ],
       };
 
-      const result = evaluator.testConditions(group, createContext());
+      const result = await evaluator.testConditions(group, createContext());
 
       expect(result.result).toBe(true);
       expect(result.details).toHaveLength(2);
@@ -555,7 +558,7 @@ describe('ConditionEvaluator', () => {
       expect(result.details[1].actualValue).toBe(5000000);
     });
 
-    it('should show failed condition details', () => {
+    it('should show failed condition details', async () => {
       const group: ConditionGroup = {
         logic: ConditionLogic.AND,
         conditions: [
@@ -568,10 +571,170 @@ describe('ConditionEvaluator', () => {
         ],
       };
 
-      const result = evaluator.testConditions(group, createContext());
+      const result = await evaluator.testConditions(group, createContext());
 
       expect(result.result).toBe(false);
       expect(result.details[0].result).toBe(false);
+    });
+  });
+
+  describe('price trigger conditions', () => {
+    let mockOracle: jest.Mocked<Pick<OracleAggregator, 'getAggregatedPrice'>>;
+    let priceEvaluator: ConditionEvaluator;
+
+    beforeEach(() => {
+      mockOracle = {
+        getAggregatedPrice: jest.fn(),
+      };
+      priceEvaluator = new ConditionEvaluator(
+        mockOracle as unknown as OracleAggregator
+      );
+    });
+
+    const makePriceCond = (
+      operator: ConditionOperator,
+      threshold: number
+    ): PriceTriggerCondition => ({
+      type: 'price',
+      id: 'price-cond-1',
+      asset: 'XLM',
+      operator,
+      threshold,
+    });
+
+    const mockPrice = (price: number) => {
+      mockOracle.getAggregatedPrice.mockResolvedValue({
+        symbol: 'XLM',
+        price,
+        timestamp: new Date(),
+        confidence: 0.95,
+        sourcesUsed: ['coingecko'],
+        outliersFiltered: [],
+        sourceCount: 1,
+      });
+    };
+
+    it('GT: price above threshold returns true', async () => {
+      mockPrice(0.20);
+      const cond = makePriceCond(ConditionOperator.GREATER_THAN, 0.15);
+      const result = await priceEvaluator.evaluateCondition(cond, createContext());
+      expect(result).toBe(true);
+    });
+
+    it('GT: price below threshold returns false', async () => {
+      mockPrice(0.10);
+      const cond = makePriceCond(ConditionOperator.GREATER_THAN, 0.15);
+      const result = await priceEvaluator.evaluateCondition(cond, createContext());
+      expect(result).toBe(false);
+    });
+
+    it('LT: price below threshold returns true', async () => {
+      mockPrice(0.10);
+      const cond = makePriceCond(ConditionOperator.LESS_THAN, 0.15);
+      const result = await priceEvaluator.evaluateCondition(cond, createContext());
+      expect(result).toBe(true);
+    });
+
+    it('LT: price above threshold returns false', async () => {
+      mockPrice(0.20);
+      const cond = makePriceCond(ConditionOperator.LESS_THAN, 0.15);
+      const result = await priceEvaluator.evaluateCondition(cond, createContext());
+      expect(result).toBe(false);
+    });
+
+    it('GTE: price equal to threshold returns true (boundary)', async () => {
+      mockPrice(0.15);
+      const cond = makePriceCond(ConditionOperator.GREATER_THAN_OR_EQUAL, 0.15);
+      const result = await priceEvaluator.evaluateCondition(cond, createContext());
+      expect(result).toBe(true);
+    });
+
+    it('LTE: price equal to threshold returns true (boundary)', async () => {
+      mockPrice(0.15);
+      const cond = makePriceCond(ConditionOperator.LESS_THAN_OR_EQUAL, 0.15);
+      const result = await priceEvaluator.evaluateCondition(cond, createContext());
+      expect(result).toBe(true);
+    });
+
+    it('throws when no oracle is configured', async () => {
+      const noOracleEvaluator = new ConditionEvaluator();
+      const cond = makePriceCond(ConditionOperator.GREATER_THAN, 0.15);
+      await expect(
+        noOracleEvaluator.evaluateCondition(cond, createContext())
+      ).rejects.toThrow('Oracle not configured');
+    });
+
+    it('propagates oracle fetch errors', async () => {
+      mockOracle.getAggregatedPrice.mockRejectedValue(
+        new Error('Oracle unavailable')
+      );
+      const cond = makePriceCond(ConditionOperator.GREATER_THAN, 0.15);
+      await expect(
+        priceEvaluator.evaluateCondition(cond, createContext())
+      ).rejects.toThrow('Oracle unavailable');
+    });
+
+    it('price condition in AND group with regular condition — both must pass', async () => {
+      mockPrice(0.20);
+      const group: ConditionGroup = {
+        logic: ConditionLogic.AND,
+        conditions: [
+          makePriceCond(ConditionOperator.GREATER_THAN, 0.15),
+          {
+            id: 'cond-regular',
+            field: 'marketData.XLM.volume24h',
+            operator: ConditionOperator.GREATER_THAN,
+            value: 1000000,
+          },
+        ],
+      };
+
+      const result = await priceEvaluator.evaluateConditionGroup(
+        group,
+        createContext()
+      );
+      expect(result).toBe(true);
+    });
+
+    it('AND group fails when price condition is false even if regular condition passes', async () => {
+      mockPrice(0.10);
+      const group: ConditionGroup = {
+        logic: ConditionLogic.AND,
+        conditions: [
+          makePriceCond(ConditionOperator.GREATER_THAN, 0.15),
+          {
+            id: 'cond-regular',
+            field: 'marketData.XLM.volume24h',
+            operator: ConditionOperator.GREATER_THAN,
+            value: 1000000,
+          },
+        ],
+      };
+
+      const result = await priceEvaluator.evaluateConditionGroup(
+        group,
+        createContext()
+      );
+      expect(result).toBe(false);
+    });
+
+    it('validates a well-formed PriceTriggerCondition', () => {
+      const cond = makePriceCond(ConditionOperator.GREATER_THAN, 0.15);
+      const result = priceEvaluator.validateCondition(cond);
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects PriceTriggerCondition missing asset', () => {
+      const cond: any = {
+        type: 'price',
+        id: 'pc',
+        asset: '',
+        operator: ConditionOperator.GREATER_THAN,
+        threshold: 0.15,
+      };
+      const result = priceEvaluator.validateCondition(cond);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('asset');
     });
   });
 });

--- a/packages/core/automation/src/types/automation-types.ts
+++ b/packages/core/automation/src/types/automation-types.ts
@@ -50,9 +50,20 @@ export interface Condition {
   value2?: number | string; // For BETWEEN operations
 }
 
+export interface PriceTriggerCondition {
+  type: 'price';
+  id: string;
+  asset: string;          // e.g. 'XLM', 'BTC'
+  operator: ConditionOperator; // GT | LT | GTE | LTE
+  threshold: number;      // USD value
+  quoteAsset?: string;    // default 'USD' (informational)
+}
+
+export type AnyCondition = Condition | PriceTriggerCondition;
+
 export interface ConditionGroup {
   logic: ConditionLogic;
-  conditions: Condition[];
+  conditions: AnyCondition[];
   groups?: ConditionGroup[];
 }
 

--- a/packages/core/automation/src/utils/condition-evaluator.ts
+++ b/packages/core/automation/src/utils/condition-evaluator.ts
@@ -1,23 +1,35 @@
 import {
+  AnyCondition,
   Condition,
   ConditionGroup,
-  ConditionOperator,
   ConditionLogic,
+  ConditionOperator,
   ExecutionContext,
+  PriceTriggerCondition,
 } from '../types/automation-types.js';
+import { OracleAggregator } from '@galaxy-kj/core-oracles';
 
 export class ConditionEvaluator {
+  private oracle?: OracleAggregator;
 
-  evaluateConditionGroup(
+  constructor(oracle?: OracleAggregator) {
+    this.oracle = oracle;
+  }
+
+  async evaluateConditionGroup(
     group: ConditionGroup,
     context: ExecutionContext
-  ): boolean {
-    const conditionResults = group.conditions.map(condition =>
-      this.evaluateCondition(condition, context)
+  ): Promise<boolean> {
+    const conditionResults = await Promise.all(
+      group.conditions.map(condition =>
+        this.evaluateCondition(condition, context)
+      )
     );
 
-    const nestedResults = (group.groups || []).map(nestedGroup =>
-      this.evaluateConditionGroup(nestedGroup, context)
+    const nestedResults = await Promise.all(
+      (group.groups || []).map(nestedGroup =>
+        this.evaluateConditionGroup(nestedGroup, context)
+      )
     );
 
     const allResults = [...conditionResults, ...nestedResults];
@@ -30,9 +42,16 @@ export class ConditionEvaluator {
   }
 
   /**
-   * Evaluate a single condition
+   * Evaluate a single condition (Condition or PriceTriggerCondition)
    */
-  evaluateCondition(condition: Condition, context: ExecutionContext): boolean {
+  async evaluateCondition(
+    condition: AnyCondition,
+    context: ExecutionContext
+  ): Promise<boolean> {
+    if (this.isPriceCondition(condition)) {
+      return this.evaluatePriceCondition(condition);
+    }
+
     const actualValue = this.resolveValue(condition.field, context);
 
     if (actualValue === undefined || actualValue === null) {
@@ -46,6 +65,42 @@ export class ConditionEvaluator {
       condition.value,
       condition.value2
     );
+  }
+
+  /**
+   * Type guard for PriceTriggerCondition
+   */
+  private isPriceCondition(c: AnyCondition): c is PriceTriggerCondition {
+    return (c as PriceTriggerCondition).type === 'price';
+  }
+
+  /**
+   * Evaluate a price trigger condition via the oracle
+   */
+  private async evaluatePriceCondition(
+    condition: PriceTriggerCondition
+  ): Promise<boolean> {
+    if (!this.oracle) {
+      throw new Error('Oracle not configured for price trigger conditions');
+    }
+
+    const aggregated = await this.oracle.getAggregatedPrice(condition.asset);
+    const price = aggregated.price;
+
+    switch (condition.operator) {
+      case ConditionOperator.GREATER_THAN:
+        return price > condition.threshold;
+      case ConditionOperator.LESS_THAN:
+        return price < condition.threshold;
+      case ConditionOperator.GREATER_THAN_OR_EQUAL:
+        return price >= condition.threshold;
+      case ConditionOperator.LESS_THAN_OR_EQUAL:
+        return price <= condition.threshold;
+      default:
+        throw new Error(
+          `Operator ${condition.operator} is not supported for price trigger conditions`
+        );
+    }
   }
 
   /**
@@ -75,7 +130,7 @@ export class ConditionEvaluator {
     expectedValue: any,
     expectedValue2?: any
   ): boolean {
- 
+
     const numActual = this.toNumber(actualValue);
     const numExpected = this.toNumber(expectedValue);
     const numExpected2 = expectedValue2
@@ -155,7 +210,20 @@ export class ConditionEvaluator {
   /**
    * Validate condition structure
    */
-  validateCondition(condition: Condition): { valid: boolean; error?: string } {
+  validateCondition(condition: AnyCondition): { valid: boolean; error?: string } {
+    if (this.isPriceCondition(condition)) {
+      if (!condition.asset || typeof condition.asset !== 'string') {
+        return { valid: false, error: 'Price condition must have a valid asset' };
+      }
+      if (!condition.operator) {
+        return { valid: false, error: 'Condition must have an operator' };
+      }
+      if (condition.threshold === undefined || condition.threshold === null) {
+        return { valid: false, error: 'Price condition must have a threshold value' };
+      }
+      return { valid: true };
+    }
+
     if (!condition.field || typeof condition.field !== 'string') {
       return { valid: false, error: 'Condition must have a valid field' };
     }
@@ -228,26 +296,28 @@ export class ConditionEvaluator {
   /**
    * Test conditions with sample data
    */
-  testConditions(
+  async testConditions(
     group: ConditionGroup,
     sampleContext: ExecutionContext
-  ): {
+  ): Promise<{
     result: boolean;
     details: Array<{
-      condition: Condition;
+      condition: AnyCondition;
       result: boolean;
       actualValue: any;
     }>;
-  } {
+  }> {
     const details: Array<{
-      condition: Condition;
+      condition: AnyCondition;
       result: boolean;
       actualValue: any;
     }> = [];
 
-    const evaluateWithDetails = (cond: Condition): boolean => {
-      const actualValue = this.resolveValue(cond.field, sampleContext);
-      const result = this.evaluateCondition(cond, sampleContext);
+    const evaluateWithDetails = async (cond: AnyCondition): Promise<boolean> => {
+      const actualValue = this.isPriceCondition(cond)
+        ? undefined
+        : this.resolveValue((cond as Condition).field, sampleContext);
+      const result = await this.evaluateCondition(cond, sampleContext);
 
       details.push({
         condition: cond,
@@ -258,9 +328,9 @@ export class ConditionEvaluator {
       return result;
     };
 
-    group.conditions.forEach(evaluateWithDetails);
+    await Promise.all(group.conditions.map(evaluateWithDetails));
 
-    const result = this.evaluateConditionGroup(group, sampleContext);
+    const result = await this.evaluateConditionGroup(group, sampleContext);
 
     return { result, details };
   }


### PR DESCRIPTION
Summary
Add PriceTriggerCondition interface and AnyCondition union type to automation-types.ts, enabling rules like "fire when XLM > $0.15"
Extend ConditionEvaluator to accept an optional OracleAggregator, make evaluation async, and route type: 'price' conditions to live oracle price fetching via getAggregatedPrice()
Wire oracle?: OracleAggregator into AutomationServiceConfig and AutomationService constructor; await async condition evaluation in executeRule and testRuleConditions
Add 11 new price trigger tests covering all 4 operators (GT/LT/GTE/LTE), boundary cases, no-oracle error, oracle failure propagation, and mixed AND groups

Test plan
 All 43 condition tests pass (32 existing + 11 new price trigger tests)
 All 59 automation service tests pass with updated mockResolvedValue mocks
 Oracle is optional — existing rules without price conditions work with zero regression
 Add @galaxy-kj/core-oracles workspace dep to automation package.json
 Add moduleNameMapper for @galaxy-kj/core-oracles to root jest.config.js

Closes #130 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added price-based automation conditions, enabling rules to trigger based on asset price thresholds
  * Integrated oracle support for real-time price data in automation rules

* **Chores**
  * Refactored condition evaluation to support asynchronous operations
  * Expanded test coverage for price-trigger scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->