### PR TITLE
feat(defi): fill Blend mainnet contract addresses

### DIFF
--- a/packages/core/defi-protocols/src/protocols/blend/blend-config.ts
+++ b/packages/core/defi-protocols/src/protocols/blend/blend-config.ts
@@ -54,8 +54,8 @@ export const BLEND_TESTNET_CONFIG: ProtocolConfig = {
 
 /**
  * Blend Protocol Mainnet Configuration
- * @description Official Blend Protocol contracts on Stellar Mainnet
- * @note Official mainnet contract addresses
+ * @description Blend V1 mainnet defaults for a specific Reward Zone pool (Fixed XLM-USDC)
+ * @note This mainnet config is V1 pool-instance based (not a generic V2 deployment map)
  * @see https://blend.capital/
  */
 export const BLEND_MAINNET_CONFIG: ProtocolConfig = {
@@ -68,9 +68,13 @@ export const BLEND_MAINNET_CONFIG: ProtocolConfig = {
     passphrase: 'Public Global Stellar Network ; September 2015'
   },
   contractAddresses: {
-    pool: 'CDVQVKOY2YSXS2IC7KN6MNASSHPAO7UN2UR2ON4OI2SKMFJNVAMDX6DP', // Source: https://docs-v1.blend.capital/mainnet-deployments (Fixed XLM-USDC Pool)
-    oracle: 'CATKK5ZNJCKQQWTUWIUFZMY6V6MOQUGSTFSXMNQZHVJHYF7GVV36FB3Y', // Source: https://mainnet.sorobanrpc.com (queried via PoolMetadata.load for the mainnet pool)
-    backstop: 'CAO3AGAMZVRMHITL36EJ2VZQWKYRPWMQAPDQD5YEOF3GIF7T44U4JAL3', // Source: https://docs-v1.blend.capital/mainnet-deployments (Backstop Smart Contract)
+    // Fixed XLM-USDC Reward Zone Pool (V1) - specific pool instance.
+    // For generic pool discovery use the V1 Pool Factory: CCZD6ESMOGMPWH2KRO4O7RGTAPGTUPFWFQBELQSS7ZUK63V3TZWETGAG.
+    pool: 'CDVQVKOY2YSXS2IC7KN6MNASSHPAO7UN2UR2ON4OI2SKMFJNVAMDX6DP', // Source: https://docs-v1.blend.capital/mainnet-deployments
+    // Pool-specific oracle snapshot for the fixed V1 pool above.
+    // Prefer runtime derivation from the on-chain pool (Pool.loadOracle()/PoolMetadata.load()).
+    oracle: 'CATKK5ZNJCKQQWTUWIUFZMY6V6MOQUGSTFSXMNQZHVJHYF7GVV36FB3Y', // Source: https://stellar.expert/explorer/public/contract/CDVQVKOY2YSXS2IC7KN6MNASSHPAO7UN2UR2ON4OI2SKMFJNVAMDX6DP and https://stellar.expert/explorer/public/contract/CATKK5ZNJCKQQWTUWIUFZMY6V6MOQUGSTFSXMNQZHVJHYF7GVV36FB3Y
+    backstop: 'CAO3AGAMZVRMHITL36EJ2VZQWKYRPWMQAPDQD5YEOF3GIF7T44U4JAL3', // Source: https://docs-v1.blend.capital/mainnet-deployments (Backstop Smart Contract, V1)
     emitter: 'CCOQM6S7ICIUWA225O5PSJWUBEMXGFSSW2PQFO6FP4DQEKMS5DASRGRR' // Source: https://docs-v1.blend.capital/mainnet-deployments (Emitter Smart Contract)
   },
   metadata: {


### PR DESCRIPTION
﻿## Description
Fill in Blend Protocol mainnet contract addresses in `BLEND_MAINNET_CONFIG` so mainnet usage is no longer blocked by placeholder/invalid values.

Closes #128

## Changes proposed

### What were you told to do?
I was tasked with completing Blend mainnet config by:

- replacing all `TODO_MAINNET_*` placeholders in `blend-config.ts`
- using canonical/official Blend contract references
- verifying addresses against on-chain data
- leaving `BLEND_TESTNET_CONFIG` unchanged
- adding source comments for auditability

### What did I do?

#### Updated Blend mainnet contract addresses
- Updated `packages/core/defi-protocols/src/protocols/blend/blend-config.ts` (`BLEND_MAINNET_CONFIG.contractAddresses`):
  - `pool`: `CDVQVKOY2YSXS2IC7KN6MNASSHPAO7UN2UR2ON4OI2SKMFJNVAMDX6DP`
  - `oracle`: `CATKK5ZNJCKQQWTUWIUFZMY6V6MOQUGSTFSXMNQZHVJHYF7GVV36FB3Y`
  - `backstop`: `CAO3AGAMZVRMHITL36EJ2VZQWKYRPWMQAPDQD5YEOF3GIF7T44U4JAL3`
  - `emitter`: `CCOQM6S7ICIUWA225O5PSJWUBEMXGFSSW2PQFO6FP4DQEKMS5DASRGRR`

#### Source + verification notes
- Added inline source comments beside each mainnet address.
- Oracle was derived from live mainnet pool metadata via `PoolMetadata.load(...)` for the selected pool.
- All four updated IDs were validated locally with `@stellar/stellar-sdk` `Contract(...)` checks.

#### Scope control
- Only `BLEND_MAINNET_CONFIG` was changed.
- `BLEND_TESTNET_CONFIG` and all other protocol configs were left untouched.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [ ] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Terminal output (validation evidence)
```bash
$ npx tsx -e "... PoolMetadata.load(...) ..."
{
  "ok": true,
  "rpc": "https://mainnet.sorobanrpc.com",
  "pool": "CDVQVKOY2YSXS2IC7KN6MNASSHPAO7UN2UR2ON4OI2SKMFJNVAMDX6DP",
  "oracle": "CATKK5ZNJCKQQWTUWIUFZMY6V6MOQUGSTFSXMNQZHVJHYF7GVV36FB3Y",
  "backstop": "CAO3AGAMZVRMHITL36EJ2VZQWKYRPWMQAPDQD5YEOF3GIF7T44U4JAL3",
  "name": "Fixed XLM-USDC"
}

$ npx tsx -e "... new Contract(id) validation ..."
pool: valid
oracle: valid
backstop: valid
emitter: valid

$ npx tsx -e "... BlendProtocol mainnet smoke test ..."
{
  "ok": false,
  "error": "Error: Failed to initialize Blend Protocol: Error: Failed to connect to Horizon server: Error: getaddrinfo EAI_AGAIN horizon.stellar.org"
}
# note: runtime smoke test blocked by transient DNS/network, not contract ID validity
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced placeholder mainnet values with finalized Blend mainnet contract addresses for pool, oracle, backstop, and emitter.
* **Documentation**
  * Updated the mainnet configuration description to reflect V1 pool-instance defaults and clarified pool discovery/source notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->