### PR TITLE
feat(frontend): session key panel, TX builder, and responsive mobile UI

### DIFF
--- a/docs/interactive/index.html
+++ b/docs/interactive/index.html
@@ -13,6 +13,7 @@
       <li><a href="api-tester.html">API Tester</a></li>
       <li><a href="contract-explorer.html">Contract Explorer</a></li>
       <li><a href="code-examples/index.html">Code Examples</a></li>
+      <li><a href="../../packages/frontend/src/app.ts">Smart Wallet Playground</a> — session keys, TX builder, responsive UI</li>
     </ul>
   </main>
 </body>

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ const tsJestTransformCfg = createDefaultPreset().transform;
 /** @type {import("jest").Config} **/
 module.exports = {
   testEnvironment: "node",
+  setupFiles: ["<rootDir>/packages/frontend/src/tests/jest.setup.ts"],
   testPathIgnorePatterns: [
     "/node_modules/",
     "\\.e2e\\.test\\.[jt]sx?$",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "globals": "^15.0.0",
         "http-server": "^14.1.1",
         "jest": "^30.2.0",
+        "jest-environment-jsdom": "^30.3.0",
         "lerna": "^9.0.3",
         "prettier": "^3.0.0",
         "ts-jest": "^29.4.5",
@@ -41,6 +42,27 @@
         "node": ">=18.0.0",
         "npm": ">=8.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.28.6",
@@ -591,6 +613,121 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1228,6 +1365,10 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@galaxy-devkit/frontend": {
+      "resolved": "packages/frontend",
+      "link": true
     },
     "node_modules/@galaxy-kj/cli": {
       "resolved": "tools/cli",
@@ -2021,6 +2162,192 @@
         "@jest/types": "30.2.0",
         "@types/node": "*",
         "jest-mock": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.3.0.tgz",
+      "integrity": "sha512-0hNFs5N6We3DMCwobzI0ydhkY10sT1tZSC0AAiy+0g2Dt/qEWgrcV5BrMxPczhe41cxW4qm6X+jqZaUdpZIajA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/environment": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/fake-timers": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@sinonjs/fake-timers": "^15.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@sinonjs/fake-timers": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-mock": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -4364,6 +4691,18 @@
         "pretty-format": "^30.0.0"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4431,6 +4770,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -6865,6 +7211,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/dargs": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
@@ -6873,6 +7233,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/date-fns": {
@@ -6955,6 +7329,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -7294,6 +7675,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -9276,6 +9670,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-retry-allowed": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
@@ -9711,6 +10112,187 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-environment-jsdom": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.3.0.tgz",
+      "integrity": "sha512-RLEOJy6ip1lpw0yqJ8tB3i88FC7VBz7i00Zvl2qF71IdxjS98gC9/0SPWYIBVXHm5hgCYK0PAlSlnHGGy9RoMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/environment-jsdom-abstract": "30.3.0",
+        "jsdom": "^26.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/environment": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/fake-timers": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@sinonjs/fake-timers": "^15.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@sinonjs/fake-timers": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/jest-mock": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/jest-environment-node": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.2.0.tgz",
@@ -10114,6 +10696,86 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/jsesc": {
@@ -12029,6 +12691,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nx": {
       "version": "22.4.0",
       "resolved": "https://registry.npmjs.org/nx/-/nx-22.4.0.tgz",
@@ -12741,6 +13410,19 @@
       "license": "MIT",
       "dependencies": {
         "parse-path": "^7.0.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -13957,6 +14639,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-async": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
@@ -13995,6 +14684,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/secure-compare": {
@@ -14733,6 +15435,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/synckit": {
       "version": "0.11.12",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
@@ -14973,6 +15682,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -15042,6 +15771,32 @@
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
       "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -15648,6 +16403,19 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walk-up-path": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
@@ -15677,6 +16445,16 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/whatwg-encoding": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
@@ -15702,6 +16480,30 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -16053,6 +16855,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
@@ -16074,6 +16886,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -16264,6 +17083,19 @@
         "jest": "^30.2.0",
         "ts-jest": "^29.4.5",
         "typescript": "^5.9.3"
+      }
+    },
+    "packages/frontend": {
+      "name": "@galaxy-devkit/frontend",
+      "version": "1.0.0",
+      "dependencies": {
+        "@stellar/stellar-sdk": "*"
+      },
+      "devDependencies": {
+        "@types/jest": "*",
+        "jest": "*",
+        "ts-jest": "*",
+        "typescript": "*"
       }
     },
     "tools/cli": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "globals": "^15.0.0",
         "http-server": "^14.1.1",
         "jest": "^30.2.0",
+        "jest-environment-jsdom": "^30.3.0",
         "lerna": "^9.0.3",
         "prettier": "^3.0.0",
         "ts-jest": "^29.4.5",
@@ -244,6 +245,27 @@
       "dependencies": {
         "xss": "^1.0.8"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.28.6",
@@ -794,6 +816,121 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2854,6 +2991,192 @@
         "@jest/types": "30.2.0",
         "@types/node": "*",
         "jest-mock": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.3.0.tgz",
+      "integrity": "sha512-0hNFs5N6We3DMCwobzI0ydhkY10sT1tZSC0AAiy+0g2Dt/qEWgrcV5BrMxPczhe41cxW4qm6X+jqZaUdpZIajA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/environment": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/fake-timers": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@sinonjs/fake-timers": "^15.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@sinonjs/fake-timers": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-mock": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -5680,16 +6003,6 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -6024,9 +6337,9 @@
       }
     },
     "node_modules/@types/jsdom": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
-      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7067,14 +7380,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/abab": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
-      "deprecated": "Use your platform's native atob() and btoa() methods instead",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/abbrev": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
@@ -7118,17 +7423,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-globals": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
-      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.1.0",
-        "acorn-walk": "^8.0.2"
       }
     },
     "node_modules/acorn-jsx": {
@@ -10518,32 +10812,19 @@
       "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
       "license": "MIT"
     },
-    "node_modules/cssom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cssstyle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cssom": "~0.3.6"
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
-    },
-    "node_modules/cssstyle/node_modules/cssom": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -10570,18 +10851,27 @@
       }
     },
     "node_modules/data-urls": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
-      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "abab": "^2.0.6",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0"
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/data-view-buffer": {
@@ -10976,20 +11266,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/domexception": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
-      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/dot-prop": {
@@ -11594,28 +11870,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -15170,26 +15424,21 @@
       }
     },
     "node_modules/jest-environment-jsdom": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
-      "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.3.0.tgz",
+      "integrity": "sha512-RLEOJy6ip1lpw0yqJ8tB3i88FC7VBz7i00Zvl2qF71IdxjS98gC9/0SPWYIBVXHm5hgCYK0PAlSlnHGGy9RoMg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/jsdom": "^20.0.0",
-        "@types/node": "*",
-        "jest-mock": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jsdom": "^20.0.0"
+        "@jest/environment": "30.3.0",
+        "@jest/environment-jsdom-abstract": "30.3.0",
+        "jsdom": "^26.1.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "canvas": "^2.5.0"
+        "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -15198,85 +15447,66 @@
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/@jest/environment": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
-      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/types": "^29.6.3",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
         "@types/node": "*",
-        "jest-mock": "^29.7.0"
+        "jest-mock": "30.3.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/@jest/fake-timers": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
-      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@sinonjs/fake-timers": "^10.0.2",
+        "@jest/types": "30.3.0",
+        "@sinonjs/fake-timers": "^15.0.0",
         "@types/node": "*",
-        "jest-message-util": "^29.7.0",
-        "jest-mock": "^29.7.0",
-        "jest-util": "^29.7.0"
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-environment-jsdom/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
         "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-environment-jsdom/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/jest-environment-jsdom/node_modules/@sinonjs/fake-timers": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@sinonjs/commons": "^3.0.0"
+        "@sinonjs/commons": "^3.0.1"
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/ansi-styles": {
@@ -15292,89 +15522,86 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-environment-jsdom/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-environment-jsdom/node_modules/jest-message-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.6.3",
-        "@types/stack-utils": "^2.0.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
         "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
+        "stack-utils": "^2.0.6"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/jest-mock": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.3",
+        "@jest/types": "30.3.0",
         "@types/node": "*",
-        "jest-util": "^29.7.0"
+        "jest-util": "30.3.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.3",
+        "@jest/types": "30.3.0",
         "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-environment-node": {
@@ -15806,44 +16033,38 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
-      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "abab": "^2.0.6",
-        "acorn": "^8.8.1",
-        "acorn-globals": "^7.0.0",
-        "cssom": "^0.5.0",
-        "cssstyle": "^2.3.0",
-        "data-urls": "^3.0.2",
-        "decimal.js": "^10.4.2",
-        "domexception": "^4.0.0",
-        "escodegen": "^2.0.0",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^3.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.1",
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.2",
-        "parse5": "^7.1.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.2",
-        "w3c-xmlserializer": "^4.0.0",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^2.0.0",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0",
-        "ws": "^8.11.0",
-        "xml-name-validator": "^4.0.0"
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "canvas": "^2.5.0"
+        "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -15851,46 +16072,54 @@
         }
       }
     },
-    "node_modules/jsdom/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+    "node_modules/jsdom/node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "4"
+        "whatwg-encoding": "^3.1.1"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">=18"
       }
     },
-    "node_modules/jsdom/node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+    "node_modules/jsdom/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=0.10.0"
       }
     },
-    "node_modules/jsdom/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+    "node_modules/jsdom/node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
+        "iconv-lite": "0.6.3"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/jsesc": {
@@ -19374,6 +19603,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -19676,19 +19906,6 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -19917,13 +20134,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -20608,6 +20818,13 @@
         "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-async": {
       "version": "4.0.6",
@@ -22230,6 +22447,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -22310,42 +22547,29 @@
       "license": "MIT"
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
+        "tldts": "^6.1.32"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "punycode": "^2.1.1"
+        "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tree-kill": {
@@ -22969,17 +23193,6 @@
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
     },
     "node_modules/usb": {
       "version": "2.9.0",
@@ -23614,16 +23827,16 @@
       }
     },
     "node_modules/w3c-xmlserializer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
-      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "xml-name-validator": "^4.0.0"
+        "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/walk-up-path": {
@@ -23702,17 +23915,17 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tr46": "^3.0.0",
+        "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -24132,13 +24345,13 @@
       }
     },
     "node_modules/xml-name-validator": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/xml2js": {
@@ -25228,11 +25441,11 @@
         "buffer": "^6.0.3"
       },
       "devDependencies": {
-        "@types/jest": "^29.5.0",
+        "@types/jest": "^30.0.0",
         "@types/node": "^20.0.0",
-        "jest": "^29.5.0",
-        "jest-environment-jsdom": "^29.5.0",
-        "ts-jest": "^29.1.0",
+        "jest": "^30.2.0",
+        "jest-environment-jsdom": "^30.3.0",
+        "ts-jest": "^29.4.5",
         "typescript": "^5.0.0",
         "vite": "^5.4.14"
       }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "globals": "^15.0.0",
     "http-server": "^14.1.1",
     "jest": "^30.2.0",
+    "jest-environment-jsdom": "^30.3.0",
     "lerna": "^9.0.3",
     "prettier": "^3.0.0",
     "ts-jest": "^29.4.5",

--- a/packages/frontend/jest.config.js
+++ b/packages/frontend/jest.config.js
@@ -1,0 +1,12 @@
+const { createDefaultPreset } = require('ts-jest');
+
+/** @type {import('jest').Config} */
+module.exports = {
+  ...createDefaultPreset(),
+  testEnvironment: 'jest-environment-jsdom',
+  setupFiles: ['<rootDir>/src/tests/jest.setup.ts'],
+  testMatch: ['<rootDir>/src/tests/**/*.test.ts'],
+  moduleNameMapper: {
+    '^(\\.\\.?/.*)\\.js$': '$1',
+  },
+};

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@galaxy-devkit/frontend",
+  "version": "1.0.0",
+  "description": "Galaxy DevKit smart wallet playground frontend",
+  "main": "src/app.ts",
+  "scripts": {
+    "test": "jest --config jest.config.js"
+  },
+  "dependencies": {
+    "@stellar/stellar-sdk": "*"
+  },
+  "devDependencies": {
+    "@types/jest": "*",
+    "jest": "*",
+    "ts-jest": "*",
+    "typescript": "*"
+  }
+}

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -18,11 +18,11 @@
     "buffer": "^6.0.3"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.0",
+    "@types/jest": "^30.0.0",
     "@types/node": "^20.0.0",
-    "jest": "^29.5.0",
-    "jest-environment-jsdom": "^29.5.0",
-    "ts-jest": "^29.1.0",
+    "jest": "^30.2.0",
+    "jest-environment-jsdom": "^30.3.0",
+    "ts-jest": "^29.4.5",
     "typescript": "^5.0.0",
     "vite": "^5.4.14"
   }

--- a/packages/frontend/src/app.ts
+++ b/packages/frontend/src/app.ts
@@ -1,0 +1,309 @@
+/**
+ * Galaxy DevKit — Smart Wallet Playground
+ *
+ * App shell: wires the sidebar nav, session panel, TX panel, and handles
+ * responsive drawer open/close with full keyboard navigation support.
+ * WCAG 2.1 AA: skip link, ARIA landmarks, focus trap for mobile drawer.
+ */
+
+import './styles/main.css';
+import { WalletSessionPanel, type SessionEntry } from './panels/wallet-session';
+import { WalletTxPanel } from './panels/wallet-tx';
+
+const RPC_URL = 'https://soroban-testnet.stellar.org';
+
+type PanelId = 'session' | 'tx';
+
+function getCurrentLedger(): Promise<number> {
+  return fetch(RPC_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'getLatestLedger', params: [] }),
+  })
+    .then(r => r.json())
+    .then(data => (data?.result?.sequence as number) ?? 0)
+    .catch(() => 0);
+}
+
+function getStoredSessions(): SessionEntry[] {
+  try {
+    const raw = localStorage.getItem('galaxy_sessions');
+    return raw ? (JSON.parse(raw) as SessionEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function storeSessions(sessions: SessionEntry[]): void {
+  localStorage.setItem('galaxy_sessions', JSON.stringify(sessions));
+}
+
+class App {
+  private sidebar!: HTMLElement;
+  private overlay!: HTMLElement;
+  private hamburger!: HTMLButtonElement;
+  private navLinks!: NodeListOf<HTMLAnchorElement>;
+  private activePanel: PanelId = 'session';
+  private panels: Map<PanelId, HTMLElement> = new Map();
+
+  init(): void {
+    document.documentElement.lang = 'en';
+
+    const root = document.getElementById('app');
+    if (!root) throw new Error('Missing #app root element');
+    root.innerHTML = this.buildShellHTML();
+
+    this.sidebar = document.getElementById('sidebar') as HTMLElement;
+    this.overlay = document.getElementById('sidebar-overlay') as HTMLElement;
+    this.hamburger = document.getElementById('hamburger-btn') as HTMLButtonElement;
+    this.navLinks = document.querySelectorAll<HTMLAnchorElement>('.sidebar__nav-link');
+
+    this.bindHamburger();
+    this.bindNavLinks();
+    this.bindOverlayClose();
+    this.bindKeyboardNav();
+
+    // Mount panels
+    const sessionContainer = document.getElementById('panel-session') as HTMLElement;
+    const txContainer = document.getElementById('panel-tx') as HTMLElement;
+    this.panels.set('session', sessionContainer);
+    this.panels.set('tx', txContainer);
+
+    this.mountSessionPanel(sessionContainer);
+    this.mountTxPanel(txContainer);
+
+    this.showPanel('session');
+  }
+
+  private buildShellHTML(): string {
+    return `
+      <a class="skip-link" href="#main-content">Skip to main content</a>
+
+      <header class="app-header" role="banner">
+        <button
+          class="hamburger"
+          id="hamburger-btn"
+          aria-label="Open navigation menu"
+          aria-expanded="false"
+          aria-controls="sidebar"
+        >
+          <span class="hamburger__bar"></span>
+          <span class="hamburger__bar"></span>
+          <span class="hamburger__bar"></span>
+        </button>
+        <span class="app-header__logo">Galaxy DevKit — Wallet Playground</span>
+      </header>
+
+      <div id="sidebar-overlay" class="sidebar-overlay" role="presentation"></div>
+
+      <div class="app-shell">
+        <nav
+          id="sidebar"
+          class="sidebar"
+          role="navigation"
+          aria-label="Wallet playground navigation"
+        >
+          <ul class="sidebar__nav" role="list">
+            <li class="sidebar__nav-item">
+              <a
+                href="#session"
+                class="sidebar__nav-link"
+                data-panel="session"
+                aria-current="page"
+              >Session Keys</a>
+            </li>
+            <li class="sidebar__nav-item">
+              <a
+                href="#tx"
+                class="sidebar__nav-link"
+                data-panel="tx"
+              >Send Transaction</a>
+            </li>
+          </ul>
+        </nav>
+
+        <main id="main-content" class="main-content" role="main" tabindex="-1">
+          <div id="panel-session" class="panel" role="region" aria-label="Session key management" hidden></div>
+          <div id="panel-tx" class="panel" role="region" aria-label="Transaction builder" hidden></div>
+        </main>
+      </div>
+    `;
+  }
+
+  private mountSessionPanel(container: HTMLElement): void {
+    const sessions = getStoredSessions();
+    const panel = new WalletSessionPanel(container, {
+      onAddSessionKey: async (params) => {
+        // Dynamic import keeps the wallet service out of the initial bundle
+        const { SmartWalletService } = await import(
+          '../../core/wallet/src/smart-wallet.service'
+        );
+        const { BrowserCredentialBackend } = await import(
+          '../../core/wallet/src/credential-backends/browser.backend'
+        );
+        const svc = new SmartWalletService(
+          { relyingPartyId: window.location.hostname },
+          RPC_URL,
+          undefined,
+          undefined,
+          new BrowserCredentialBackend()
+        );
+        const xdr = await svc.addSessionSigner({
+          walletAddress: params.walletAddress,
+          sessionPublicKey: params.sessionPublicKey,
+          ttlSeconds: params.ttlSeconds,
+          credentialId: params.credentialId,
+        });
+
+        // Record the session locally for the active-sessions display
+        const currentLedger = await getCurrentLedger();
+        const LEDGER_CLOSE = 5;
+        const expiresAtLedger =
+          currentLedger + Math.ceil(params.ttlSeconds / LEDGER_CLOSE);
+        const updated: SessionEntry[] = [
+          ...getStoredSessions(),
+          {
+            sessionPublicKey: params.sessionPublicKey,
+            expiresAtLedger,
+            createdAt: Date.now(),
+            ttlSeconds: params.ttlSeconds,
+          },
+        ];
+        storeSessions(updated);
+        panel.setSessions(updated);
+        return xdr;
+      },
+      getCurrentLedger,
+    });
+    panel.setSessions(sessions);
+  }
+
+  private mountTxPanel(container: HTMLElement): void {
+    new WalletTxPanel(
+      container,
+      { rpcUrl: RPC_URL },
+      {
+        onSign: async (walletAddress, unsignedXdr, credentialId) => {
+          const { SmartWalletService } = await import(
+            '../../core/wallet/src/smart-wallet.service'
+          );
+          const { BrowserCredentialBackend } = await import(
+            '../../core/wallet/src/credential-backends/browser.backend'
+          );
+          const { TransactionBuilder } = await import('@stellar/stellar-sdk');
+          const { Networks } = await import('@stellar/stellar-sdk');
+          const svc = new SmartWalletService(
+            { relyingPartyId: window.location.hostname },
+            RPC_URL,
+            undefined,
+            undefined,
+            new BrowserCredentialBackend()
+          );
+          const tx = TransactionBuilder.fromXDR(unsignedXdr, Networks.TESTNET);
+          return svc.sign(walletAddress, tx as any, credentialId);
+        },
+        onSubmit: async (signedXdr) => {
+          const { TxBuilderClient } = await import('./services/tx-builder.client');
+          const client = new TxBuilderClient(RPC_URL);
+          return client.submitSignedXdr(signedXdr);
+        },
+      }
+    );
+  }
+
+  // ── Hamburger / drawer ───────────────────────────────────
+
+  private bindHamburger(): void {
+    this.hamburger.addEventListener('click', () => this.toggleDrawer());
+  }
+
+  private bindOverlayClose(): void {
+    this.overlay.addEventListener('click', () => this.closeDrawer());
+  }
+
+  private openDrawer(): void {
+    this.sidebar.classList.add('open');
+    this.overlay.classList.add('visible');
+    this.hamburger.setAttribute('aria-expanded', 'true');
+    this.hamburger.setAttribute('aria-label', 'Close navigation menu');
+    // Move focus to first nav link so keyboard users can navigate
+    (this.sidebar.querySelector<HTMLAnchorElement>('.sidebar__nav-link'))?.focus();
+  }
+
+  private closeDrawer(): void {
+    this.sidebar.classList.remove('open');
+    this.overlay.classList.remove('visible');
+    this.hamburger.setAttribute('aria-expanded', 'false');
+    this.hamburger.setAttribute('aria-label', 'Open navigation menu');
+    this.hamburger.focus();
+  }
+
+  private toggleDrawer(): void {
+    if (this.sidebar.classList.contains('open')) {
+      this.closeDrawer();
+    } else {
+      this.openDrawer();
+    }
+  }
+
+  // ── Nav links ────────────────────────────────────────────
+
+  private bindNavLinks(): void {
+    this.navLinks.forEach(link => {
+      link.addEventListener('click', (e) => {
+        e.preventDefault();
+        const panelId = link.dataset['panel'] as PanelId;
+        if (panelId) {
+          this.showPanel(panelId);
+          // Close drawer on mobile after selection
+          if (window.innerWidth <= 768) this.closeDrawer();
+          // Move focus to main content for screen readers
+          (document.getElementById('main-content') as HTMLElement)?.focus();
+        }
+      });
+    });
+  }
+
+  private showPanel(id: PanelId): void {
+    this.activePanel = id;
+    this.panels.forEach((el, key) => {
+      el.hidden = key !== id;
+    });
+    this.navLinks.forEach(link => {
+      const isCurrent = link.dataset['panel'] === id;
+      link.setAttribute('aria-current', isCurrent ? 'page' : 'false');
+    });
+  }
+
+  // ── Keyboard navigation ─────────────────────────────────
+
+  private bindKeyboardNav(): void {
+    // Close drawer on Escape
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && this.sidebar.classList.contains('open')) {
+        this.closeDrawer();
+      }
+    });
+
+    // Arrow-key navigation within the sidebar nav list
+    this.sidebar.addEventListener('keydown', (e) => {
+      const links = [...this.sidebar.querySelectorAll<HTMLAnchorElement>('.sidebar__nav-link')];
+      const idx = links.indexOf(document.activeElement as HTMLAnchorElement);
+      if (idx === -1) return;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        links[(idx + 1) % links.length]?.focus();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        links[(idx - 1 + links.length) % links.length]?.focus();
+      }
+    });
+  }
+}
+
+// Bootstrap when DOM is ready
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => new App().init());
+} else {
+  new App().init();
+}

--- a/packages/frontend/src/panels/wallet-session.ts
+++ b/packages/frontend/src/panels/wallet-session.ts
@@ -1,0 +1,327 @@
+/**
+ * Session key creation and TTL management panel.
+ *
+ * Renders a form that lets users specify an Ed25519 public key and a
+ * human-readable TTL (seconds, minutes, or hours).  On submit it calls
+ * walletContract.add_session_key via SmartWalletService.addSessionSigner,
+ * displays active sessions with remaining time, and handles timezone-safe
+ * ledger-bound TTL conversions.
+ */
+
+import { ttlSecondsToLedgers } from '../../../core/wallet/src/smart-wallet.service';
+
+export interface SessionEntry {
+  sessionPublicKey: string;
+  /** Ledger number at which this session expires */
+  expiresAtLedger: number;
+  /** Wall-clock creation timestamp (ms) */
+  createdAt: number;
+  /** Requested TTL in seconds */
+  ttlSeconds: number;
+}
+
+/** Unit options exposed in the UI so users don't have to do mental maths */
+export type TtlUnit = 'seconds' | 'minutes' | 'hours';
+
+export function ttlToSeconds(value: number, unit: TtlUnit): number {
+  switch (unit) {
+    case 'minutes':
+      return value * 60;
+    case 'hours':
+      return value * 3600;
+    default:
+      return value;
+  }
+}
+
+/**
+ * Returns ledger-based remaining TTL as a human-readable string.
+ * Uses ledger count difference, not wall-clock time, so timezone
+ * differences never affect the displayed value.
+ */
+export function formatRemainingLedgers(
+  expiresAtLedger: number,
+  currentLedger: number,
+  ledgerCloseTimeSeconds = 5
+): string {
+  const remainingLedgers = expiresAtLedger - currentLedger;
+  if (remainingLedgers <= 0) return 'Expired';
+  const remainingSeconds = remainingLedgers * ledgerCloseTimeSeconds;
+  if (remainingSeconds < 60) return `${remainingSeconds}s`;
+  if (remainingSeconds < 3600) return `${Math.floor(remainingSeconds / 60)}m`;
+  return `${Math.floor(remainingSeconds / 3600)}h ${Math.floor((remainingSeconds % 3600) / 60)}m`;
+}
+
+export interface AddSessionKeyParams {
+  walletAddress: string;
+  sessionPublicKey: string;
+  ttlSeconds: number;
+  credentialId: string;
+}
+
+export interface SessionKeyPanelCallbacks {
+  /** Called when the user submits the form to add a session key */
+  onAddSessionKey: (params: AddSessionKeyParams) => Promise<string>;
+  /** Called to refresh the current ledger sequence */
+  getCurrentLedger: () => Promise<number>;
+}
+
+export class WalletSessionPanel {
+  private sessions: SessionEntry[] = [];
+  private container: HTMLElement;
+  private callbacks: SessionKeyPanelCallbacks;
+
+  constructor(container: HTMLElement, callbacks: SessionKeyPanelCallbacks) {
+    this.container = container;
+    this.callbacks = callbacks;
+    this.render();
+  }
+
+  /** Reload sessions list (e.g. after a new one is added) */
+  setSessions(sessions: SessionEntry[]): void {
+    this.sessions = sessions;
+    this.renderSessionList();
+  }
+
+  private render(): void {
+    this.container.innerHTML = '';
+    this.container.setAttribute('role', 'region');
+    this.container.setAttribute('aria-label', 'Session key management');
+
+    const heading = document.createElement('h2');
+    heading.id = 'session-panel-heading';
+    heading.textContent = 'Session Keys';
+    this.container.appendChild(heading);
+
+    this.container.appendChild(this.buildForm());
+
+    const listSection = document.createElement('section');
+    listSection.id = 'session-list-section';
+    listSection.setAttribute('aria-labelledby', 'session-list-heading');
+    const listHeading = document.createElement('h3');
+    listHeading.id = 'session-list-heading';
+    listHeading.textContent = 'Active Sessions';
+    listSection.appendChild(listHeading);
+
+    const list = document.createElement('ul');
+    list.id = 'session-list';
+    list.setAttribute('aria-label', 'Active session keys');
+    listSection.appendChild(list);
+    this.container.appendChild(listSection);
+
+    this.renderSessionList();
+  }
+
+  private buildForm(): HTMLFormElement {
+    const form = document.createElement('form');
+    form.id = 'add-session-form';
+    form.setAttribute('aria-labelledby', 'session-panel-heading');
+    form.setAttribute('novalidate', '');
+
+    form.appendChild(this.buildField({
+      id: 'session-wallet-address',
+      label: 'Wallet Address (C…)',
+      type: 'text',
+      placeholder: 'CContract…',
+      required: true,
+    }));
+
+    form.appendChild(this.buildField({
+      id: 'session-public-key',
+      label: 'Ed25519 Session Public Key (G…)',
+      type: 'text',
+      placeholder: 'GXXXXXXXX…',
+      required: true,
+    }));
+
+    form.appendChild(this.buildField({
+      id: 'session-credential-id',
+      label: 'WebAuthn Credential ID',
+      type: 'text',
+      placeholder: 'base64url credential id',
+      required: true,
+    }));
+
+    // TTL value + unit row
+    const ttlRow = document.createElement('div');
+    ttlRow.className = 'form-row';
+
+    const ttlValueWrapper = document.createElement('div');
+    const ttlValueLabel = document.createElement('label');
+    ttlValueLabel.htmlFor = 'session-ttl-value';
+    ttlValueLabel.textContent = 'TTL Value';
+    const ttlValueInput = document.createElement('input');
+    ttlValueInput.type = 'number';
+    ttlValueInput.id = 'session-ttl-value';
+    ttlValueInput.name = 'ttlValue';
+    ttlValueInput.min = '1';
+    ttlValueInput.value = '1';
+    ttlValueInput.required = true;
+    ttlValueInput.setAttribute('aria-describedby', 'session-ttl-hint');
+    ttlValueWrapper.appendChild(ttlValueLabel);
+    ttlValueWrapper.appendChild(ttlValueInput);
+
+    const ttlUnitWrapper = document.createElement('div');
+    const ttlUnitLabel = document.createElement('label');
+    ttlUnitLabel.htmlFor = 'session-ttl-unit';
+    ttlUnitLabel.textContent = 'Unit';
+    const ttlUnitSelect = document.createElement('select');
+    ttlUnitSelect.id = 'session-ttl-unit';
+    ttlUnitSelect.name = 'ttlUnit';
+    ttlUnitSelect.setAttribute('aria-label', 'TTL time unit');
+    (['seconds', 'minutes', 'hours'] as TtlUnit[]).forEach(unit => {
+      const opt = document.createElement('option');
+      opt.value = unit;
+      opt.textContent = unit.charAt(0).toUpperCase() + unit.slice(1);
+      if (unit === 'hours') opt.selected = true;
+      ttlUnitSelect.appendChild(opt);
+    });
+    ttlUnitWrapper.appendChild(ttlUnitLabel);
+    ttlUnitWrapper.appendChild(ttlUnitSelect);
+
+    ttlRow.appendChild(ttlValueWrapper);
+    ttlRow.appendChild(ttlUnitWrapper);
+    form.appendChild(ttlRow);
+
+    const ttlHint = document.createElement('small');
+    ttlHint.id = 'session-ttl-hint';
+    ttlHint.textContent = 'Converted to ledger count using ~5 s/ledger. Timezone does not affect ledger TTL.';
+    form.appendChild(ttlHint);
+
+    // Ledger preview
+    const ledgerPreview = document.createElement('p');
+    ledgerPreview.id = 'session-ledger-preview';
+    ledgerPreview.setAttribute('aria-live', 'polite');
+    ledgerPreview.textContent = '';
+    form.appendChild(ledgerPreview);
+
+    const updatePreview = (): void => {
+      const val = parseFloat(ttlValueInput.value);
+      const unit = ttlUnitSelect.value as TtlUnit;
+      if (!isNaN(val) && val > 0) {
+        const secs = ttlToSeconds(val, unit);
+        const ledgers = ttlSecondsToLedgers(secs);
+        ledgerPreview.textContent = `≈ ${ledgers.toLocaleString()} ledgers (${secs.toLocaleString()} seconds)`;
+      } else {
+        ledgerPreview.textContent = '';
+      }
+    };
+    ttlValueInput.addEventListener('input', updatePreview);
+    ttlUnitSelect.addEventListener('change', updatePreview);
+    updatePreview();
+
+    // Status
+    const status = document.createElement('p');
+    status.id = 'session-form-status';
+    status.setAttribute('role', 'status');
+    status.setAttribute('aria-live', 'polite');
+    form.appendChild(status);
+
+    const submitBtn = document.createElement('button');
+    submitBtn.type = 'submit';
+    submitBtn.textContent = 'Add Session Key';
+    form.appendChild(submitBtn);
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      status.textContent = '';
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Adding…';
+
+      const walletAddress = (form.querySelector('#session-wallet-address') as HTMLInputElement).value.trim();
+      const sessionPublicKey = (form.querySelector('#session-public-key') as HTMLInputElement).value.trim();
+      const credentialId = (form.querySelector('#session-credential-id') as HTMLInputElement).value.trim();
+      const ttlValue = parseFloat(ttlValueInput.value);
+      const ttlUnit = ttlUnitSelect.value as TtlUnit;
+
+      if (!walletAddress || !sessionPublicKey || !credentialId) {
+        status.textContent = 'All fields are required.';
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Add Session Key';
+        return;
+      }
+      if (isNaN(ttlValue) || ttlValue <= 0) {
+        status.textContent = 'TTL must be a positive number.';
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Add Session Key';
+        return;
+      }
+
+      const ttlSeconds = ttlToSeconds(ttlValue, ttlUnit);
+
+      try {
+        const xdr = await this.callbacks.onAddSessionKey({
+          walletAddress,
+          sessionPublicKey,
+          ttlSeconds,
+          credentialId,
+        });
+        status.textContent = `Session key added. XDR: ${xdr.slice(0, 40)}…`;
+        form.reset();
+        updatePreview();
+      } catch (err) {
+        status.textContent = `Error: ${err instanceof Error ? err.message : String(err)}`;
+      } finally {
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Add Session Key';
+      }
+    });
+
+    return form;
+  }
+
+  private buildField(opts: {
+    id: string;
+    label: string;
+    type: string;
+    placeholder?: string;
+    required?: boolean;
+  }): HTMLDivElement {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'form-field';
+    const label = document.createElement('label');
+    label.htmlFor = opts.id;
+    label.textContent = opts.label;
+    const input = document.createElement('input');
+    input.type = opts.type;
+    input.id = opts.id;
+    input.name = opts.id;
+    if (opts.placeholder) input.placeholder = opts.placeholder;
+    if (opts.required) input.required = true;
+    wrapper.appendChild(label);
+    wrapper.appendChild(input);
+    return wrapper;
+  }
+
+  private renderSessionList(): void {
+    const list = this.container.querySelector('#session-list');
+    if (!list) return;
+    list.innerHTML = '';
+
+    if (this.sessions.length === 0) {
+      const empty = document.createElement('li');
+      empty.textContent = 'No active sessions.';
+      list.appendChild(empty);
+      return;
+    }
+
+    // getCurrentLedger is async; render optimistically and update once resolved
+    this.callbacks.getCurrentLedger().then(currentLedger => {
+      list.innerHTML = '';
+      this.sessions.forEach(session => {
+        const li = document.createElement('li');
+        li.className = 'session-item';
+        const remaining = formatRemainingLedgers(session.expiresAtLedger, currentLedger);
+        const isExpired = remaining === 'Expired';
+        if (isExpired) li.classList.add('session-expired');
+        li.setAttribute('aria-label', `Session key ${session.sessionPublicKey.slice(0, 8)}… expires in ${remaining}`);
+        li.innerHTML = `
+          <span class="session-key">${session.sessionPublicKey.slice(0, 12)}…</span>
+          <span class="session-ttl ${isExpired ? 'expired' : ''}" aria-label="Remaining time">${remaining}</span>
+          <span class="session-ledger">Expires ledger ${session.expiresAtLedger.toLocaleString()}</span>
+        `;
+        list.appendChild(li);
+      });
+    });
+  }
+}

--- a/packages/frontend/src/panels/wallet-tx.ts
+++ b/packages/frontend/src/panels/wallet-tx.ts
@@ -1,0 +1,245 @@
+/**
+ * Transaction signing and submission panel.
+ *
+ * Implements the end-to-end payment flow:
+ *   build → simulate (display payload) → sign (WebAuthn) → submit → confirm
+ *
+ * The simulation result is rendered before the user commits so they can
+ * inspect fee, auth entries, and the destination before authorizing.
+ */
+
+import { TxBuilderClient, type PaymentParams } from '../services/tx-builder.client';
+
+export interface WalletTxCallbacks {
+  /**
+   * Signs the simulated transaction via smart-wallet __check_auth and returns
+   * the signed fee-less XDR ready for submission.
+   */
+  onSign: (walletAddress: string, unsignedXdr: string, credentialId: string) => Promise<string>;
+  /** Submits the signed XDR and returns the transaction hash */
+  onSubmit: (signedXdr: string) => Promise<string>;
+  /** Called after successful submission so the parent can refresh balances */
+  onConfirmed?: (txHash: string) => void;
+}
+
+export interface WalletTxPanelOptions {
+  rpcUrl: string;
+  network?: string;
+}
+
+export class WalletTxPanel {
+  private container: HTMLElement;
+  private callbacks: WalletTxCallbacks;
+  private txBuilder: TxBuilderClient;
+
+  constructor(
+    container: HTMLElement,
+    options: WalletTxPanelOptions,
+    callbacks: WalletTxCallbacks
+  ) {
+    this.container = container;
+    this.callbacks = callbacks;
+    this.txBuilder = new TxBuilderClient(options.rpcUrl, options.network);
+    this.render();
+  }
+
+  private render(): void {
+    this.container.innerHTML = '';
+    this.container.setAttribute('role', 'region');
+    this.container.setAttribute('aria-label', 'Transaction builder');
+
+    const heading = document.createElement('h2');
+    heading.id = 'tx-panel-heading';
+    heading.textContent = 'Send Transaction';
+    this.container.appendChild(heading);
+
+    this.container.appendChild(this.buildForm());
+  }
+
+  private buildForm(): HTMLFormElement {
+    const form = document.createElement('form');
+    form.id = 'tx-form';
+    form.setAttribute('aria-labelledby', 'tx-panel-heading');
+    form.setAttribute('novalidate', '');
+
+    form.appendChild(this.buildField({ id: 'tx-wallet-address', label: 'Wallet Address (C…)', type: 'text', placeholder: 'CContract…', required: true }));
+    form.appendChild(this.buildField({ id: 'tx-credential-id', label: 'WebAuthn Credential ID', type: 'text', placeholder: 'base64url credential id', required: true }));
+    form.appendChild(this.buildField({ id: 'tx-destination', label: 'Destination Address (G…)', type: 'text', placeholder: 'GXXXXXXXX…', required: true }));
+    form.appendChild(this.buildField({ id: 'tx-amount', label: 'Amount (XLM)', type: 'number', placeholder: '10.0', required: true }));
+    form.appendChild(this.buildField({ id: 'tx-memo', label: 'Memo (optional)', type: 'text', placeholder: 'Optional memo text' }));
+
+    // Simulate preview section — shown before user authorizes
+    const previewSection = document.createElement('section');
+    previewSection.id = 'tx-preview-section';
+    previewSection.hidden = true;
+    previewSection.setAttribute('aria-label', 'Transaction simulation preview');
+    const previewHeading = document.createElement('h3');
+    previewHeading.textContent = 'Simulation Preview';
+    previewSection.appendChild(previewHeading);
+    const previewPre = document.createElement('pre');
+    previewPre.id = 'tx-preview-pre';
+    previewPre.setAttribute('aria-label', 'Simulated transaction details');
+    previewSection.appendChild(previewPre);
+    form.appendChild(previewSection);
+
+    // Status area
+    const status = document.createElement('p');
+    status.id = 'tx-status';
+    status.setAttribute('role', 'status');
+    status.setAttribute('aria-live', 'polite');
+    form.appendChild(status);
+
+    // Action buttons
+    const btnRow = document.createElement('div');
+    btnRow.className = 'btn-row';
+
+    const simulateBtn = document.createElement('button');
+    simulateBtn.type = 'button';
+    simulateBtn.id = 'tx-simulate-btn';
+    simulateBtn.textContent = 'Simulate';
+    simulateBtn.setAttribute('aria-describedby', 'tx-status');
+
+    const signSubmitBtn = document.createElement('button');
+    signSubmitBtn.type = 'submit';
+    signSubmitBtn.id = 'tx-sign-submit-btn';
+    signSubmitBtn.textContent = 'Sign & Submit';
+    signSubmitBtn.disabled = true;
+    signSubmitBtn.setAttribute('aria-describedby', 'tx-status');
+
+    btnRow.appendChild(simulateBtn);
+    btnRow.appendChild(signSubmitBtn);
+    form.appendChild(btnRow);
+
+    // Confirmation area
+    const confirmation = document.createElement('div');
+    confirmation.id = 'tx-confirmation';
+    confirmation.hidden = true;
+    confirmation.setAttribute('role', 'alert');
+    confirmation.setAttribute('aria-live', 'assertive');
+    form.appendChild(confirmation);
+
+    // State used across simulate → sign flow
+    let pendingSimResult: Awaited<ReturnType<TxBuilderClient['buildAndSimulate']>> | null = null;
+
+    const collectParams = (): PaymentParams | null => {
+      const walletAddress = (form.querySelector('#tx-wallet-address') as HTMLInputElement).value.trim();
+      const destination = (form.querySelector('#tx-destination') as HTMLInputElement).value.trim();
+      const amount = (form.querySelector('#tx-amount') as HTMLInputElement).value.trim();
+      const memo = (form.querySelector('#tx-memo') as HTMLInputElement).value.trim();
+      if (!walletAddress || !destination || !amount) return null;
+      return { walletAddress, destination, amount, memo: memo || undefined };
+    };
+
+    simulateBtn.addEventListener('click', async () => {
+      const params = collectParams();
+      if (!params) {
+        status.textContent = 'Wallet address, destination, and amount are required.';
+        return;
+      }
+
+      simulateBtn.disabled = true;
+      simulateBtn.textContent = 'Simulating…';
+      signSubmitBtn.disabled = true;
+      previewSection.hidden = true;
+      status.textContent = '';
+      confirmation.hidden = true;
+      pendingSimResult = null;
+
+      try {
+        pendingSimResult = await this.txBuilder.buildAndSimulate(params);
+        previewPre.textContent = JSON.stringify(
+          {
+            estimatedFee: `${pendingSimResult.estimatedFee} stroops`,
+            authEntries: pendingSimResult.authEntryCount,
+            destination: params.destination,
+            amount: `${params.amount} XLM`,
+            memo: params.memo ?? '(none)',
+          },
+          null,
+          2
+        );
+        previewSection.hidden = false;
+        signSubmitBtn.disabled = false;
+        status.textContent = 'Review simulation above, then click Sign & Submit.';
+      } catch (err) {
+        status.textContent = `Simulation failed: ${err instanceof Error ? err.message : String(err)}`;
+      } finally {
+        simulateBtn.disabled = false;
+        simulateBtn.textContent = 'Simulate';
+      }
+    });
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      if (!pendingSimResult) {
+        status.textContent = 'Run Simulate first.';
+        return;
+      }
+
+      const walletAddress = (form.querySelector('#tx-wallet-address') as HTMLInputElement).value.trim();
+      const credentialId = (form.querySelector('#tx-credential-id') as HTMLInputElement).value.trim();
+      if (!credentialId) {
+        status.textContent = 'Credential ID is required for signing.';
+        return;
+      }
+
+      signSubmitBtn.disabled = true;
+      signSubmitBtn.textContent = 'Signing…';
+      status.textContent = '';
+
+      try {
+        const unsignedXdr = this.txBuilder.assembleFromSimulation(
+          pendingSimResult.transaction,
+          pendingSimResult.raw
+        );
+
+        const signedXdr = await this.callbacks.onSign(walletAddress, unsignedXdr, credentialId);
+
+        signSubmitBtn.textContent = 'Submitting…';
+        const txHash = await this.callbacks.onSubmit(signedXdr);
+
+        confirmation.hidden = false;
+        confirmation.innerHTML = `
+          <strong>Transaction submitted!</strong>
+          <br>Hash: <code>${txHash}</code>
+        `;
+        status.textContent = '';
+        previewSection.hidden = true;
+        signSubmitBtn.disabled = true;
+        pendingSimResult = null;
+        form.reset();
+
+        this.callbacks.onConfirmed?.(txHash);
+      } catch (err) {
+        status.textContent = `Error: ${err instanceof Error ? err.message : String(err)}`;
+        signSubmitBtn.disabled = false;
+        signSubmitBtn.textContent = 'Sign & Submit';
+      }
+    });
+
+    return form;
+  }
+
+  private buildField(opts: {
+    id: string;
+    label: string;
+    type: string;
+    placeholder?: string;
+    required?: boolean;
+  }): HTMLDivElement {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'form-field';
+    const label = document.createElement('label');
+    label.htmlFor = opts.id;
+    label.textContent = opts.label;
+    const input = document.createElement('input');
+    input.type = opts.type;
+    input.id = opts.id;
+    input.name = opts.id;
+    if (opts.placeholder) input.placeholder = opts.placeholder;
+    if (opts.required) input.required = true;
+    wrapper.appendChild(label);
+    wrapper.appendChild(input);
+    return wrapper;
+  }
+}

--- a/packages/frontend/src/services/tx-builder.client.ts
+++ b/packages/frontend/src/services/tx-builder.client.ts
@@ -1,0 +1,146 @@
+/**
+ * Client-side Soroban transaction assembly for the smart wallet playground.
+ *
+ * Responsibilities:
+ *  1. Build a native XLM payment transaction envelope.
+ *  2. Simulate it against the RPC to derive auth entries and fee estimate.
+ *  3. Return the simulate result separately so the UI can render it before
+ *     the user commits to broadcasting.
+ *  4. Assemble the final signed XDR once the wallet has signed the auth entry.
+ */
+
+import {
+  Asset,
+  BASE_FEE,
+  Networks,
+  Operation,
+  Transaction,
+  TransactionBuilder,
+} from '@stellar/stellar-sdk';
+import {
+  Server,
+  Api,
+  assembleTransaction,
+} from '@stellar/stellar-sdk/rpc';
+
+export interface PaymentParams {
+  /** Bech32 contract address of the smart wallet (source) */
+  walletAddress: string;
+  /** Classic Stellar G-address of the recipient */
+  destination: string;
+  /** XLM amount as a decimal string, e.g. "10.5" */
+  amount: string;
+  /** Optional memo text (max 28 bytes) */
+  memo?: string;
+}
+
+export interface SimulateResult {
+  /** Estimated fee in stroops */
+  estimatedFee: string;
+  /** Raw simulation result for display */
+  raw: Api.SimulateTransactionResponse;
+  /** The unsigned transaction that was simulated */
+  transaction: Transaction;
+}
+
+export interface BuildAndSimulateResult extends SimulateResult {
+  /** Auth entries count */
+  authEntryCount: number;
+}
+
+const MIN_FEE_STROOPS = 100;
+
+export class TxBuilderClient {
+  private server: Server;
+  private network: string;
+
+  constructor(rpcUrl: string, network: string = Networks.TESTNET) {
+    this.server = new Server(rpcUrl);
+    this.network = network;
+  }
+
+  /**
+   * Builds a native XLM payment and simulates it.
+   * Returns the simulation payload so the caller can render it before
+   * asking the user to authorize.
+   */
+  async buildAndSimulate(params: PaymentParams): Promise<BuildAndSimulateResult> {
+    const { walletAddress, destination, amount, memo } = params;
+
+    if (!walletAddress) throw new Error('buildAndSimulate: walletAddress is required');
+    if (!destination) throw new Error('buildAndSimulate: destination is required');
+    if (!amount || isNaN(parseFloat(amount)) || parseFloat(amount) <= 0) {
+      throw new Error('buildAndSimulate: amount must be a positive number');
+    }
+
+    const { sequence } = await this.server.getLatestLedger();
+    const sourceAccount = {
+      accountId: () => walletAddress,
+      sequenceNumber: () => String(BigInt(sequence) + 1n),
+      incrementSequenceNumber: () => {},
+    } as unknown as ConstructorParameters<typeof TransactionBuilder>[0];
+
+    const builder = new TransactionBuilder(sourceAccount, {
+      fee: BASE_FEE,
+      networkPassphrase: this.network,
+    }).addOperation(
+      Operation.payment({
+        destination,
+        asset: Asset.native(),
+        amount,
+      })
+    );
+
+    if (memo) {
+      builder.addMemo({ value: memo } as any);
+    }
+
+    const tx = builder.setTimeout(300).build();
+    const simResult = await this.server.simulateTransaction(tx);
+
+    if (Api.isSimulationError(simResult)) {
+      throw new Error(`Transaction simulation failed: ${simResult.error}`);
+    }
+
+    const estimatedFee = String(
+      Math.max(MIN_FEE_STROOPS, parseInt(simResult.minResourceFee ?? '0', 10))
+    );
+
+    return {
+      estimatedFee,
+      raw: simResult,
+      transaction: tx,
+      authEntryCount: simResult.result?.auth?.length ?? 0,
+    };
+  }
+
+  /**
+   * Assembles the final transaction from signed XDR returned by the wallet.
+   * Broadcasts it to the network and returns the transaction hash.
+   */
+  async submitSignedXdr(signedXdr: string): Promise<string> {
+    if (!signedXdr) throw new Error('submitSignedXdr: signedXdr is required');
+
+    const sendResult = await this.server.sendTransaction(
+      TransactionBuilder.fromXDR(signedXdr, this.network) as Transaction
+    );
+
+    if (sendResult.status === 'ERROR') {
+      throw new Error(`Transaction submission failed: ${sendResult.errorResult ?? 'unknown error'}`);
+    }
+
+    return sendResult.hash;
+  }
+
+  /**
+   * Assembles a fee-less signed transaction XDR from the simulate result
+   * and the signed auth payload returned by the wallet service.
+   */
+  assembleFromSimulation(
+    tx: Transaction,
+    simResult: Api.SimulateTransactionResponse
+  ): string {
+    const assembled = assembleTransaction(tx, simResult).build();
+    return assembled.toEnvelope().toXDR('base64');
+  }
+}

--- a/packages/frontend/src/styles/main.css
+++ b/packages/frontend/src/styles/main.css
@@ -1,0 +1,478 @@
+/* Galaxy DevKit — Smart Wallet Playground Styles
+ * Responsive layout using pure CSS media queries.
+ * No JS required for breakpoint-driven layout changes.
+ */
+
+/* ── Reset / Base ─────────────────────────────────────────── */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+:root {
+  --color-bg: #0f172a;
+  --color-surface: #1e293b;
+  --color-surface-hover: #334155;
+  --color-border: #334155;
+  --color-text: #e2e8f0;
+  --color-text-muted: #94a3b8;
+  --color-accent: #6366f1;
+  --color-accent-hover: #818cf8;
+  --color-error: #f87171;
+  --color-success: #34d399;
+  --color-warning: #fbbf24;
+  --sidebar-width: 240px;
+  --header-height: 52px;
+  --focus-ring: 0 0 0 3px rgba(99, 102, 241, 0.5);
+}
+
+html {
+  font-size: 16px;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
+  line-height: 1.5;
+}
+
+/* ── Focus management — WCAG 2.1 AA ──────────────────────── */
+:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+  border-radius: 4px;
+}
+
+/* ── Skip link ────────────────────────────────────────────── */
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--color-accent);
+  color: #fff;
+  padding: 8px 16px;
+  z-index: 9999;
+  border-radius: 0 0 4px 0;
+  transition: top 0.2s;
+}
+
+.skip-link:focus {
+  top: 0;
+}
+
+/* ── Header ───────────────────────────────────────────────── */
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  height: var(--header-height);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  gap: 12px;
+}
+
+.app-header__logo {
+  font-weight: 700;
+  font-size: 1rem;
+  white-space: nowrap;
+}
+
+.app-header__spacer {
+  flex: 1;
+}
+
+/* Hamburger — hidden on desktop */
+.hamburger {
+  display: none;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 28px;
+  height: 20px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: var(--color-text);
+}
+
+.hamburger__bar {
+  display: block;
+  height: 2px;
+  background: currentColor;
+  border-radius: 2px;
+  transition: transform 0.2s, opacity 0.2s;
+}
+
+/* Animate into X when open */
+.hamburger[aria-expanded="true"] .hamburger__bar:nth-child(1) {
+  transform: translateY(9px) rotate(45deg);
+}
+.hamburger[aria-expanded="true"] .hamburger__bar:nth-child(2) {
+  opacity: 0;
+}
+.hamburger[aria-expanded="true"] .hamburger__bar:nth-child(3) {
+  transform: translateY(-9px) rotate(-45deg);
+}
+
+/* ── App shell grid ───────────────────────────────────────── */
+.app-shell {
+  display: grid;
+  grid-template-columns: var(--sidebar-width) 1fr;
+  min-height: calc(100vh - var(--header-height));
+}
+
+/* ── Sidebar nav ──────────────────────────────────────────── */
+.sidebar {
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-border);
+  padding: 16px 0;
+  /* z-index below sticky header but above main content on mobile */
+  z-index: 50;
+}
+
+.sidebar__nav {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sidebar__nav-item {
+  display: block;
+}
+
+.sidebar__nav-link {
+  display: block;
+  padding: 10px 16px;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  border-left: 3px solid transparent;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.sidebar__nav-link:hover,
+.sidebar__nav-link:focus-visible {
+  background: var(--color-surface-hover);
+  color: var(--color-text);
+}
+
+.sidebar__nav-link[aria-current="page"] {
+  border-left-color: var(--color-accent);
+  color: var(--color-accent-hover);
+  background: rgba(99, 102, 241, 0.08);
+}
+
+/* ── Main content ─────────────────────────────────────────── */
+.main-content {
+  padding: 24px 20px;
+  max-width: 800px;
+  width: 100%;
+}
+
+/* ── Panels ───────────────────────────────────────────────── */
+.panel {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 20px;
+}
+
+.panel h2 {
+  margin-top: 0;
+  font-size: 1.1rem;
+}
+
+/* ── Forms ────────────────────────────────────────────────── */
+.form-field {
+  margin-bottom: 14px;
+}
+
+.form-field label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 4px;
+  color: var(--color-text-muted);
+}
+
+.form-field input,
+.form-field select,
+.form-field textarea {
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  color: var(--color-text);
+  font-size: 0.9rem;
+  transition: border-color 0.15s;
+}
+
+.form-field input:focus-visible,
+.form-field select:focus-visible,
+.form-field textarea:focus-visible {
+  border-color: var(--color-accent);
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* TTL value + unit row */
+.form-row {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.form-row > div {
+  flex: 1;
+}
+
+/* Button row */
+.btn-row {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+button[type="submit"],
+button[type="button"] {
+  padding: 9px 18px;
+  background: var(--color-accent);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+  min-height: 44px; /* WCAG touch target */
+}
+
+button[type="submit"]:hover:not(:disabled),
+button[type="button"]:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Secondary button style */
+button.btn-secondary {
+  background: var(--color-surface-hover);
+  color: var(--color-text);
+}
+
+button.btn-secondary:hover:not(:disabled) {
+  background: var(--color-border);
+}
+
+/* ── Status / feedback text ───────────────────────────────── */
+[role="status"],
+[role="alert"] {
+  font-size: 0.875rem;
+  min-height: 1.25em;
+  margin: 6px 0;
+}
+
+[role="alert"] {
+  color: var(--color-success);
+}
+
+/* ── Session list ─────────────────────────────────────────── */
+#session-list {
+  list-style: none;
+  padding: 0;
+  margin: 8px 0 0;
+}
+
+.session-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 10px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  margin-bottom: 6px;
+  font-size: 0.875rem;
+  flex-wrap: wrap;
+}
+
+.session-item.session-expired {
+  opacity: 0.55;
+}
+
+.session-key {
+  font-family: monospace;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-ttl {
+  white-space: nowrap;
+  font-weight: 600;
+  color: var(--color-success);
+}
+
+.session-ttl.expired {
+  color: var(--color-error);
+}
+
+.session-ledger {
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+/* ── TX preview ───────────────────────────────────────────── */
+#tx-preview-pre {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 12px;
+  font-size: 0.85rem;
+  overflow-x: auto;
+  color: var(--color-text);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* ── Confirmation ─────────────────────────────────────────── */
+#tx-confirmation {
+  background: rgba(52, 211, 153, 0.08);
+  border: 1px solid var(--color-success);
+  border-radius: 4px;
+  padding: 12px;
+  margin-top: 8px;
+  font-size: 0.875rem;
+}
+
+#tx-confirmation code {
+  word-break: break-all;
+  font-size: 0.8rem;
+}
+
+/* ── Small text / hints ───────────────────────────────────── */
+small {
+  display: block;
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+  margin-bottom: 8px;
+}
+
+#session-ledger-preview {
+  color: var(--color-accent-hover);
+  font-size: 0.875rem;
+  min-height: 1.25em;
+}
+
+/* ── Drawer overlay (mobile) ─────────────────────────────── */
+.sidebar-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 49;
+}
+
+.sidebar-overlay.visible {
+  display: block;
+}
+
+/* ════════════════════════════════════════════════════════════
+   RESPONSIVE BREAKPOINTS
+   Using pure CSS — no JS needed for layout shifts.
+   ════════════════════════════════════════════════════════════ */
+
+/* ── Tablet: 768px and below ─────────────────────────────── */
+@media (max-width: 768px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  /* Sidebar becomes a drawer */
+  .sidebar {
+    position: fixed;
+    top: var(--header-height);
+    left: 0;
+    bottom: 0;
+    width: var(--sidebar-width);
+    transform: translateX(-100%);
+    transition: transform 0.25s ease;
+    overflow-y: auto;
+  }
+
+  .sidebar.open {
+    transform: translateX(0);
+  }
+
+  /* Show hamburger */
+  .hamburger {
+    display: flex;
+  }
+
+  .main-content {
+    padding: 16px 12px;
+  }
+
+  .panel {
+    padding: 14px;
+  }
+}
+
+/* ── Mobile: 480px and below ─────────────────────────────── */
+@media (max-width: 480px) {
+  :root {
+    --header-height: 48px;
+  }
+
+  .form-row {
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .btn-row {
+    flex-direction: column;
+  }
+
+  .btn-row button {
+    width: 100%;
+  }
+
+  .session-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .session-key {
+    width: 100%;
+  }
+
+  .main-content {
+    padding: 12px 8px;
+  }
+}
+
+/* ── Large screens: 1200px and above ────────────────────── */
+@media (min-width: 1200px) {
+  :root {
+    --sidebar-width: 260px;
+  }
+
+  .main-content {
+    padding: 32px 28px;
+  }
+}

--- a/packages/frontend/src/tests/jest.setup.ts
+++ b/packages/frontend/src/tests/jest.setup.ts
@@ -1,0 +1,3 @@
+import { TextEncoder, TextDecoder } from 'util';
+
+Object.assign(global, { TextEncoder, TextDecoder });

--- a/packages/frontend/src/tests/tx-builder.test.ts
+++ b/packages/frontend/src/tests/tx-builder.test.ts
@@ -1,0 +1,130 @@
+import { TxBuilderClient } from '../services/tx-builder.client';
+
+// Mock @stellar/stellar-sdk/rpc so tests don't hit the network
+const mockSimulateTransaction = jest.fn();
+const mockSendTransaction = jest.fn();
+const mockGetLatestLedger = jest.fn().mockResolvedValue({ sequence: 5000 });
+
+jest.mock('@stellar/stellar-sdk/rpc', () => ({
+  Server: jest.fn().mockImplementation(() => ({
+    simulateTransaction: mockSimulateTransaction,
+    sendTransaction: mockSendTransaction,
+    getLatestLedger: mockGetLatestLedger,
+  })),
+  Api: {
+    isSimulationError: jest.fn((r: unknown) => (r as any).error !== undefined),
+  },
+  assembleTransaction: jest.fn((tx: unknown) => ({
+    build: () => ({ toEnvelope: () => ({ toXDR: () => 'assembled-xdr' }) }),
+  })),
+}));
+
+jest.mock('@stellar/stellar-sdk', () => {
+  // Full mock — avoids loading the real stellar-sdk (which needs TextEncoder +
+  // valid Stellar addresses) and keeps unit tests focused on service logic.
+  const mockTx = { toEnvelope: () => ({ toXDR: () => 'unsigned-xdr' }) };
+  class MockTransactionBuilder {
+    addOperation() { return this; }
+    setTimeout() { return this; }
+    build() { return mockTx; }
+    static fromXDR() { return mockTx; }
+  }
+  return {
+    Asset: { native: () => ({ code: 'XLM' }) },
+    BASE_FEE: '100',
+    Networks: { TESTNET: 'Test SDF Network ; September 2015' },
+    Operation: { payment: () => ({}) },
+    TransactionBuilder: MockTransactionBuilder,
+  };
+});
+
+describe('TxBuilderClient', () => {
+  const RPC = 'https://soroban-testnet.stellar.org';
+  let client: TxBuilderClient;
+
+  beforeEach(() => {
+    client = new TxBuilderClient(RPC);
+    jest.clearAllMocks();
+    mockGetLatestLedger.mockResolvedValue({ sequence: 5000 });
+  });
+
+  describe('buildAndSimulate', () => {
+    it('throws when walletAddress is missing', async () => {
+      await expect(
+        client.buildAndSimulate({ walletAddress: '', destination: 'GDEST', amount: '10' })
+      ).rejects.toThrow('walletAddress is required');
+    });
+
+    it('throws when destination is missing', async () => {
+      await expect(
+        client.buildAndSimulate({ walletAddress: 'CWALLET', destination: '', amount: '10' })
+      ).rejects.toThrow('destination is required');
+    });
+
+    it('throws when amount is zero or negative', async () => {
+      await expect(
+        client.buildAndSimulate({ walletAddress: 'CWALLET', destination: 'GDEST', amount: '0' })
+      ).rejects.toThrow('amount must be a positive number');
+
+      await expect(
+        client.buildAndSimulate({ walletAddress: 'CWALLET', destination: 'GDEST', amount: '-5' })
+      ).rejects.toThrow('amount must be a positive number');
+    });
+
+    it('throws when amount is not a number', async () => {
+      await expect(
+        client.buildAndSimulate({ walletAddress: 'CWALLET', destination: 'GDEST', amount: 'abc' })
+      ).rejects.toThrow('amount must be a positive number');
+    });
+
+    it('throws when simulation returns an error', async () => {
+      mockSimulateTransaction.mockResolvedValue({ error: 'contract not found' });
+      await expect(
+        client.buildAndSimulate({ walletAddress: 'CWALLET', destination: 'GDEST', amount: '5' })
+      ).rejects.toThrow('Transaction simulation failed: contract not found');
+    });
+
+    it('returns estimated fee and auth entry count on success', async () => {
+      mockSimulateTransaction.mockResolvedValue({
+        minResourceFee: '200',
+        result: { auth: [{}, {}] },
+      });
+      const result = await client.buildAndSimulate({
+        walletAddress: 'CWALLET',
+        destination: 'GDEST',
+        amount: '10',
+      });
+      expect(result.estimatedFee).toBe('200');
+      expect(result.authEntryCount).toBe(2);
+    });
+
+    it('uses MIN_FEE when minResourceFee is missing', async () => {
+      mockSimulateTransaction.mockResolvedValue({ result: { auth: [] } });
+      const result = await client.buildAndSimulate({
+        walletAddress: 'CWALLET',
+        destination: 'GDEST',
+        amount: '1',
+      });
+      expect(parseInt(result.estimatedFee, 10)).toBeGreaterThanOrEqual(100);
+    });
+  });
+
+  describe('submitSignedXdr', () => {
+    it('throws when signedXdr is empty', async () => {
+      await expect(client.submitSignedXdr('')).rejects.toThrow('signedXdr is required');
+    });
+
+    it('throws when sendTransaction returns ERROR status', async () => {
+      mockSendTransaction.mockResolvedValue({ status: 'ERROR', errorResult: 'bad tx' });
+      await expect(client.submitSignedXdr('AXDR==')).rejects.toThrow(
+        'Transaction submission failed: bad tx'
+      );
+    });
+
+    it('returns transaction hash on success', async () => {
+      mockSendTransaction.mockResolvedValue({ status: 'PENDING', hash: 'abc123hash' });
+      const hash = await client.submitSignedXdr('AXDR==');
+      expect(hash).toBe('abc123hash');
+    });
+  });
+});

--- a/packages/frontend/src/tests/wallet-session.test.ts
+++ b/packages/frontend/src/tests/wallet-session.test.ts
@@ -1,0 +1,173 @@
+/**
+ * @jest-environment jest-environment-jsdom
+ */
+import {
+  ttlToSeconds,
+  formatRemainingLedgers,
+  WalletSessionPanel,
+  type SessionEntry,
+  type SessionKeyPanelCallbacks,
+} from '../panels/wallet-session';
+import { ttlSecondsToLedgers } from '../../../core/wallet/src/smart-wallet.service';
+
+// ── ttlToSeconds ─────────────────────────────────────────────────────────────
+
+describe('ttlToSeconds', () => {
+  it('returns raw value for seconds unit', () => {
+    expect(ttlToSeconds(30, 'seconds')).toBe(30);
+  });
+
+  it('multiplies by 60 for minutes', () => {
+    expect(ttlToSeconds(5, 'minutes')).toBe(300);
+  });
+
+  it('multiplies by 3600 for hours', () => {
+    expect(ttlToSeconds(2, 'hours')).toBe(7200);
+  });
+});
+
+// ── ttlSecondsToLedgers ──────────────────────────────────────────────────────
+
+describe('ttlSecondsToLedgers', () => {
+  it('converts exactly divisible seconds', () => {
+    expect(ttlSecondsToLedgers(100)).toBe(20);
+  });
+
+  it('rounds up for non-divisible seconds', () => {
+    expect(ttlSecondsToLedgers(6)).toBe(2);
+    expect(ttlSecondsToLedgers(11)).toBe(3);
+  });
+
+  it('returns 1 ledger for values less than close time', () => {
+    expect(ttlSecondsToLedgers(1)).toBe(1);
+  });
+});
+
+// ── formatRemainingLedgers ───────────────────────────────────────────────────
+
+describe('formatRemainingLedgers', () => {
+  it('returns "Expired" when expiresAtLedger <= currentLedger', () => {
+    expect(formatRemainingLedgers(100, 100)).toBe('Expired');
+    expect(formatRemainingLedgers(99, 100)).toBe('Expired');
+  });
+
+  it('shows seconds for < 60 seconds remaining', () => {
+    // 10 ledgers * 5 s = 50 s
+    expect(formatRemainingLedgers(110, 100)).toBe('50s');
+  });
+
+  it('shows minutes for < 3600 seconds remaining', () => {
+    // 60 ledgers * 5 s = 300 s = 5 m
+    expect(formatRemainingLedgers(160, 100)).toBe('5m');
+  });
+
+  it('shows hours and minutes for >= 3600 seconds remaining', () => {
+    // 900 ledgers * 5 s = 4500 s = 1h 15m
+    expect(formatRemainingLedgers(1000, 100)).toBe('1h 15m');
+  });
+
+  it('uses custom ledgerCloseTimeSeconds', () => {
+    // 10 ledgers * 6 s = 60 s = 1m
+    expect(formatRemainingLedgers(110, 100, 6)).toBe('1m');
+  });
+});
+
+// ── WalletSessionPanel DOM integration ──────────────────────────────────────
+
+function createContainer(): HTMLDivElement {
+  const div = document.createElement('div');
+  document.body.appendChild(div);
+  return div;
+}
+
+function makeCallbacks(
+  overrides: Partial<SessionKeyPanelCallbacks> = {}
+): SessionKeyPanelCallbacks {
+  return {
+    onAddSessionKey: jest.fn().mockResolvedValue('AXDR=='),
+    getCurrentLedger: jest.fn().mockResolvedValue(1000),
+    ...overrides,
+  };
+}
+
+describe('WalletSessionPanel', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = createContainer();
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('renders form and session list', () => {
+    new WalletSessionPanel(container, makeCallbacks());
+    expect(container.querySelector('#add-session-form')).not.toBeNull();
+    expect(container.querySelector('#session-list')).not.toBeNull();
+  });
+
+  it('shows empty state when no sessions', () => {
+    new WalletSessionPanel(container, makeCallbacks());
+    expect(container.querySelector('#session-list')?.textContent).toContain('No active sessions');
+  });
+
+  it('sets aria-label on the region', () => {
+    new WalletSessionPanel(container, makeCallbacks());
+    expect(container.getAttribute('aria-label')).toBe('Session key management');
+  });
+
+  it('renders session items when setSessions is called', async () => {
+    const panel = new WalletSessionPanel(container, makeCallbacks());
+    const sessions: SessionEntry[] = [
+      { sessionPublicKey: 'GABC123', expiresAtLedger: 2000, createdAt: Date.now(), ttlSeconds: 3600 },
+    ];
+    panel.setSessions(sessions);
+    // getCurrentLedger resolves async; flush microtasks
+    await Promise.resolve();
+    const list = container.querySelector('#session-list') as HTMLUListElement;
+    expect(list.children.length).toBe(1);
+  });
+
+  it('disables submit and shows error for empty wallet address', async () => {
+    new WalletSessionPanel(container, makeCallbacks());
+    const form = container.querySelector('#add-session-form') as HTMLFormElement;
+    // Set required fields but leave wallet address empty
+    (form.querySelector('#session-public-key') as HTMLInputElement).value = 'GXXX';
+    (form.querySelector('#session-credential-id') as HTMLInputElement).value = 'cred123';
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    await Promise.resolve();
+    const status = container.querySelector('#session-form-status') as HTMLElement;
+    expect(status.textContent).toContain('required');
+  });
+
+  it('calls onAddSessionKey with correct seconds conversion', async () => {
+    const onAddSessionKey = jest.fn().mockResolvedValue('XDR');
+    new WalletSessionPanel(container, makeCallbacks({ onAddSessionKey }));
+    const form = container.querySelector('#add-session-form') as HTMLFormElement;
+
+    (form.querySelector('#session-wallet-address') as HTMLInputElement).value = 'CADDR';
+    (form.querySelector('#session-public-key') as HTMLInputElement).value = 'GKEY';
+    (form.querySelector('#session-credential-id') as HTMLInputElement).value = 'CRED';
+    (form.querySelector('#session-ttl-value') as HTMLInputElement).value = '1';
+    (form.querySelector('#session-ttl-unit') as HTMLSelectElement).value = 'hours';
+
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    await Promise.resolve();
+    await Promise.resolve(); // second tick for async callback
+
+    expect(onAddSessionKey).toHaveBeenCalledWith(
+      expect.objectContaining({ ttlSeconds: 3600 })
+    );
+  });
+
+  it('shows ledger preview that updates with TTL input', () => {
+    new WalletSessionPanel(container, makeCallbacks());
+    const ttlInput = container.querySelector('#session-ttl-value') as HTMLInputElement;
+    const preview = container.querySelector('#session-ledger-preview') as HTMLElement;
+    ttlInput.value = '2';
+    ttlInput.dispatchEvent(new Event('input'));
+    // 2 hours = 7200 s → 1440 ledgers
+    expect(preview.textContent).toContain('1,440');
+  });
+});

--- a/packages/frontend/src/tests/wallet-tx-panel.test.ts
+++ b/packages/frontend/src/tests/wallet-tx-panel.test.ts
@@ -1,0 +1,170 @@
+/**
+ * @jest-environment jest-environment-jsdom
+ *
+ * WalletTxPanel DOM tests.
+ * TxBuilderClient network calls are mocked via jest.mock so these
+ * tests run without a live RPC endpoint.
+ */
+
+import { WalletTxPanel } from '../panels/wallet-tx';
+
+const mockBuildAndSimulate = jest.fn();
+const mockSubmitSignedXdr = jest.fn();
+const mockAssembleFromSimulation = jest.fn().mockReturnValue('assembled-xdr');
+
+jest.mock('../services/tx-builder.client', () => ({
+  TxBuilderClient: jest.fn().mockImplementation(() => ({
+    buildAndSimulate: mockBuildAndSimulate,
+    submitSignedXdr: mockSubmitSignedXdr,
+    assembleFromSimulation: mockAssembleFromSimulation,
+  })),
+}));
+
+function makeContainer(): HTMLDivElement {
+  const div = document.createElement('div');
+  document.body.appendChild(div);
+  return div;
+}
+
+function makeCallbacks() {
+  return {
+    onSign: jest.fn().mockResolvedValue('signed-xdr'),
+    onSubmit: jest.fn().mockResolvedValue('txhash123'),
+    onConfirmed: jest.fn(),
+  };
+}
+
+describe('WalletTxPanel', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = makeContainer();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('renders the form with all required fields', () => {
+    new WalletTxPanel(container, { rpcUrl: 'https://rpc' }, makeCallbacks());
+    expect(container.querySelector('#tx-form')).not.toBeNull();
+    expect(container.querySelector('#tx-wallet-address')).not.toBeNull();
+    expect(container.querySelector('#tx-destination')).not.toBeNull();
+    expect(container.querySelector('#tx-amount')).not.toBeNull();
+    expect(container.querySelector('#tx-credential-id')).not.toBeNull();
+    expect(container.querySelector('#tx-memo')).not.toBeNull();
+  });
+
+  it('sets aria-label on the region', () => {
+    new WalletTxPanel(container, { rpcUrl: 'https://rpc' }, makeCallbacks());
+    expect(container.getAttribute('aria-label')).toBe('Transaction builder');
+  });
+
+  it('Sign & Submit button is disabled before simulate', () => {
+    new WalletTxPanel(container, { rpcUrl: 'https://rpc' }, makeCallbacks());
+    const btn = container.querySelector('#tx-sign-submit-btn') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('shows status message when simulate is clicked without required fields', async () => {
+    new WalletTxPanel(container, { rpcUrl: 'https://rpc' }, makeCallbacks());
+    const simulateBtn = container.querySelector('#tx-simulate-btn') as HTMLButtonElement;
+    simulateBtn.click();
+    await Promise.resolve();
+    const status = container.querySelector('#tx-status') as HTMLElement;
+    expect(status.textContent).toContain('required');
+  });
+
+  it('calls buildAndSimulate with correct params and enables Sign & Submit', async () => {
+    mockBuildAndSimulate.mockResolvedValue({
+      estimatedFee: '300',
+      authEntryCount: 1,
+      raw: {},
+      transaction: {},
+    });
+
+    new WalletTxPanel(container, { rpcUrl: 'https://rpc' }, makeCallbacks());
+    (container.querySelector('#tx-wallet-address') as HTMLInputElement).value = 'CWALLET';
+    (container.querySelector('#tx-destination') as HTMLInputElement).value = 'GDEST';
+    (container.querySelector('#tx-amount') as HTMLInputElement).value = '10';
+
+    const simulateBtn = container.querySelector('#tx-simulate-btn') as HTMLButtonElement;
+    simulateBtn.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockBuildAndSimulate).toHaveBeenCalledWith(
+      expect.objectContaining({ walletAddress: 'CWALLET', destination: 'GDEST', amount: '10' })
+    );
+    const signBtn = container.querySelector('#tx-sign-submit-btn') as HTMLButtonElement;
+    expect(signBtn.disabled).toBe(false);
+  });
+
+  it('shows simulation preview after successful simulate', async () => {
+    mockBuildAndSimulate.mockResolvedValue({
+      estimatedFee: '500',
+      authEntryCount: 1,
+      raw: {},
+      transaction: {},
+    });
+
+    new WalletTxPanel(container, { rpcUrl: 'https://rpc' }, makeCallbacks());
+    (container.querySelector('#tx-wallet-address') as HTMLInputElement).value = 'CW';
+    (container.querySelector('#tx-destination') as HTMLInputElement).value = 'GD';
+    (container.querySelector('#tx-amount') as HTMLInputElement).value = '5';
+
+    (container.querySelector('#tx-simulate-btn') as HTMLButtonElement).click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const preview = container.querySelector('#tx-preview-section') as HTMLElement;
+    expect(preview.hidden).toBe(false);
+    expect(container.querySelector('#tx-preview-pre')?.textContent).toContain('500 stroops');
+  });
+
+  it('shows error status when simulate fails', async () => {
+    mockBuildAndSimulate.mockRejectedValue(new Error('RPC timeout'));
+
+    new WalletTxPanel(container, { rpcUrl: 'https://rpc' }, makeCallbacks());
+    (container.querySelector('#tx-wallet-address') as HTMLInputElement).value = 'CW';
+    (container.querySelector('#tx-destination') as HTMLInputElement).value = 'GD';
+    (container.querySelector('#tx-amount') as HTMLInputElement).value = '1';
+
+    (container.querySelector('#tx-simulate-btn') as HTMLButtonElement).click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect((container.querySelector('#tx-status') as HTMLElement).textContent).toContain('RPC timeout');
+  });
+
+  it('calls onSign and onSubmit on form submit, shows confirmation', async () => {
+    mockBuildAndSimulate.mockResolvedValue({ estimatedFee: '100', authEntryCount: 1, raw: {}, transaction: {} });
+    const cbs = makeCallbacks();
+
+    new WalletTxPanel(container, { rpcUrl: 'https://rpc' }, cbs);
+    (container.querySelector('#tx-wallet-address') as HTMLInputElement).value = 'CW';
+    (container.querySelector('#tx-credential-id') as HTMLInputElement).value = 'CRED';
+    (container.querySelector('#tx-destination') as HTMLInputElement).value = 'GD';
+    (container.querySelector('#tx-amount') as HTMLInputElement).value = '2';
+
+    // Simulate first
+    (container.querySelector('#tx-simulate-btn') as HTMLButtonElement).click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Sign & Submit
+    const form = container.querySelector('#tx-form') as HTMLFormElement;
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(cbs.onSign).toHaveBeenCalled();
+    expect(cbs.onSubmit).toHaveBeenCalledWith('signed-xdr');
+    const confirmation = container.querySelector('#tx-confirmation') as HTMLElement;
+    expect(confirmation.hidden).toBe(false);
+    expect(confirmation.textContent).toContain('txhash123');
+    expect(cbs.onConfirmed).toHaveBeenCalledWith('txhash123');
+  });
+});

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2020", "DOM"]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary

- **#209** — `wallet-session.ts` panel: Ed25519 public key input, TTL picker (seconds/minutes/hours) converted to ledger count (~5 s/ledger), live ledger-count preview, and active-session list displaying remaining time. Timezone differences never affect ledger TTL estimation.
- **#210** — `wallet-tx.ts` panel + `tx-builder.client.ts` service: full build → simulate (preview rendered before authorization) → sign via smart wallet WebAuthn `__check_auth` → submit → confirmation flow with tx hash display.
- **#237** — `main.css` pure-CSS responsive layout: grid shell collapses to animated hamburger drawer ≤768 px, stacked form rows and full-width buttons ≤480 px. `app.ts` adds skip-link, ARIA landmarks, `aria-current` nav, arrow-key sidebar navigation, Escape drawer close, and 44 px min touch targets (WCAG 2.1 AA).

## Test plan

- [ ] `npx jest packages/frontend --no-coverage` — 36 tests, 3 suites all green
- [ ] TTL unit conversion: 1 hour → 720 ledgers shown in preview
- [ ] Simulate button renders fee + auth entry count before Sign & Submit is enabled
- [ ] Sign & Submit calls `__check_auth` and shows tx hash on success
- [ ] Sidebar collapses to hamburger at ≤768 px; Escape and overlay click close it
- [ ] Arrow-up/down keyboard navigation works within sidebar nav
- [ ] Skip-link appears on Tab and moves focus to `#main-content`

Closes #209
Closes #210
Closes #237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session key management with TTL controls and active session tracking
  * Transaction simulator and submission interface with preview
  * Responsive sidebar navigation with keyboard accessibility
  * Dark-themed UI with enhanced styling

* **Documentation**
  * Added Smart Wallet Playground to interactive docs navigation

* **Tests**
  * Added comprehensive test coverage for new session and transaction features
<!-- end of auto-generated comment: release notes by coderabbit.ai -->