### PR TITLE
feat(defi): Soroswap liquidity pool analytics [closes #30]

### DIFF
--- a/packages/api/rest/src/routes/defi.routes.ts
+++ b/packages/api/rest/src/routes/defi.routes.ts
@@ -386,5 +386,50 @@ export function setupDefiRoutes(): express.Router {
         }
     });
 
+    // Route: Soroswap pool analytics
+    // GET /api/v1/defi/pools/analytics?poolAddress=... (optional; omit for all pools)
+    /**
+     * @route GET /api/v1/defi/pools/analytics
+     * @description Get liquidity pool analytics (TVL, spot prices, fee APR).
+     *   Omit `poolAddress` to retrieve analytics for all registered pools.
+     *   Supply `poolAddress` to query a single pool.
+     */
+    router.get('/pools/analytics', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const { poolAddress } = req.query;
+
+            const factory = ProtocolFactory.getInstance();
+            const protocol = factory.createProtocol({ ...defaultConfig, protocolId: 'soroswap' }) as any;
+            await protocol.initialize();
+
+            if (poolAddress) {
+                if (typeof poolAddress !== 'string' || !poolAddress.trim()) {
+                    res.status(400).json({
+                        error: {
+                            code: 'VALIDATION_ERROR',
+                            message: 'poolAddress must be a non-empty string',
+                            details: {},
+                        },
+                    });
+                    return;
+                }
+
+                if (!protocol.getPoolAnalytics) {
+                    throw new Error('getPoolAnalytics not implemented');
+                }
+                const analytics = await protocol.getPoolAnalytics(poolAddress);
+                res.json(analytics);
+            } else {
+                if (!protocol.getAllPoolsAnalytics) {
+                    throw new Error('getAllPoolsAnalytics not implemented');
+                }
+                const analytics = await protocol.getAllPoolsAnalytics();
+                res.json(analytics);
+            }
+        } catch (error) {
+            next(error);
+        }
+    });
+
     return router;
 }

--- a/packages/core/defi-protocols/__tests__/protocols/soroswap-protocol.test.ts
+++ b/packages/core/defi-protocols/__tests__/protocols/soroswap-protocol.test.ts
@@ -890,4 +890,202 @@ describe('SoroswapProtocol', () => {
       ).rejects.toThrow(/Amount must be a positive number/);
     });
   });
+
+  // ==========================================
+  // GET POOL ANALYTICS
+  // ==========================================
+
+  describe('getPoolAnalytics()', () => {
+    beforeEach(async () => {
+      await soroswapProtocol.initialize();
+    });
+
+    it('should return a PoolAnalytics object for a valid pool address', async () => {
+      const analytics = await soroswapProtocol.getPoolAnalytics(poolAddress);
+
+      expect(analytics).toBeDefined();
+      expect(analytics.poolAddress).toBe(poolAddress);
+      expect(typeof analytics.reserve0).toBe('bigint');
+      expect(typeof analytics.reserve1).toBe('bigint');
+      expect(typeof analytics.priceToken0InToken1).toBe('number');
+      expect(typeof analytics.priceToken1InToken0).toBe('number');
+      expect(typeof analytics.tvlUsd).toBe('number');
+      expect(typeof analytics.volume24hUsd).toBe('number');
+      expect(typeof analytics.feeApr).toBe('number');
+      expect(analytics.lastUpdated).toBeGreaterThan(0);
+    });
+
+    it('should compute correct spot prices from reserves', async () => {
+      // Default mock: scValToNative returns [1000000n, 2000000n, 500000n]
+      // reserve0 = 1000000 stroops = 0.1 units, reserve1 = 2000000 stroops = 0.2 units
+      // priceToken0InToken1 = r1/r0 = 0.2/0.1 = 2.0
+      // priceToken1InToken0 = r0/r1 = 0.1/0.2 = 0.5
+      const analytics = await soroswapProtocol.getPoolAnalytics(poolAddress);
+
+      expect(analytics.priceToken0InToken1).toBeCloseTo(2.0, 5);
+      expect(analytics.priceToken1InToken0).toBeCloseTo(0.5, 5);
+    });
+
+    it('should use bigint 0n for reserves when simulation fails', async () => {
+      const mockSorobanServer = (soroswapProtocol as any).sorobanServer;
+      mockSorobanServer.simulateTransaction.mockResolvedValueOnce({ error: 'fail' });
+      (rpc.Api.isSimulationError as any).mockReturnValueOnce(true);
+
+      const analytics = await soroswapProtocol.getPoolAnalytics(poolAddress);
+
+      expect(analytics.reserve0).toBe(0n);
+      expect(analytics.reserve1).toBe(0n);
+    });
+
+    it('should return priceToken0InToken1 = 0 when reserve0 is zero', async () => {
+      (scValToNative as any).mockReturnValueOnce([0n, 2000000n, 0n]);
+
+      const analytics = await soroswapProtocol.getPoolAnalytics(poolAddress);
+
+      expect(analytics.priceToken0InToken1).toBe(0);
+    });
+
+    it('should return priceToken1InToken0 = 0 when reserve1 is zero', async () => {
+      (scValToNative as any).mockReturnValueOnce([1000000n, 0n, 0n]);
+
+      const analytics = await soroswapProtocol.getPoolAnalytics(poolAddress);
+
+      expect(analytics.priceToken1InToken0).toBe(0);
+    });
+
+    it('should detect native XLM token0 when address matches SAC', async () => {
+      // token_0 simulation resolves to the XLM native contract address
+      const mockSorobanServer = (soroswapProtocol as any).sorobanServer;
+      // Call order: get_reserves (1st), token_0 (2nd), token_1 (3rd)
+      mockSorobanServer.simulateTransaction
+        .mockResolvedValueOnce({ result: { retval: { type: 'scval' } } })   // reserves
+        .mockResolvedValueOnce({ result: { retval: { type: 'address' } } }) // token_0
+        .mockResolvedValueOnce({ result: { retval: { type: 'address' } } }); // token_1
+
+      (Address.fromScVal as jest.Mock).mockReturnValueOnce({
+        toString: jest.fn().mockReturnValue('CNATIVE_CONTRACT_ADDRESS'),
+      });
+
+      const analytics = await soroswapProtocol.getPoolAnalytics(poolAddress);
+
+      expect(analytics.token0.type).toBe('native');
+      expect(analytics.token0.code).toBe('XLM');
+    });
+
+    it('should fall back to UNKN asset when token address query fails', async () => {
+      const mockSorobanServer = (soroswapProtocol as any).sorobanServer;
+      mockSorobanServer.simulateTransaction
+        .mockResolvedValueOnce({ result: { retval: { type: 'scval' } } }) // reserves
+        .mockRejectedValueOnce(new Error('rpc error'))                    // token_0
+        .mockRejectedValueOnce(new Error('rpc error'));                   // token_1
+
+      const analytics = await soroswapProtocol.getPoolAnalytics(poolAddress);
+
+      expect(analytics.token0.code).toBe('UNKN');
+      expect(analytics.token1.code).toBe('UNKN');
+    });
+
+    it('should handle short reserves array gracefully', async () => {
+      (scValToNative as any).mockReturnValueOnce([1000000n]); // Only 1 element, need ≥ 2
+
+      const analytics = await soroswapProtocol.getPoolAnalytics(poolAddress);
+
+      expect(analytics.reserve0).toBe(0n);
+      expect(analytics.reserve1).toBe(0n);
+    });
+
+    it('should handle reserves scValToNative parse error', async () => {
+      // The first call (reserves) returns a retval that causes scValToNative to throw
+      (scValToNative as any).mockImplementationOnce(() => {
+        throw new Error('parse error');
+      });
+
+      const analytics = await soroswapProtocol.getPoolAnalytics(poolAddress);
+
+      expect(analytics.reserve0).toBe(0n);
+      expect(analytics.reserve1).toBe(0n);
+    });
+
+    it('should throw on empty pool address', async () => {
+      await expect(soroswapProtocol.getPoolAnalytics('')).rejects.toThrow(
+        /Pool address is required/
+      );
+    });
+
+    it('should throw if not initialized', async () => {
+      const uninitProtocol = new SoroswapProtocol(mockConfig);
+
+      await expect(uninitProtocol.getPoolAnalytics(poolAddress)).rejects.toThrow(
+        /not initialized/
+      );
+    });
+
+    it('should handle loadAccount failure for simulation placeholder', async () => {
+      mockHorizonServer.loadAccount.mockRejectedValueOnce(new Error('Horizon unavailable'));
+
+      const analytics = await soroswapProtocol.getPoolAnalytics(poolAddress);
+
+      expect(analytics).toBeDefined();
+      expect(analytics.poolAddress).toBe(poolAddress);
+    });
+
+    it('should return feeApr = 0 when volume24hUsd is 0', async () => {
+      const analytics = await soroswapProtocol.getPoolAnalytics(poolAddress);
+
+      expect(analytics.feeApr).toBe(0);
+    });
+  });
+
+  // ==========================================
+  // GET ALL POOLS ANALYTICS
+  // ==========================================
+
+  describe('getAllPoolsAnalytics()', () => {
+    beforeEach(async () => {
+      await soroswapProtocol.initialize();
+    });
+
+    it('should return an empty array when no pairs are registered', async () => {
+      const analytics = await soroswapProtocol.getAllPoolsAnalytics();
+
+      expect(Array.isArray(analytics)).toBe(true);
+      expect(analytics).toHaveLength(0);
+    });
+
+    it('should return analytics for each registered pair', async () => {
+      // Mock getAllPairs to return two pool addresses
+      jest.spyOn(soroswapProtocol, 'getAllPairs').mockResolvedValueOnce([
+        poolAddress,
+        'CPOOL2XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXYYYYYYY',
+      ]);
+
+      const analytics = await soroswapProtocol.getAllPoolsAnalytics();
+
+      expect(analytics.length).toBe(2);
+      analytics.forEach(a => {
+        expect(a).toBeDefined();
+        expect(typeof a.poolAddress).toBe('string');
+        expect(typeof a.reserve0).toBe('bigint');
+      });
+    });
+
+    it('should omit pools whose analytics call rejects', async () => {
+      jest.spyOn(soroswapProtocol, 'getAllPairs').mockResolvedValueOnce([
+        poolAddress,
+        '', // empty address will cause getPoolAnalytics to throw
+      ]);
+
+      const analytics = await soroswapProtocol.getAllPoolsAnalytics();
+
+      // Only the valid pool should appear
+      expect(analytics.length).toBe(1);
+      expect(analytics[0].poolAddress).toBe(poolAddress);
+    });
+
+    it('should throw if not initialized', async () => {
+      const uninitProtocol = new SoroswapProtocol(mockConfig);
+
+      await expect(uninitProtocol.getAllPoolsAnalytics()).rejects.toThrow(/not initialized/);
+    });
+  });
 });

--- a/packages/core/defi-protocols/src/protocols/soroswap/soroswap-protocol.ts
+++ b/packages/core/defi-protocols/src/protocols/soroswap/soroswap-protocol.ts
@@ -30,6 +30,7 @@ import {
   SwapQuote,
   LiquidityPool
 } from '../../types/defi-types.js';
+import { PoolAnalytics } from '../../types/protocol-interface.js';
 import { InvalidOperationError } from '../../errors/index.js';
 
 import { SoroswapPairInfo } from './soroswap-types.js';
@@ -836,6 +837,168 @@ export class SoroswapProtocol extends BaseProtocol {
       };
     } catch (error) {
       this.handleError(error, 'getLiquidityPool');
+    }
+  }
+
+  // ========================================
+  // POOL ANALYTICS
+  // ========================================
+
+  /**
+   * Get analytics for a specific liquidity pool.
+   *
+   * Queries the pair contract directly for reserves and token addresses,
+   * then derives spot prices from the constant-product AMM formula.
+   * TVL and 24h-volume fields require an external oracle / event indexer
+   * and are returned as 0 until that data source is wired in.
+   *
+   * @param {string} poolAddress - Pair/pool contract address
+   * @returns {Promise<PoolAnalytics>}
+   */
+  public async getPoolAnalytics(poolAddress: string): Promise<PoolAnalytics> {
+    this.ensureInitialized();
+
+    if (!poolAddress) {
+      throw new Error('Pool address is required');
+    }
+
+    try {
+      const SIMULATION_PLACEHOLDER = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+      const sourceAccount = await this.horizonServer.loadAccount(SIMULATION_PLACEHOLDER).catch(() => ({
+        accountId: () => SIMULATION_PLACEHOLDER,
+        sequenceNumber: () => '0',
+        incrementSequenceNumber: () => {},
+        sequence: '0',
+      } as any));
+
+      const pairContract = new Contract(poolAddress);
+
+      /** Simulate a single read-only call and return the raw simulation result. */
+      const simulate = async (op: ReturnType<Contract['call']>) => {
+        const tx = new TransactionBuilder(sourceAccount, {
+          fee: BASE_FEE,
+          networkPassphrase: this.networkPassphrase,
+        })
+          .addOperation(op)
+          .setTimeout(30)
+          .build();
+        return this.sorobanServer.simulateTransaction(tx);
+      };
+
+      // ---- Reserves -------------------------------------------------------
+      let reserve0 = 0n;
+      let reserve1 = 0n;
+
+      const reserveSim = await simulate(pairContract.call('get_reserves'));
+      if (
+        reserveSim &&
+        !rpc.Api.isSimulationError(reserveSim) &&
+        'result' in reserveSim &&
+        reserveSim.result?.retval
+      ) {
+        try {
+          const native = scValToNative(reserveSim.result.retval) as bigint[];
+          if (Array.isArray(native) && native.length >= 2) {
+            reserve0 = native[0] ?? 0n;
+            reserve1 = native[1] ?? 0n;
+          }
+        } catch {
+          // Unexpected ScVal shape — keep defaults
+        }
+      }
+
+      // ---- Token addresses ------------------------------------------------
+      const nativeContractId = StellarAsset.native().contractId(this.networkPassphrase);
+
+      const resolveToken = async (method: string): Promise<Asset> => {
+        try {
+          const sim = await simulate(pairContract.call(method));
+          if (
+            sim &&
+            !rpc.Api.isSimulationError(sim) &&
+            'result' in sim &&
+            sim.result?.retval
+          ) {
+            const addr = Address.fromScVal(sim.result.retval).toString();
+            if (addr === nativeContractId) {
+              return { code: 'XLM', type: 'native' };
+            }
+            // Use the last 4 chars of the contract address as a short code
+            return {
+              code: addr.slice(-4).toUpperCase(),
+              issuer: addr,
+              type: 'credit_alphanum4',
+            };
+          }
+        } catch {
+          // Resolution failed — return an unknown placeholder
+        }
+        return { code: 'UNKN', type: 'credit_alphanum4' };
+      };
+
+      const [token0, token1] = await Promise.all([
+        resolveToken('token_0'),
+        resolveToken('token_1'),
+      ]);
+
+      // ---- Spot prices from reserves (constant-product AMM) ---------------
+      const r0 = Number(reserve0) / 1e7;
+      const r1 = Number(reserve1) / 1e7;
+      const priceToken0InToken1 = r0 > 0 ? r1 / r0 : 0;
+      const priceToken1InToken0 = r1 > 0 ? r0 / r1 : 0;
+
+      // ---- Oracle-dependent metrics (placeholders) ------------------------
+      // tvlUsd and volume24hUsd require an external price oracle / event indexer.
+      // feeApr = (volume24h * 0.003 * 365) / TVL — computed once oracle data arrives.
+      const tvlUsd = 0;
+      const volume24hUsd = 0;
+      const feeApr =
+        volume24hUsd > 0 && tvlUsd > 0
+          ? (volume24hUsd * 0.003 * 365) / tvlUsd
+          : 0;
+
+      return {
+        poolAddress,
+        token0,
+        token1,
+        reserve0,
+        reserve1,
+        tvlUsd,
+        volume24hUsd,
+        feeApr,
+        priceToken0InToken1,
+        priceToken1InToken0,
+        lastUpdated: Date.now(),
+      };
+    } catch (error) {
+      this.handleError(error, 'getPoolAnalytics');
+    }
+  }
+
+  /**
+   * Get analytics for all registered liquidity pools.
+   *
+   * Fetches the list of known pair addresses from the factory contract via
+   * {@link getAllPairs} and resolves each pool's analytics in parallel.
+   * Pools whose analytics cannot be fetched are silently omitted.
+   *
+   * @returns {Promise<PoolAnalytics[]>}
+   */
+  public async getAllPoolsAnalytics(): Promise<PoolAnalytics[]> {
+    this.ensureInitialized();
+
+    try {
+      const pairs = await this.getAllPairs();
+
+      const results = await Promise.allSettled(
+        pairs.map(pairAddress => this.getPoolAnalytics(pairAddress))
+      );
+
+      return results
+        .filter((r): r is PromiseFulfilledResult<PoolAnalytics> => r.status === 'fulfilled')
+        .map(r => r.value);
+    } catch (error) {
+      this.handleError(error, 'getAllPoolsAnalytics');
     }
   }
 }

--- a/packages/core/defi-protocols/src/types/protocol-interface.ts
+++ b/packages/core/defi-protocols/src/types/protocol-interface.ts
@@ -250,6 +250,48 @@ export interface IDefiProtocol {
    * @returns {Promise<LiquidityPool>}
    */
   getLiquidityPool?(tokenA: Asset, tokenB: Asset): Promise<LiquidityPool>;
+
+  /**
+   * Get analytics for a specific liquidity pool
+   * @param {string} poolAddress - Pair/pool contract address
+   * @returns {Promise<PoolAnalytics>}
+   */
+  getPoolAnalytics?(poolAddress: string): Promise<PoolAnalytics>;
+
+  /**
+   * Get analytics for all registered liquidity pools
+   * @returns {Promise<PoolAnalytics[]>}
+   */
+  getAllPoolsAnalytics?(): Promise<PoolAnalytics[]>;
+}
+
+/**
+ * Liquidity pool analytics including TVL, volume, APR, and spot prices
+ * @interface PoolAnalytics
+ */
+export interface PoolAnalytics {
+  /** Pair/pool contract address */
+  poolAddress: string;
+  /** First token in the pair */
+  token0: Asset;
+  /** Second token in the pair */
+  token1: Asset;
+  /** Raw reserve of token0 in stroops (i128) */
+  reserve0: bigint;
+  /** Raw reserve of token1 in stroops (i128) */
+  reserve1: bigint;
+  /** Total value locked in USD (requires oracle; 0 if unavailable) */
+  tvlUsd: number;
+  /** 24-hour trading volume in USD (requires event data; 0 if unavailable) */
+  volume24hUsd: number;
+  /** Annualised fee APR: (volume24h * 0.003 * 365) / TVL; 0 if TVL is zero */
+  feeApr: number;
+  /** Spot price of token0 denominated in token1 (reserve1 / reserve0) */
+  priceToken0InToken1: number;
+  /** Spot price of token1 denominated in token0 (reserve0 / reserve1) */
+  priceToken1InToken0: number;
+  /** Unix timestamp (ms) when analytics were last computed */
+  lastUpdated: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

 Soroswap liquidity pool analytics, closing the underlying DeFi milestone Closes #30.

## Changes

### `packages/core/defi-protocols/src/types/protocol-interface.ts`
- Added `PoolAnalytics` interface (TVL, 24h volume, fee APR, spot prices, bigint reserves, `lastUpdated` timestamp)
- Added optional `getPoolAnalytics?(poolAddress)` and `getAllPoolsAnalytics?()` to `IDefiProtocol`

### `packages/core/defi-protocols/src/protocols/soroswap/soroswap-protocol.ts`
- Implemented `getPoolAnalytics(poolAddress)`: queries `get_reserves`, `token_0`, `token_1` via Soroban simulation; derives spot prices from constant-product AMM (`priceToken0InToken1 = reserve1/reserve0`); native XLM SAC detection; graceful fallback on simulation errors
- Implemented `getAllPoolsAnalytics()`: aggregates analytics across all pairs returned by `getAllPairs()` using `Promise.allSettled` to tolerate per-pool failures

### `packages/api/rest/src/routes/defi.routes.ts`
- Added `GET /api/v1/defi/pools/analytics` — omit `?poolAddress` for all pools, supply it for a single pool

### `packages/core/defi-protocols/__tests__/protocols/soroswap-protocol.test.ts`
- 17 new tests: happy path, spot price maths, zero-reserve edge case, native XLM detection, simulation error fallbacks, uninitialized state, empty-address validation, `getAllPoolsAnalytics` with 0/2 pools and partial failures

## Test results

```
Test Suites: 1 passed, 1 total
Tests:       93 passed, 0 failed  (+17 new)
```

## Notes
- **No new dependencies** (as required)
- `tvlUsd` and `volume24hUsd` are `0` placeholders — oracle / event-indexer integration can be added in a follow-up without breaking the interface
- `feeApr` formula: `(volume24h * 0.003 * 365) / TVL` — ready to activate once oracle data is wired in

Closes #153 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new API endpoints for querying DeFi liquidity pool analytics
  * Retrieve analytics for individual pools or all pools in aggregate
  * Pool data includes reserves, token information, spot prices, total value locked (TVL), and 24-hour trading volume

* **Tests**
  * Added comprehensive test coverage for new analytics functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->