### PR TITLE
feat: add liquidity provision REST endpoints to DeFi routes

### DIFF
--- a/packages/api/rest/src/routes/defi.routes.test.ts
+++ b/packages/api/rest/src/routes/defi.routes.test.ts
@@ -18,6 +18,8 @@ jest.mock('@galaxy-kj/core-defi-protocols', () => {
                                 priceImpact: '0.5'
                             }),
                             swap: jest.fn().mockResolvedValue({ hash: 'mock-unsigned-xdr-swap' }),
+                            addLiquidity: jest.fn().mockResolvedValue({ hash: 'mock-unsigned-xdr-add-liquidity' }),
+                            removeLiquidity: jest.fn().mockResolvedValue({ hash: 'mock-unsigned-xdr-remove-liquidity' }),
                             initialize: jest.fn().mockResolvedValue(undefined),
                         };
                     } else if (config.protocolId === 'blend') {
@@ -173,6 +175,103 @@ describe('DeFi Routes', () => {
 
             expect(response.status).toBe(200);
             expect(response.body).toHaveProperty('hash', 'mock-unsigned-xdr-repay');
+        });
+    });
+
+    describe('Liquidity Routes', () => {
+        it('POST /api/v1/defi/liquidity/add should return unsigned XDR', async () => {
+            const response = await request(app)
+                .post('/api/v1/defi/liquidity/add')
+                .send({
+                    assetA: 'XLM',
+                    assetB: 'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+                    amountA: '100',
+                    amountB: '200',
+                    signerPublicKey: 'GD...SIGNER'
+                });
+
+            expect(response.status).toBe(200);
+            expect(response.body).toHaveProperty('hash', 'mock-unsigned-xdr-add-liquidity');
+        });
+
+        it('POST /api/v1/defi/liquidity/add should validate missing parameters', async () => {
+            const response = await request(app)
+                .post('/api/v1/defi/liquidity/add')
+                .send({ assetA: 'XLM', assetB: 'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' });
+
+            expect(response.status).toBe(400);
+            expect(response.body.error).toBeDefined();
+            expect(response.body.error.code).toBe('VALIDATION_ERROR');
+        });
+
+        it('POST /api/v1/defi/liquidity/add should validate missing assetA', async () => {
+            const response = await request(app)
+                .post('/api/v1/defi/liquidity/add')
+                .send({
+                    assetB: 'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+                    amountA: '100',
+                    amountB: '200',
+                    signerPublicKey: 'GD...SIGNER'
+                });
+
+            expect(response.status).toBe(400);
+            expect(response.body.error.code).toBe('VALIDATION_ERROR');
+        });
+
+        it('POST /api/v1/defi/liquidity/remove should return unsigned XDR', async () => {
+            const response = await request(app)
+                .post('/api/v1/defi/liquidity/remove')
+                .send({
+                    assetA: 'XLM',
+                    assetB: 'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+                    poolAddress: 'CA...POOL',
+                    lpAmount: '50',
+                    signerPublicKey: 'GD...SIGNER'
+                });
+
+            expect(response.status).toBe(200);
+            expect(response.body).toHaveProperty('hash', 'mock-unsigned-xdr-remove-liquidity');
+        });
+
+        it('POST /api/v1/defi/liquidity/remove should accept optional minAmountA and minAmountB', async () => {
+            const response = await request(app)
+                .post('/api/v1/defi/liquidity/remove')
+                .send({
+                    assetA: 'XLM',
+                    assetB: 'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+                    poolAddress: 'CA...POOL',
+                    lpAmount: '50',
+                    minAmountA: '47',
+                    minAmountB: '94',
+                    signerPublicKey: 'GD...SIGNER'
+                });
+
+            expect(response.status).toBe(200);
+            expect(response.body).toHaveProperty('hash', 'mock-unsigned-xdr-remove-liquidity');
+        });
+
+        it('POST /api/v1/defi/liquidity/remove should validate missing parameters', async () => {
+            const response = await request(app)
+                .post('/api/v1/defi/liquidity/remove')
+                .send({ assetA: 'XLM', lpAmount: '50' });
+
+            expect(response.status).toBe(400);
+            expect(response.body.error).toBeDefined();
+            expect(response.body.error.code).toBe('VALIDATION_ERROR');
+        });
+
+        it('POST /api/v1/defi/liquidity/remove should validate missing poolAddress', async () => {
+            const response = await request(app)
+                .post('/api/v1/defi/liquidity/remove')
+                .send({
+                    assetA: 'XLM',
+                    assetB: 'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+                    lpAmount: '50',
+                    signerPublicKey: 'GD...SIGNER'
+                });
+
+            expect(response.status).toBe(400);
+            expect(response.body.error.code).toBe('VALIDATION_ERROR');
         });
     });
 });

--- a/packages/api/rest/src/routes/defi.routes.ts
+++ b/packages/api/rest/src/routes/defi.routes.ts
@@ -308,5 +308,83 @@ export function setupDefiRoutes(): express.Router {
         }
     });
 
+    // Route: Soroswap add liquidity
+    // POST /api/v1/defi/liquidity/add
+    /**
+     * @route POST /api/v1/defi/liquidity/add
+     * @description Add liquidity to a Soroswap pool and return unsigned XDR
+     */
+    router.post('/liquidity/add', authenticate(), async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const { assetA, assetB, amountA, amountB, signerPublicKey } = req.body;
+
+            if (!assetA || !assetB || !amountA || !amountB || !signerPublicKey) {
+                res.status(400).json({
+                    error: {
+                        code: 'VALIDATION_ERROR',
+                        message: 'assetA, assetB, amountA, amountB, and signerPublicKey are required in the body',
+                        details: {},
+                    },
+                });
+                return;
+            }
+
+            const factory = ProtocolFactory.getInstance();
+            const protocol = factory.createProtocol({ ...defaultConfig, protocolId: 'soroswap' }) as any;
+            await protocol.initialize();
+
+            const tokenA = parseAsset(assetA);
+            const tokenB = parseAsset(assetB);
+
+            if (!protocol.addLiquidity) {
+                throw new Error('addLiquidity not implemented');
+            }
+            const result = await protocol.addLiquidity(signerPublicKey, '', tokenA, tokenB, amountA, amountB);
+
+            res.json(result);
+        } catch (error) {
+            next(error);
+        }
+    });
+
+    // Route: Soroswap remove liquidity
+    // POST /api/v1/defi/liquidity/remove
+    /**
+     * @route POST /api/v1/defi/liquidity/remove
+     * @description Remove liquidity from a Soroswap pool and return unsigned XDR
+     */
+    router.post('/liquidity/remove', authenticate(), async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const { assetA, assetB, poolAddress, lpAmount, minAmountA, minAmountB, signerPublicKey } = req.body;
+
+            if (!assetA || !assetB || !poolAddress || !lpAmount || !signerPublicKey) {
+                res.status(400).json({
+                    error: {
+                        code: 'VALIDATION_ERROR',
+                        message: 'assetA, assetB, poolAddress, lpAmount, and signerPublicKey are required in the body',
+                        details: {},
+                    },
+                });
+                return;
+            }
+
+            const factory = ProtocolFactory.getInstance();
+            const protocol = factory.createProtocol({ ...defaultConfig, protocolId: 'soroswap' }) as any;
+            await protocol.initialize();
+
+            const tokenA = parseAsset(assetA);
+            const tokenB = parseAsset(assetB);
+
+            if (!protocol.removeLiquidity) {
+                throw new Error('removeLiquidity not implemented');
+            }
+            const result = await protocol.removeLiquidity(signerPublicKey, '', tokenA, tokenB, poolAddress, lpAmount, minAmountA, minAmountB);
+
+            res.json(result);
+        } catch (error) {
+            next(error);
+        }
+    });
+
     return router;
 }


### PR DESCRIPTION
## Summary

- Added `POST /api/v1/defi/liquidity/add` endpoint to expose `SoroswapProtocol.addLiquidity()` via the REST API
- Added `POST /api/v1/defi/liquidity/remove` endpoint to expose `SoroswapProtocol.removeLiquidity()` via the REST API
- Both routes return unsigned XDR for the client to sign with their passkey via `SmartWalletService.sign()`
- Added 6 new tests covering success cases and input validation for both endpoints

## Changes

### `packages/api/rest/src/routes/defi.routes.ts`

Added two new authenticated routes following the exact same pattern as the existing `/swap` and `/blend/*` routes:

**`POST /api/v1/defi/liquidity/add`**
- Required body: `assetA`, `assetB`, `amountA`, `amountB`, `signerPublicKey`
- Parses assets using the existing `parseAsset()` helper
- Calls `protocol.addLiquidity(signerPublicKey, '', tokenA, tokenB, amountA, amountB)`
- 5% slippage protection is handled internally by the protocol
- Returns unsigned XDR result

**`POST /api/v1/defi/liquidity/remove`**
- Required body: `assetA`, `assetB`, `poolAddress`, `lpAmount`, `signerPublicKey`
- Optional body: `minAmountA`, `minAmountB` (protocol defaults to 5% slippage if omitted)
- Calls `protocol.removeLiquidity(signerPublicKey, '', tokenA, tokenB, poolAddress, lpAmount, minAmountA, minAmountB)`
- Returns unsigned XDR result

### `packages/api/rest/src/routes/defi.routes.test.ts`

- Added `addLiquidity` and `removeLiquidity` mocks to the soroswap protocol mock factory
- Added a `Liquidity Routes` describe block with 6 tests:
  - `POST /liquidity/add` returns unsigned XDR on success
  - `POST /liquidity/add` validates missing parameters
  - `POST /liquidity/add` validates missing `assetA`
  - `POST /liquidity/remove` returns unsigned XDR on success
  - `POST /liquidity/remove` accepts optional `minAmountA` and `minAmountB`
  - `POST /liquidity/remove` validates missing required parameters
  - `POST /liquidity/remove` validates missing `poolAddress`

## Test plan

- [ ] Run `npm test` in `packages/api/rest` and confirm all existing tests still pass
- [ ] Confirm all 6 new liquidity tests pass
- [ ] Manually test `POST /api/v1/defi/liquidity/add` with valid body returns unsigned XDR
- [ ] Manually test `POST /api/v1/defi/liquidity/remove` with valid body returns unsigned XDR
- [ ] Confirm both endpoints return `400 VALIDATION_ERROR` when required fields are missing
- [ ] Confirm both endpoints require authentication (401 without token)

Closes #157


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new DeFi liquidity endpoints: ability to add and remove liquidity for Soroswap protocol with parameter validation and transaction hash responses.

* **Tests**
  * Added comprehensive test coverage for liquidity endpoints, including validation error scenarios and successful transaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->