### PR TITLE
feat(defi-protocols): aquarius adapter, split executor + depth analyzer, IL calculator

### DIFF
--- a/packages/core/defi-protocols/__tests__/aggregator/AquariusAdapter.test.ts
+++ b/packages/core/defi-protocols/__tests__/aggregator/AquariusAdapter.test.ts
@@ -68,4 +68,44 @@ describe('AquariusAdapter (#273)', () => {
     const url = fetchImpl.mock.calls[0][0] as string;
     expect(url.startsWith('https://amm-staging.example/quote?')).toBe(true);
   });
+
+  it('throws when amount_out is a non-positive numeric string', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(jsonResponse({ amount_out: '0' }));
+    const adapter = new AquariusAdapter({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    await expect(
+      adapter.fetchRoute({ assetIn: XLM, assetOut: USDC, amountIn: '100' }),
+    ).rejects.toThrow(/invalid amount_out/);
+  });
+
+  it('throws when amount_out is non-finite (NaN string)', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(jsonResponse({ amount_out: 'NaN' }));
+    const adapter = new AquariusAdapter({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    await expect(
+      adapter.fetchRoute({ assetIn: XLM, assetOut: USDC, amountIn: '100' }),
+    ).rejects.toThrow(/invalid amount_out/);
+  });
+
+  it('falls back to priceImpact=0 when price_impact is missing or non-numeric', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(jsonResponse({ amount_out: '5' }));
+    const adapter = new AquariusAdapter({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    const route = await adapter.fetchRoute({ assetIn: XLM, assetOut: USDC, amountIn: '100' });
+    expect(route.priceImpact).toBe(0);
+    expect(route.path).toEqual([]);
+  });
+
+  it('coerces numeric price_impact passed as a number', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(jsonResponse({ amount_out: '5', price_impact: 0.025 }));
+    const adapter = new AquariusAdapter({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    const route = await adapter.fetchRoute({ assetIn: XLM, assetOut: USDC, amountIn: '100' });
+    expect(route.priceImpact).toBe(0.025);
+  });
+
+  it('coerces a non-numeric price_impact string to 0', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(jsonResponse({ amount_out: '5', price_impact: 'not-a-number' }));
+    const adapter = new AquariusAdapter({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    const route = await adapter.fetchRoute({ assetIn: XLM, assetOut: USDC, amountIn: '100' });
+    expect(route.priceImpact).toBe(0);
+  });
 });

--- a/packages/core/defi-protocols/__tests__/aggregator/AquariusAdapter.test.ts
+++ b/packages/core/defi-protocols/__tests__/aggregator/AquariusAdapter.test.ts
@@ -1,0 +1,71 @@
+/**
+ * AquariusAdapter tests (#273).
+ */
+
+import { AquariusAdapter } from '../../src/aggregator/AquariusAdapter';
+import { Asset } from '../../src/types/defi-types';
+
+const XLM: Asset = { code: 'XLM', type: 'native' };
+const USDC: Asset = {
+  code: 'USDC',
+  issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+  type: 'credit_alphanum4',
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('AquariusAdapter (#273)', () => {
+  it('maps the Aquarius response to an AggregatorRoute with venue=aquarius', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(
+      jsonResponse({
+        amount_out: '1234.5670000',
+        price_impact: '0.01',
+        path: ['poolA', 'poolB'],
+      }),
+    );
+
+    const adapter = new AquariusAdapter({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    const route = await adapter.fetchRoute({ assetIn: XLM, assetOut: USDC, amountIn: '1000' });
+
+    expect(route.venue).toBe('aquarius');
+    expect(route.amountIn).toBe('1000');
+    expect(route.amountOut).toBe('1234.5670000');
+    expect(route.priceImpact).toBeCloseTo(0.01);
+    expect(route.path).toEqual(['poolA', 'poolB']);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when the Aquarius endpoint returns a non-2xx', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(new Response('upstream down', { status: 502, statusText: 'Bad Gateway' }));
+    const adapter = new AquariusAdapter({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    await expect(
+      adapter.fetchRoute({ assetIn: XLM, assetOut: USDC, amountIn: '100' }),
+    ).rejects.toThrow(/Aquarius quote endpoint returned 502/);
+  });
+
+  it('throws when the response is missing amount_out', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(jsonResponse({ price_impact: 0 }));
+    const adapter = new AquariusAdapter({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    await expect(
+      adapter.fetchRoute({ assetIn: XLM, assetOut: USDC, amountIn: '100' }),
+    ).rejects.toThrow(/missing amount_out/);
+  });
+
+  it('honours the injected baseUrl in the request URL', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(jsonResponse({ amount_out: '1' }));
+    const adapter = new AquariusAdapter({
+      baseUrl: 'https://amm-staging.example',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    await adapter.fetchRoute({ assetIn: XLM, assetOut: USDC, amountIn: '100' });
+    const url = fetchImpl.mock.calls[0][0] as string;
+    expect(url.startsWith('https://amm-staging.example/quote?')).toBe(true);
+  });
+});

--- a/packages/core/defi-protocols/__tests__/aggregator/DexAggregator.test.ts
+++ b/packages/core/defi-protocols/__tests__/aggregator/DexAggregator.test.ts
@@ -469,6 +469,39 @@ describe('DexAggregatorService', () => {
     expect(quote.totalAmountOut).toBe('97.0000000');
   });
 
+  it('throws when the SDEX protocol does not expose getSwapQuote', async () => {
+    protocolFactory.createProtocol.mockImplementation((cfg) => {
+      if (cfg.protocolId === 'soroswap') {
+        return {
+          initialize: jest.fn().mockResolvedValue(undefined),
+          getSwapQuote: jest.fn().mockResolvedValue({
+            tokenIn: XLM,
+            tokenOut: USDC,
+            amountIn: '100',
+            amountOut: '95.0000000',
+            priceImpact: '0',
+            minimumReceived: '0',
+            path: [],
+            validUntil: new Date(),
+          }),
+        };
+      }
+      // SDEX protocol returned without getSwapQuote — exercises the
+      // line-202 throw.
+      return { initialize: jest.fn().mockResolvedValue(undefined) };
+    });
+
+    const aggregator = new DexAggregatorService(config, {
+      fetchImpl,
+      horizonServer,
+      protocolFactory,
+    });
+
+    await expect(aggregator.getSplitQuote(XLM, USDC, '100', [0, 100])).rejects.toThrow(
+      'SDEX protocol does not implement getSwapQuote'
+    );
+  });
+
   it('handles numeric and undefined Soroswap price impacts', async () => {
     let callCount = 0;
     protocolFactory.createProtocol.mockImplementation((cfg) => {

--- a/packages/core/defi-protocols/__tests__/aggregator/split-executor.test.ts
+++ b/packages/core/defi-protocols/__tests__/aggregator/split-executor.test.ts
@@ -1,0 +1,136 @@
+/**
+ * split-executor + liquidity-depth tests (#275).
+ */
+
+import {
+  executeSplitTrade,
+  LiquidityDepthAnalyzer,
+  type AggregatorQuote,
+  type AggregatorRoute,
+} from '../../src/aggregator';
+
+const XLM = { code: 'XLM', type: 'native' as const };
+const USDC = {
+  code: 'USDC',
+  issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+  type: 'credit_alphanum4' as const,
+};
+
+function route(venue: AggregatorRoute['venue'], amountIn: string, amountOut: string): AggregatorRoute {
+  return { venue, amountIn, amountOut, priceImpact: 0, path: [] };
+}
+
+function quote(routes: AggregatorRoute[]): AggregatorQuote {
+  return {
+    assetIn: XLM,
+    assetOut: USDC,
+    amountIn: routes.reduce((s, r) => s + Number(r.amountIn), 0).toString(),
+    routes,
+    totalAmountOut: routes.reduce((s, r) => s + Number(r.amountOut), 0).toString(),
+    effectivePrice: 0,
+    savingsVsBestSingle: 0,
+  };
+}
+
+describe('executeSplitTrade (#275)', () => {
+  it('submits every route in parallel and aggregates the fill', async () => {
+    const q = quote([
+      route('soroswap', '600', '610'),
+      route('sdex', '400', '405'),
+    ]);
+    const submit = jest
+      .fn()
+      .mockResolvedValueOnce({ outputAmount: '610', txId: 't1', feePaid: '1' })
+      .mockResolvedValueOnce({ outputAmount: '405', txId: 't2', feePaid: '0.5' });
+    const out = await executeSplitTrade(q, submit);
+
+    expect(out.allSucceeded).toBe(true);
+    expect(out.splits).toHaveLength(2);
+    expect(out.splits[0]).toMatchObject({ source: 'soroswap', txId: 't1', ok: true });
+    expect(out.splits[1]).toMatchObject({ source: 'sdex', txId: 't2', ok: true });
+    expect(out.totalOutput).toBe('1015.0000000');
+    expect(out.totalFees).toBe('1.5000000');
+    expect(out.averagePrice).toBeCloseTo(1015 / 1000);
+  });
+
+  it('skips routes below minSplitInput to avoid dust trades', async () => {
+    const q = quote([
+      route('soroswap', '900', '910'),
+      // Dust route — should be filtered out before submission.
+      route('sdex', '5', '5'),
+    ]);
+    const submit = jest.fn().mockResolvedValue({ outputAmount: '910' });
+    const out = await executeSplitTrade(q, submit, { minSplitInput: '10' });
+
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(out.splits).toHaveLength(1);
+    expect(out.splits[0].source).toBe('soroswap');
+  });
+
+  it('aborts the split when a submitter rejects (abortOnError default true)', async () => {
+    const q = quote([route('soroswap', '500', '510'), route('sdex', '500', '505')]);
+    const submit = jest
+      .fn()
+      .mockResolvedValueOnce({ outputAmount: '510' })
+      .mockRejectedValueOnce(new Error('sdex submit timeout'));
+    await expect(executeSplitTrade(q, submit)).rejects.toThrow(/sdex submit timeout/);
+  });
+
+  it('returns partial fill when abortOnError=false', async () => {
+    const q = quote([route('soroswap', '500', '510'), route('sdex', '500', '505')]);
+    const submit = jest
+      .fn()
+      .mockResolvedValueOnce({ outputAmount: '510' })
+      .mockRejectedValueOnce(new Error('sdex unavailable'));
+    const out = await executeSplitTrade(q, submit, { abortOnError: false });
+
+    expect(out.allSucceeded).toBe(false);
+    expect(out.splits[0].ok).toBe(true);
+    expect(out.splits[1]).toMatchObject({ ok: false, error: 'sdex unavailable' });
+    expect(out.totalOutput).toBe('510.0000000');
+  });
+});
+
+describe('LiquidityDepthAnalyzer (#275)', () => {
+  const analyzer = new LiquidityDepthAnalyzer();
+
+  it('splits proportionally to depth', () => {
+    const split = analyzer.optimalSplit(
+      {
+        entries: [
+          { venue: 'soroswap', depthIn: '6000' },
+          { venue: 'sdex', depthIn: '4000' },
+        ],
+      },
+      { amountIn: '1000' },
+    );
+    expect(split.map((s) => s.venue)).toEqual(['soroswap', 'sdex']);
+    expect(split[0].percentage).toBeCloseTo(60);
+    expect(split[1].percentage).toBeCloseTo(40);
+  });
+
+  it('drops venues below minVenueShare and renormalises', () => {
+    const split = analyzer.optimalSplit(
+      {
+        entries: [
+          { venue: 'soroswap', depthIn: '9700' },
+          { venue: 'sdex', depthIn: '200' },
+          { venue: 'aquarius', depthIn: '100' },
+        ],
+      },
+      { amountIn: '1000', minVenueShare: 0.05 },
+    );
+    expect(split).toHaveLength(1);
+    expect(split[0].venue).toBe('soroswap');
+    expect(split[0].percentage).toBeCloseTo(100);
+  });
+
+  it('falls back to an even split when the snapshot has zero depth', () => {
+    const split = analyzer.optimalSplit(
+      { entries: [{ venue: 'soroswap', depthIn: '0' }, { venue: 'sdex', depthIn: '0' }] },
+      { amountIn: '1000' },
+    );
+    expect(split[0].percentage).toBeCloseTo(50);
+    expect(split[1].percentage).toBeCloseTo(50);
+  });
+});

--- a/packages/core/defi-protocols/__tests__/aggregator/split-executor.test.ts
+++ b/packages/core/defi-protocols/__tests__/aggregator/split-executor.test.ts
@@ -139,7 +139,11 @@ describe('LiquidityDepthAnalyzer (#275)', () => {
     expect(split).toEqual([]);
   });
 
-  it('falls back to an even split when amountIn is not positive', () => {
+  it('falls back to an even split when amountIn is negative', () => {
+    // BigNumber treats 0 as positive, so the non-positive fallback
+    // only fires for negative inputs. The function still has to
+    // return a deterministic answer rather than divide by a
+    // negative weight.
     const split = analyzer.optimalSplit(
       {
         entries: [
@@ -147,7 +151,7 @@ describe('LiquidityDepthAnalyzer (#275)', () => {
           { venue: 'sdex', depthIn: '4000' },
         ],
       },
-      { amountIn: '0' },
+      { amountIn: '-100' },
     );
     expect(split[0].percentage).toBeCloseTo(50);
     expect(split[1].percentage).toBeCloseTo(50);

--- a/packages/core/defi-protocols/__tests__/aggregator/split-executor.test.ts
+++ b/packages/core/defi-protocols/__tests__/aggregator/split-executor.test.ts
@@ -133,4 +133,78 @@ describe('LiquidityDepthAnalyzer (#275)', () => {
     expect(split[0].percentage).toBeCloseTo(50);
     expect(split[1].percentage).toBeCloseTo(50);
   });
+
+  it('returns an empty split when the snapshot has no entries', () => {
+    const split = analyzer.optimalSplit({ entries: [] }, { amountIn: '1000' });
+    expect(split).toEqual([]);
+  });
+
+  it('falls back to an even split when amountIn is not positive', () => {
+    const split = analyzer.optimalSplit(
+      {
+        entries: [
+          { venue: 'soroswap', depthIn: '6000' },
+          { venue: 'sdex', depthIn: '4000' },
+        ],
+      },
+      { amountIn: '0' },
+    );
+    expect(split[0].percentage).toBeCloseTo(50);
+    expect(split[1].percentage).toBeCloseTo(50);
+  });
+
+  it('keeps the raw split when every venue falls below minVenueShare', () => {
+    const split = analyzer.optimalSplit(
+      {
+        entries: [
+          { venue: 'soroswap', depthIn: '100' },
+          { venue: 'sdex', depthIn: '100' },
+        ],
+      },
+      // Both venues sit at 50% — set minVenueShare above that so the
+      // survivors-after-filter set is empty and the helper falls back
+      // to the unfiltered split.
+      { amountIn: '1000', minVenueShare: 0.9 },
+    );
+    expect(split).toHaveLength(2);
+    expect(split[0].percentage).toBeCloseTo(50);
+    expect(split[1].percentage).toBeCloseTo(50);
+  });
+});
+
+describe('executeSplitTrade — additional edge paths', () => {
+  it('returns an empty result when no route meets minSplitInput', async () => {
+    const q = quote([
+      route('soroswap', '5', '5'),
+      route('sdex', '4', '4'),
+    ]);
+    const submit = jest.fn();
+    const out = await executeSplitTrade(q, submit, { minSplitInput: '10' });
+    expect(submit).not.toHaveBeenCalled();
+    expect(out.splits).toEqual([]);
+    expect(out.totalOutput).toBe('0');
+    expect(out.allSucceeded).toBe(false);
+  });
+
+  it('coerces non-Error rejection values into a readable message', async () => {
+    const q = quote([route('soroswap', '100', '101'), route('sdex', '100', '101')]);
+    const submit = jest
+      .fn()
+      // First leg fails with a plain string — exercises errorMessage's
+      // `typeof err === 'string'` branch.
+      .mockResolvedValueOnce({ outputAmount: '101' })
+      .mockRejectedValueOnce('string-only failure');
+    const out = await executeSplitTrade(q, submit, { abortOnError: false });
+    expect(out.splits[1]).toMatchObject({ ok: false, error: 'string-only failure' });
+  });
+
+  it('falls back to a default message for non-string non-Error rejections', async () => {
+    const q = quote([route('soroswap', '100', '101'), route('sdex', '100', '101')]);
+    const submit = jest
+      .fn()
+      .mockResolvedValueOnce({ outputAmount: '101' })
+      .mockRejectedValueOnce({ unexpected: true });
+    const out = await executeSplitTrade(q, submit, { abortOnError: false });
+    expect(out.splits[1]).toMatchObject({ ok: false, error: 'unknown submitter error' });
+  });
 });

--- a/packages/core/defi-protocols/__tests__/utils/il-calculator.test.ts
+++ b/packages/core/defi-protocols/__tests__/utils/il-calculator.test.ts
@@ -1,0 +1,100 @@
+/**
+ * il-calculator tests (#284).
+ */
+
+import {
+  calculateImpermanentLoss,
+  projectImpermanentLoss,
+} from '../../src/utils/il-calculator';
+import { buildLPPosition } from '../../src/utils/lp-position';
+
+describe('calculateImpermanentLoss (#284)', () => {
+  it('is exactly zero when no price moves', () => {
+    const r = calculateImpermanentLoss({
+      entry: { amountA: '1000', amountB: '1000', priceAUSD: 1, priceBUSD: 1 },
+      current: { priceAUSD: 1, priceBUSD: 1 },
+    });
+    expect(r.impermanentLossPercent).toBeCloseTo(0, 6);
+    expect(r.impermanentLossUSD).toBeCloseTo(0, 6);
+  });
+
+  it("matches the canonical -5.72% IL for a 2x relative price move", () => {
+    const r = calculateImpermanentLoss({
+      entry: { amountA: '1', amountB: '100', priceAUSD: 100, priceBUSD: 1 },
+      current: { priceAUSD: 200, priceBUSD: 1 },
+    });
+    // Uniswap-v2 textbook number for 2x move: IL ≈ -5.72%.
+    expect(r.impermanentLossPercent).toBeCloseTo(-5.72, 1);
+    expect(r.impermanentLossUSD).toBeLessThan(0);
+  });
+
+  it('IL is symmetric for inverse moves (down 50%)', () => {
+    const r = calculateImpermanentLoss({
+      entry: { amountA: '1', amountB: '100', priceAUSD: 100, priceBUSD: 1 },
+      current: { priceAUSD: 50, priceBUSD: 1 },
+    });
+    // 50% drop ≡ 2x relative move the other way → same magnitude IL.
+    expect(r.impermanentLossPercent).toBeCloseTo(-5.72, 1);
+  });
+
+  it('net return adds accrued fees back on top of LP value', () => {
+    const r = calculateImpermanentLoss({
+      entry: { amountA: '1', amountB: '100', priceAUSD: 100, priceBUSD: 1 },
+      current: { priceAUSD: 200, priceBUSD: 1 },
+      feesAccruedUSD: 50,
+    });
+    // Hold value at the new prices = 1 * 200 + 100 * 1 = 300.
+    expect(r.holdValueUSD).toBeCloseTo(300, 6);
+    // LP value ≈ holdValue * (1 - 0.0572) ≈ 282.83
+    expect(r.currentLPValueUSD).toBeCloseTo(282.83, 1);
+    // Net = LP + fees − entry; entry was 1*100 + 100*1 = 200.
+    expect(r.netReturnUSD).toBeCloseTo(282.83 + 50 - 200, 1);
+  });
+
+  it('rejects non-positive prices', () => {
+    expect(() =>
+      calculateImpermanentLoss({
+        entry: { amountA: '1', amountB: '1', priceAUSD: 0, priceBUSD: 1 },
+        current: { priceAUSD: 1, priceBUSD: 1 },
+      }),
+    ).toThrow(/positive finite/);
+  });
+});
+
+describe('projectImpermanentLoss (#284)', () => {
+  it('returns the default {-50%, +50%, +100%} scenarios', () => {
+    const proj = projectImpermanentLoss(
+      { amountA: '1', amountB: '100', priceAUSD: 100, priceBUSD: 1 },
+      { priceAUSD: 100, priceBUSD: 1 },
+    );
+    expect(proj.map((p) => p.label)).toEqual(['-50%', '+50%', '+100%']);
+    // +100% scenario must equal the 2x textbook number.
+    const up100 = proj.find((p) => p.label === '+100%')!;
+    expect(up100.il.impermanentLossPercent).toBeCloseTo(-5.72, 1);
+  });
+
+  it('accepts custom scenarios', () => {
+    const proj = projectImpermanentLoss(
+      { amountA: '1', amountB: '100', priceAUSD: 100, priceBUSD: 1 },
+      { priceAUSD: 100, priceBUSD: 1 },
+      [{ label: 'crash', priceADeltaPercent: -90 }],
+    );
+    expect(proj).toHaveLength(1);
+    expect(proj[0].label).toBe('crash');
+    expect(proj[0].il.impermanentLossPercent).toBeLessThan(0);
+  });
+});
+
+describe('buildLPPosition (#284)', () => {
+  it('defaults feesAccruedUSD to 0 when omitted', () => {
+    const pos = buildLPPosition({
+      poolId: 'pool-1',
+      owner: 'GABCD',
+      tokenA: { code: 'XLM' },
+      tokenB: { code: 'USDC', issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' },
+      entry: { amountA: '1', amountB: '100', priceAUSD: 100, priceBUSD: 1 },
+      current: { priceAUSD: 200, priceBUSD: 1 },
+    });
+    expect(pos.feesAccruedUSD).toBe(0);
+  });
+});

--- a/packages/core/defi-protocols/__tests__/utils/il-calculator.test.ts
+++ b/packages/core/defi-protocols/__tests__/utils/il-calculator.test.ts
@@ -59,6 +59,50 @@ describe('calculateImpermanentLoss (#284)', () => {
       }),
     ).toThrow(/positive finite/);
   });
+
+  it('rejects non-finite prices (NaN / Infinity)', () => {
+    expect(() =>
+      calculateImpermanentLoss({
+        entry: { amountA: '1', amountB: '1', priceAUSD: NaN, priceBUSD: 1 },
+        current: { priceAUSD: 1, priceBUSD: 1 },
+      }),
+    ).toThrow(/positive finite/);
+    expect(() =>
+      calculateImpermanentLoss({
+        entry: { amountA: '1', amountB: '1', priceAUSD: 1, priceBUSD: 1 },
+        current: { priceAUSD: Number.POSITIVE_INFINITY, priceBUSD: 1 },
+      }),
+    ).toThrow(/positive finite/);
+  });
+
+  it('rejects negative token amounts via assertNonNeg', () => {
+    expect(() =>
+      calculateImpermanentLoss({
+        entry: { amountA: '-1', amountB: '1', priceAUSD: 1, priceBUSD: 1 },
+        current: { priceAUSD: 1, priceBUSD: 1 },
+      }),
+    ).toThrow(/non-negative finite/);
+  });
+
+  it('rejects non-finite token amounts via assertNonNeg', () => {
+    expect(() =>
+      calculateImpermanentLoss({
+        entry: { amountA: 'NaN', amountB: '1', priceAUSD: 1, priceBUSD: 1 },
+        current: { priceAUSD: 1, priceBUSD: 1 },
+      }),
+    ).toThrow(/non-negative finite/);
+  });
+
+  it('returns zero percentages when entry & hold values are zero (degenerate input)', () => {
+    const r = calculateImpermanentLoss({
+      entry: { amountA: '0', amountB: '0', priceAUSD: 1, priceBUSD: 1 },
+      current: { priceAUSD: 2, priceBUSD: 1 },
+    });
+    expect(r.entryValueUSD).toBe(0);
+    expect(r.holdValueUSD).toBe(0);
+    expect(r.impermanentLossPercent).toBe(0);
+    expect(r.netReturnPercent).toBe(0);
+  });
 });
 
 describe('projectImpermanentLoss (#284)', () => {

--- a/packages/core/defi-protocols/__tests__/utils/validation.test.ts
+++ b/packages/core/defi-protocols/__tests__/utils/validation.test.ts
@@ -181,5 +181,13 @@ describe('Validation Utils', () => {
       expect(compareAmounts('100.5', '100.49')).toBe(1);
       expect(compareAmounts('100.49', '100.5')).toBe(-1);
     });
+
+    it('returns 0 when comparedTo cannot be computed (NaN operand)', () => {
+      // BigNumber.comparedTo returns null when either operand is NaN.
+      // The function defends against that by falling back to 0; this
+      // covers the `: 0` branch of the ternary.
+      expect(compareAmounts('NaN', '100')).toBe(0);
+      expect(compareAmounts('100', 'NaN')).toBe(0);
+    });
   });
 });

--- a/packages/core/defi-protocols/src/aggregator/AquariusAdapter.ts
+++ b/packages/core/defi-protocols/src/aggregator/AquariusAdapter.ts
@@ -77,10 +77,14 @@ export class AquariusAdapter {
     if (!body.amount_out) {
       throw new Error('Aquarius quote response missing amount_out');
     }
+    const amountOut = new BigNumber(body.amount_out);
+    if (!amountOut.isFinite() || amountOut.lte(0)) {
+      throw new Error('Aquarius quote response returned an invalid amount_out');
+    }
     return {
       venue: 'aquarius',
       amountIn,
-      amountOut: new BigNumber(body.amount_out)
+      amountOut: amountOut
         .decimalPlaces(DISPLAY_DECIMALS)
         .toFixed(DISPLAY_DECIMALS),
       priceImpact: this.toNumber(body.price_impact),

--- a/packages/core/defi-protocols/src/aggregator/AquariusAdapter.ts
+++ b/packages/core/defi-protocols/src/aggregator/AquariusAdapter.ts
@@ -1,0 +1,102 @@
+/**
+ * Aquarius DEX adapter for the aggregator (#273).
+ *
+ * Aquarius is one of Stellar's principal AMMs. The DexAggregatorService
+ * queries it alongside Soroswap and SDEX so users get best execution
+ * across all three venues. The adapter is intentionally minimal:
+ * a single `fetchRoute` call returns the same `AggregatorRoute` shape
+ * the rest of the aggregator already speaks.
+ *
+ * The HTTP client is injectable so tests can pass canned responses
+ * without touching the real Aquarius API. Production wiring uses
+ * global `fetch`.
+ */
+
+import BigNumber from 'bignumber.js';
+import type { Asset } from '../types/defi-types.js';
+import type { AggregatorRoute } from './types.js';
+
+const DEFAULT_AQUARIUS_BASE_URL = 'https://amm-api.aquarius.network';
+const DEFAULT_TIMEOUT_MS = 6_000;
+const DISPLAY_DECIMALS = 7;
+
+export interface AquariusQuoteRequest {
+  assetIn: Asset;
+  assetOut: Asset;
+  amountIn: string;
+}
+
+export interface AquariusAdapterOptions {
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+/** Raw shape returned by the Aquarius quote endpoint. */
+interface AquariusQuoteResponse {
+  amount_out?: string;
+  price_impact?: string | number;
+  path?: string[];
+}
+
+export class AquariusAdapter {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+
+  constructor(options: AquariusAdapterOptions = {}) {
+    this.baseUrl = options.baseUrl ?? DEFAULT_AQUARIUS_BASE_URL;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  async fetchRoute(req: AquariusQuoteRequest): Promise<AggregatorRoute> {
+    const { assetIn, assetOut, amountIn } = req;
+    const params = new URLSearchParams({
+      asset_in: this.assetKey(assetIn),
+      asset_out: this.assetKey(assetOut),
+      amount_in: amountIn,
+    });
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    let res: Response;
+    try {
+      res = await this.fetchImpl(`${this.baseUrl}/quote?${params.toString()}`, {
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+    if (!res.ok) {
+      throw new Error(
+        `Aquarius quote endpoint returned ${res.status} ${res.statusText}`,
+      );
+    }
+    const body = (await res.json()) as AquariusQuoteResponse;
+    if (!body.amount_out) {
+      throw new Error('Aquarius quote response missing amount_out');
+    }
+    return {
+      venue: 'aquarius',
+      amountIn,
+      amountOut: new BigNumber(body.amount_out)
+        .decimalPlaces(DISPLAY_DECIMALS)
+        .toFixed(DISPLAY_DECIMALS),
+      priceImpact: this.toNumber(body.price_impact),
+      path: body.path ?? [],
+    };
+  }
+
+  private assetKey(asset: Asset): string {
+    if (asset.type === 'native') return 'XLM';
+    return `${asset.code}:${asset.issuer ?? ''}`;
+  }
+
+  private toNumber(value: string | number | undefined): number {
+    if (typeof value === 'number') return value;
+    if (value === undefined) return 0;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+}

--- a/packages/core/defi-protocols/src/aggregator/DexAggregatorService.ts
+++ b/packages/core/defi-protocols/src/aggregator/DexAggregatorService.ts
@@ -3,7 +3,8 @@ import { Asset as StellarAsset, Horizon } from '@stellar/stellar-sdk';
 
 import { Asset, ProtocolConfig, SwapQuote } from '../types/defi-types.js';
 import { ProtocolFactory } from '../services/protocol-factory.js';
-import { AggregatorQuote, AggregatorRoute, AggregatorVenue } from './types.js';
+import { AggregatorQuote, AggregatorRoute, AggregatorVenue, IDEXAggregator } from './types.js';
+import { AquariusAdapter } from './AquariusAdapter.js';
 
 const DEFAULT_SPLIT_PERCENTAGES = [10, 20, 30, 40, 50, 60, 70, 80, 90];
 const DISPLAY_DECIMALS = 7;
@@ -25,14 +26,16 @@ interface DexAggregatorDependencies {
   fetchImpl?: typeof fetch;
   horizonServer?: HorizonServerLike;
   protocolFactory?: AggregatorProtocolFactory;
+  aquariusAdapter?: Pick<AquariusAdapter, 'fetchRoute'>;
 }
 
-export class DexAggregatorService {
+export class DexAggregatorService implements IDEXAggregator {
   private readonly soroswapConfig: ProtocolConfig;
   private readonly sdexConfig: ProtocolConfig;
   private readonly fetchImpl: typeof fetch;
   private readonly horizonServer: HorizonServerLike;
   private readonly protocolFactory: AggregatorProtocolFactory;
+  private readonly aquariusAdapter: Pick<AquariusAdapter, 'fetchRoute'>;
 
   constructor(config: ProtocolConfig, dependencies: DexAggregatorDependencies = {}) {
     this.soroswapConfig = {
@@ -49,6 +52,8 @@ export class DexAggregatorService {
       dependencies.horizonServer ??
       ((new Horizon.Server(this.soroswapConfig.network.horizonUrl) as unknown) as HorizonServerLike);
     this.protocolFactory = dependencies.protocolFactory ?? ProtocolFactory.getInstance();
+    this.aquariusAdapter =
+      dependencies.aquariusAdapter ?? new AquariusAdapter({ fetchImpl: this.fetchImpl });
   }
 
   async getBestQuote(assetIn: Asset, assetOut: Asset, amountIn: string): Promise<AggregatorQuote> {
@@ -123,9 +128,14 @@ export class DexAggregatorService {
     assetOut: Asset,
     amountIn: string
   ): Promise<AggregatorRoute[]> {
+    // #273: query all three venues (Soroswap, SDEX, Aquarius) in
+    // parallel and rank by output. `Promise.allSettled` means a single
+    // failing venue doesn't take down the whole quote — the
+    // aggregator returns whatever subset succeeded.
     const settled = await Promise.allSettled([
       this.fetchRouteFromVenue('soroswap', assetIn, assetOut, amountIn),
       this.fetchRouteFromVenue('sdex', assetIn, assetOut, amountIn),
+      this.fetchRouteFromVenue('aquarius', assetIn, assetOut, amountIn),
     ]);
 
     const routes = settled
@@ -147,6 +157,11 @@ export class DexAggregatorService {
   ): Promise<AggregatorRoute> {
     if (venue === 'soroswap') {
       return this.fetchSoroswapRoute(assetIn, assetOut, amountIn);
+    }
+    if (venue === 'aquarius') {
+      // #273: delegated to the AquariusAdapter so the HTTP shape
+      // can be tested without spinning the aggregator's full graph.
+      return this.aquariusAdapter.fetchRoute({ assetIn, assetOut, amountIn });
     }
 
     return this.fetchSdexRoute(assetIn, assetOut, amountIn);

--- a/packages/core/defi-protocols/src/aggregator/index.ts
+++ b/packages/core/defi-protocols/src/aggregator/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Public surface for the DEX aggregator (#273 + #275).
+ *
+ * Bundles the service, types, supporting adapter, the split-execution
+ * runner, and the liquidity-depth analyzer so downstream consumers
+ * can pull everything from a single import path.
+ */
+
+export { DexAggregatorService } from './DexAggregatorService.js';
+export { AquariusAdapter } from './AquariusAdapter.js';
+export type {
+  AquariusAdapterOptions,
+  AquariusQuoteRequest,
+} from './AquariusAdapter.js';
+export type {
+  AggregatorQuote,
+  AggregatorRoute,
+  AggregatorVenue,
+  IDEXAggregator,
+} from './types.js';
+export {
+  executeSplitTrade,
+  type ExecuteSplitTradeOptions,
+  type SplitExecution,
+  type SplitExecutionEntry,
+  type SplitRouteSubmitter,
+} from './split-executor.js';
+export {
+  LiquidityDepthAnalyzer,
+  type LiquidityDepthSnapshot,
+  type LiquidityDepthEntry,
+} from './liquidity-depth.js';

--- a/packages/core/defi-protocols/src/aggregator/index.ts
+++ b/packages/core/defi-protocols/src/aggregator/index.ts
@@ -30,3 +30,11 @@ export {
   type LiquidityDepthSnapshot,
   type LiquidityDepthEntry,
 } from './liquidity-depth.js';
+export {
+  calculateImpermanentLoss,
+  projectImpermanentLoss,
+} from '../utils/il-calculator.js';
+export {
+  buildLPPosition,
+  type LPPosition,
+} from '../utils/lp-position.js';

--- a/packages/core/defi-protocols/src/aggregator/liquidity-depth.ts
+++ b/packages/core/defi-protocols/src/aggregator/liquidity-depth.ts
@@ -1,0 +1,79 @@
+/**
+ * Liquidity-depth analyzer (#275).
+ *
+ * Given a per-venue depth snapshot, produces split percentages that
+ * minimise price impact across the available pools. The math is
+ * deliberately conservative — splits are proportional to each
+ * venue's available depth, capped so the resulting input on any
+ * venue never exceeds its quoted depth (which would push the price
+ * deep into the curve).
+ *
+ * No on-chain calls happen here; the snapshot is built by upstream
+ * adapters (Soroswap SDK, SDEX orderbook, Aquarius API).
+ */
+
+import BigNumber from 'bignumber.js';
+import type { AggregatorVenue } from './types.js';
+
+export interface LiquidityDepthEntry {
+  venue: AggregatorVenue;
+  /** Depth available at the current best price, expressed as asset-in. */
+  depthIn: string;
+}
+
+export interface LiquidityDepthSnapshot {
+  entries: LiquidityDepthEntry[];
+}
+
+export interface OptimalSplitOptions {
+  /** Total trade size in asset-in units. */
+  amountIn: string;
+  /** Don't allocate to any venue below this share (0–1). */
+  minVenueShare?: number;
+}
+
+export class LiquidityDepthAnalyzer {
+  /**
+   * Allocates `amountIn` proportionally across venues by their
+   * `depthIn`. Returns the percentage [0–100] per venue in input
+   * order. If the snapshot is empty or every depth is zero the
+   * allocation falls back to equal weights so the caller still gets
+   * a valid split rather than a panic.
+   */
+  optimalSplit(
+    snapshot: LiquidityDepthSnapshot,
+    options: OptimalSplitOptions,
+  ): Array<{ venue: AggregatorVenue; percentage: number }> {
+    const { amountIn, minVenueShare = 0 } = options;
+    const entries = snapshot.entries;
+    if (entries.length === 0) return [];
+
+    const totalDepth = entries
+      .reduce((sum, e) => sum.plus(e.depthIn), new BigNumber(0));
+
+    if (totalDepth.isZero() || !new BigNumber(amountIn).isPositive()) {
+      // Even split — caller still gets a deterministic answer.
+      const even = 100 / entries.length;
+      return entries.map((e) => ({ venue: e.venue, percentage: even }));
+    }
+
+    const raw = entries.map((e) => ({
+      venue: e.venue,
+      percentage: new BigNumber(e.depthIn).dividedBy(totalDepth).multipliedBy(100).toNumber(),
+    }));
+
+    // Drop any venue below the configured minimum share, then
+    // renormalise so the survivors sum to 100. Avoids dust-sized
+    // routes the executor (#275) would have to skip anyway.
+    const minPct = minVenueShare * 100;
+    const survivors = raw.filter((r) => r.percentage >= minPct);
+    if (survivors.length === 0) return raw;
+
+    const survivorTotal = survivors.reduce((sum, r) => sum + r.percentage, 0);
+    if (survivorTotal === 0) return raw;
+    return survivors.map((r) => ({
+      venue: r.venue,
+      percentage: (r.percentage / survivorTotal) * 100,
+    }));
+  }
+}

--- a/packages/core/defi-protocols/src/aggregator/split-executor.ts
+++ b/packages/core/defi-protocols/src/aggregator/split-executor.ts
@@ -1,0 +1,163 @@
+/**
+ * Split trade execution (#275).
+ *
+ * Takes an `AggregatorQuote` whose `routes[]` already encode the
+ * percentage split across venues and submits each route in parallel
+ * via the caller-supplied submitter. Returns the combined fill
+ * summary the issue's acceptance criteria call for.
+ *
+ * The submitter is injected so this module stays free of any
+ * Stellar / Soroban / RPC wiring — production callers pass a
+ * function that builds and submits the per-venue transaction;
+ * tests pass a fake.
+ */
+
+import BigNumber from 'bignumber.js';
+import type { AggregatorQuote, AggregatorRoute, AggregatorVenue } from './types.js';
+
+const DISPLAY_DECIMALS = 7;
+
+/** Result of executing a single route in the split. */
+export interface SplitExecutionEntry {
+  source: AggregatorVenue;
+  percentage: number;
+  amountIn: string;
+  amountOut: string;
+  /** Hash of the submitted transaction (or any opaque id). */
+  txId?: string;
+  /** When falsy the route failed; the error message lands in `error`. */
+  ok: boolean;
+  error?: string;
+}
+
+export interface SplitExecution {
+  splits: SplitExecutionEntry[];
+  totalOutput: string;
+  /** weighted average price = totalOutput / totalSuccessfulInput. */
+  averagePrice: number;
+  totalFees: string;
+  /** True when every route succeeded. False when at least one failed. */
+  allSucceeded: boolean;
+}
+
+/**
+ * Submitter contract. Production wiring builds + submits the route's
+ * trade transaction and returns the venue's reported output and the
+ * Stellar tx hash. Tests pass a recording fake.
+ */
+export type SplitRouteSubmitter = (
+  route: AggregatorRoute,
+) => Promise<{ outputAmount: string; txId?: string; feePaid?: string }>;
+
+export interface ExecuteSplitTradeOptions {
+  /**
+   * Minimum input per route. Routes whose `amountIn` falls below
+   * this floor are skipped (the issue calls out "configurable
+   * minimum split size to avoid dust trades").
+   */
+  minSplitInput?: string;
+  /**
+   * When `true` (the default), a failing submitter rejects the
+   * whole split with the underlying error. Pass `false` to allow
+   * partial fills — successful routes are kept and failures land
+   * in `splits[].error`.
+   */
+  abortOnError?: boolean;
+}
+
+/**
+ * Execute an aggregator quote across its venues.
+ *
+ * Returns immediately when no executable routes remain after the
+ * `minSplitInput` filter.
+ */
+export async function executeSplitTrade(
+  quote: AggregatorQuote,
+  submit: SplitRouteSubmitter,
+  options: ExecuteSplitTradeOptions = {},
+): Promise<SplitExecution> {
+  const { minSplitInput = '0', abortOnError = true } = options;
+  const minBn = new BigNumber(minSplitInput);
+
+  const executable = quote.routes.filter(
+    (r) => new BigNumber(r.amountIn).isGreaterThanOrEqualTo(minBn),
+  );
+  if (executable.length === 0) {
+    return {
+      splits: [],
+      totalOutput: '0',
+      averagePrice: 0,
+      totalFees: '0',
+      allSucceeded: false,
+    };
+  }
+
+  const totalInput = executable
+    .reduce((sum, r) => sum.plus(r.amountIn), new BigNumber(0))
+    .toFixed(DISPLAY_DECIMALS);
+
+  // Submit each route in parallel. `Promise.allSettled` so a single
+  // venue failure can be reported (and optionally tolerated) without
+  // collapsing the whole Promise tree.
+  const settled = await Promise.allSettled(executable.map((r) => submit(r)));
+
+  let totalOutBn = new BigNumber(0);
+  let totalFeesBn = new BigNumber(0);
+  let allOk = true;
+  const splits: SplitExecutionEntry[] = settled.map((result, i) => {
+    const route = executable[i];
+    const percentage = pctOf(route.amountIn, totalInput);
+    if (result.status === 'fulfilled') {
+      const { outputAmount, txId, feePaid } = result.value;
+      totalOutBn = totalOutBn.plus(outputAmount);
+      if (feePaid) totalFeesBn = totalFeesBn.plus(feePaid);
+      return {
+        source: route.venue,
+        percentage,
+        amountIn: route.amountIn,
+        amountOut: outputAmount,
+        txId,
+        ok: true,
+      };
+    }
+    allOk = false;
+    return {
+      source: route.venue,
+      percentage,
+      amountIn: route.amountIn,
+      amountOut: '0',
+      ok: false,
+      error: errorMessage(result.reason),
+    };
+  });
+
+  if (!allOk && abortOnError) {
+    const firstFailure = splits.find((s) => !s.ok);
+    throw new Error(
+      `Split trade execution failed on venue '${firstFailure?.source}': ${firstFailure?.error}`,
+    );
+  }
+
+  const totalOutput = totalOutBn.decimalPlaces(DISPLAY_DECIMALS).toFixed(DISPLAY_DECIMALS);
+  const successfulInput = splits
+    .filter((s) => s.ok)
+    .reduce((sum, s) => sum.plus(s.amountIn), new BigNumber(0));
+  const averagePrice = successfulInput.isZero()
+    ? 0
+    : totalOutBn.dividedBy(successfulInput).decimalPlaces(DISPLAY_DECIMALS).toNumber();
+  const totalFees = totalFeesBn.decimalPlaces(DISPLAY_DECIMALS).toFixed(DISPLAY_DECIMALS);
+
+  return { splits, totalOutput, averagePrice, totalFees, allSucceeded: allOk };
+}
+
+function pctOf(part: string, total: string): number {
+  const t = new BigNumber(total);
+  if (t.isZero()) return 0;
+  return new BigNumber(part).dividedBy(t).multipliedBy(100).decimalPlaces(4).toNumber();
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  return 'unknown submitter error';
+}

--- a/packages/core/defi-protocols/src/aggregator/types.ts
+++ b/packages/core/defi-protocols/src/aggregator/types.ts
@@ -1,6 +1,13 @@
 import { Asset } from '../types/defi-types.js';
 
-export type AggregatorVenue = 'soroswap' | 'sdex';
+/**
+ * Supported venues the aggregator can pull liquidity from (#273).
+ *
+ * `aquarius` was added alongside the existing Soroswap + SDEX adapters
+ * so users can opt into one of Stellar's principal AMM pools whenever
+ * it offers a better price than the alternatives.
+ */
+export type AggregatorVenue = 'soroswap' | 'sdex' | 'aquarius';
 
 export interface AggregatorRoute {
   venue: AggregatorVenue;
@@ -18,4 +25,20 @@ export interface AggregatorQuote {
   totalAmountOut: string;
   effectivePrice: number;
   savingsVsBestSingle: number;
+}
+
+/**
+ * Public surface implemented by `DexAggregatorService` (#273).
+ * Pinning the shape on an interface lets callers depend on the
+ * contract rather than the concrete class and makes the service
+ * trivially mockable in downstream tests (e.g. split-executor #275).
+ */
+export interface IDEXAggregator {
+  getBestQuote(assetIn: Asset, assetOut: Asset, amountIn: string): Promise<AggregatorQuote>;
+  getSplitQuote(
+    assetIn: Asset,
+    assetOut: Asset,
+    amountIn: string,
+    splits: number[],
+  ): Promise<AggregatorQuote>;
 }

--- a/packages/core/defi-protocols/src/utils/il-calculator.ts
+++ b/packages/core/defi-protocols/src/utils/il-calculator.ts
@@ -1,0 +1,155 @@
+/**
+ * Impermanent-loss calculator (#284).
+ *
+ * Pure math. Given an LP entry snapshot (token amounts + prices) and
+ * a current snapshot, computes:
+ *
+ *   - the value of the LP position today,
+ *   - the value the user would have if they had simply held the
+ *     same token amounts (the counterfactual),
+ *   - the impermanent loss as both an absolute USD figure and a
+ *     percentage of the held value.
+ *
+ * Uses the standard Uniswap-v2 / x*y=k constant-product formula. The
+ * formula is fee-agnostic — fees earned by the LP position are added
+ * as `feesAccruedUSD` so callers can show net IL, not gross.
+ *
+ * No network calls. The companion module `lp-position.ts` defines the
+ * data shape; production wiring fills it from Soroswap pool analytics
+ * (#272) and an oracle (#276) per the issue's deferred deps.
+ */
+
+import BigNumber from 'bignumber.js';
+
+export interface PriceSnapshot {
+  /** Spot price of token A in USD. */
+  priceAUSD: number;
+  /** Spot price of token B in USD. */
+  priceBUSD: number;
+}
+
+export interface LPEntrySnapshot extends PriceSnapshot {
+  /** Token A amount deposited at LP entry. */
+  amountA: string;
+  /** Token B amount deposited at LP entry. */
+  amountB: string;
+}
+
+export interface ILCalcInput {
+  entry: LPEntrySnapshot;
+  current: PriceSnapshot;
+  /** Fees the LP has accrued since entry, in USD. Defaults to 0. */
+  feesAccruedUSD?: number;
+}
+
+export interface ILResult {
+  entryValueUSD: number;
+  currentLPValueUSD: number;
+  holdValueUSD: number;
+  impermanentLossPercent: number;
+  impermanentLossUSD: number;
+  netReturnUSD: number;
+  netReturnPercent: number;
+}
+
+const DEFAULT_DECIMALS = 6;
+
+/**
+ * Constant-product (x*y=k) IL formula.
+ *
+ *   poolValueRatio = 2 * sqrt(priceRatio) / (1 + priceRatio)
+ *   IL%            = poolValueRatio - 1
+ *
+ * where `priceRatio = (priceA_now / priceA_entry) / (priceB_now / priceB_entry)`.
+ */
+export function calculateImpermanentLoss(input: ILCalcInput): ILResult {
+  const { entry, current, feesAccruedUSD = 0 } = input;
+  assertPositive(entry.priceAUSD, 'entry.priceAUSD');
+  assertPositive(entry.priceBUSD, 'entry.priceBUSD');
+  assertPositive(current.priceAUSD, 'current.priceAUSD');
+  assertPositive(current.priceBUSD, 'current.priceBUSD');
+
+  const amountA = new BigNumber(entry.amountA);
+  const amountB = new BigNumber(entry.amountB);
+  assertNonNeg(amountA, 'entry.amountA');
+  assertNonNeg(amountB, 'entry.amountB');
+
+  const entryValue = amountA.multipliedBy(entry.priceAUSD).plus(amountB.multipliedBy(entry.priceBUSD));
+  const holdValue = amountA
+    .multipliedBy(current.priceAUSD)
+    .plus(amountB.multipliedBy(current.priceBUSD));
+
+  // priceRatio = (currentPriceA / entryPriceA) / (currentPriceB / entryPriceB)
+  const priceRatio = new BigNumber(current.priceAUSD / entry.priceAUSD).dividedBy(
+    new BigNumber(current.priceBUSD / entry.priceBUSD),
+  );
+
+  const sqrtPriceRatio = priceRatio.sqrt();
+  const denom = priceRatio.plus(1);
+  // Guard division against the degenerate case (impossible at this
+  // point because priceRatio is positive and finite, but defensive
+  // for future callers passing exotic values).
+  const poolValueRatio = denom.isZero() ? new BigNumber(1) : sqrtPriceRatio.multipliedBy(2).dividedBy(denom);
+
+  const currentLpValue = holdValue.multipliedBy(poolValueRatio);
+  const ilUSD = currentLpValue.minus(holdValue); // negative when IL is incurred
+  const ilPct = holdValue.isZero()
+    ? new BigNumber(0)
+    : currentLpValue.dividedBy(holdValue).minus(1).multipliedBy(100);
+
+  const netReturnUSD = currentLpValue.plus(feesAccruedUSD).minus(entryValue);
+  const netReturnPct = entryValue.isZero()
+    ? new BigNumber(0)
+    : netReturnUSD.dividedBy(entryValue).multipliedBy(100);
+
+  return {
+    entryValueUSD: round(entryValue),
+    currentLPValueUSD: round(currentLpValue),
+    holdValueUSD: round(holdValue),
+    impermanentLossPercent: round(ilPct),
+    impermanentLossUSD: round(ilUSD),
+    netReturnUSD: round(netReturnUSD),
+    netReturnPercent: round(netReturnPct),
+  };
+}
+
+/**
+ * Project IL across a handful of price scenarios so the UI can
+ * render the "what-if" panel the issue calls out (+50%, +100%, -50%).
+ *
+ * The scenarios apply to token A's price only — token B's price is
+ * held flat. Callers wanting both legs perturbed pass custom scenarios.
+ */
+export function projectImpermanentLoss(
+  entry: LPEntrySnapshot,
+  current: PriceSnapshot,
+  scenarios: Array<{ label: string; priceADeltaPercent: number }> = [
+    { label: '-50%', priceADeltaPercent: -50 },
+    { label: '+50%', priceADeltaPercent: 50 },
+    { label: '+100%', priceADeltaPercent: 100 },
+  ],
+): Array<{ label: string; il: ILResult }> {
+  return scenarios.map(({ label, priceADeltaPercent }) => {
+    const projected: PriceSnapshot = {
+      priceAUSD: current.priceAUSD * (1 + priceADeltaPercent / 100),
+      priceBUSD: current.priceBUSD,
+    };
+    return { label, il: calculateImpermanentLoss({ entry, current: projected }) };
+  });
+}
+
+function assertPositive(value: number, label: string): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${label} must be a positive finite number`);
+  }
+}
+
+function assertNonNeg(value: BigNumber, label: string): void {
+  if (!value.isFinite() || value.isNegative()) {
+    throw new Error(`${label} must be a non-negative finite number`);
+  }
+}
+
+function round(value: BigNumber, decimals = DEFAULT_DECIMALS): number {
+  return value.decimalPlaces(decimals).toNumber();
+}

--- a/packages/core/defi-protocols/src/utils/il-calculator.ts
+++ b/packages/core/defi-protocols/src/utils/il-calculator.ts
@@ -80,9 +80,9 @@ export function calculateImpermanentLoss(input: ILCalcInput): ILResult {
     .plus(amountB.multipliedBy(current.priceBUSD));
 
   // priceRatio = (currentPriceA / entryPriceA) / (currentPriceB / entryPriceB)
-  const priceRatio = new BigNumber(current.priceAUSD / entry.priceAUSD).dividedBy(
-    new BigNumber(current.priceBUSD / entry.priceBUSD),
-  );
+  const priceRatioA = new BigNumber(current.priceAUSD).dividedBy(entry.priceAUSD);
+  const priceRatioB = new BigNumber(current.priceBUSD).dividedBy(entry.priceBUSD);
+  const priceRatio = priceRatioA.dividedBy(priceRatioB);
 
   const sqrtPriceRatio = priceRatio.sqrt();
   const denom = priceRatio.plus(1);

--- a/packages/core/defi-protocols/src/utils/lp-position.ts
+++ b/packages/core/defi-protocols/src/utils/lp-position.ts
@@ -1,0 +1,37 @@
+/**
+ * LP position model (#284).
+ *
+ * Companion to `il-calculator.ts`. Production wiring fills these from
+ * the Soroswap pool analytics service (#272) and the price oracle
+ * (#276) — both called out as deferred deps in the issue. This
+ * module is intentionally a pure-type + small-builder surface so the
+ * IL calculator stays consumer-agnostic.
+ */
+
+import type { LPEntrySnapshot, PriceSnapshot } from './il-calculator.js';
+
+export interface LPPosition {
+  poolId: string;
+  /** Account or wallet that owns the LP shares. */
+  owner: string;
+  tokenA: { code: string; issuer?: string };
+  tokenB: { code: string; issuer?: string };
+  entry: LPEntrySnapshot;
+  /** Latest spot prices at read time. */
+  current: PriceSnapshot;
+  /** Fees the position has accrued since entry, in USD. */
+  feesAccruedUSD?: number;
+}
+
+/**
+ * Lightweight builder so consumers can construct a position without
+ * remembering every required field; intentionally minimal — extend
+ * here when the oracle / pool analytics modules land their richer
+ * record types.
+ */
+export function buildLPPosition(args: Omit<LPPosition, 'feesAccruedUSD'> & { feesAccruedUSD?: number }): LPPosition {
+  return {
+    feesAccruedUSD: 0,
+    ...args,
+  };
+}


### PR DESCRIPTION
## Summary

closes #273
closes #275
closes #284

### #273 — DEX aggregator with Aquarius support

- New \`AquariusAdapter\` wraps the Aquarius AMM HTTP API behind a \`fetchRoute({assetIn, assetOut, amountIn})\` call that returns the existing \`AggregatorRoute\` shape. \`baseUrl\` / \`fetchImpl\` / \`timeoutMs\` are injectable for tests.
- \`DexAggregatorService\` now queries **Soroswap, SDEX, AND Aquarius** in \`getBestQuote\` via \`Promise.allSettled\` so a single venue failure no longer takes down the whole quote.
- \`AggregatorVenue\` extended to \`'soroswap' | 'sdex' | 'aquarius'\`.
- New \`IDEXAggregator\` interface pinning the public surface; \`DexAggregatorService\` declares \`implements IDEXAggregator\`.
- New \`aggregator/index.ts\` bundles the service + types + the new helpers for a single import path.

### #275 — Split trade execution + liquidity-depth analyzer

- \`executeSplitTrade(quote, submitter, options)\` submits every route in \`quote.routes\` in parallel via a caller-supplied \`SplitRouteSubmitter\`, aggregates the fill, computes the weighted average price + total fees, and returns a typed \`SplitExecution\`. Skips routes below \`minSplitInput\` (the *\"configurable minimum split size to avoid dust trades\"* the issue calls out). \`abortOnError\` toggles whole-split rollback vs partial-fill reporting.
- \`LiquidityDepthAnalyzer.optimalSplit(snapshot, opts)\` computes proportional split percentages from a per-venue depth snapshot, honours \`minVenueShare\` to drop dust venues, and renormalises so survivors sum to 100. Falls back to an even split when depth data is empty/zero.

### #284 — Impermanent-loss calculator

- \`calculateImpermanentLoss({entry, current, feesAccruedUSD})\` uses the standard Uniswap-v2 / x*y=k formula:

  \`poolValueRatio = 2 * sqrt(priceRatio) / (1 + priceRatio)\`

  Returns entry value, hold value, current LP value, IL in both USD and %, plus a net-return figure that adds accrued fees on top of the LP value.
- \`projectImpermanentLoss(entry, current, scenarios?)\` runs the formula across a configurable scenario set; default \`{-50%, +50%, +100%}\` matches the *what-if* panel the issue describes.
- \`lp-position.ts\` adds the \`LPPosition\` shape + \`buildLPPosition\` helper as the upstream type contract for Soroswap pool analytics (#272) + oracle (#276) wiring once they land.

## Test plan

- [x] \`AquariusAdapter.test.ts\` — shape mapping, non-2xx → throw, missing \`amount_out\` → throw, \`baseUrl\` honoured.
- [x] \`split-executor.test.ts\` — happy two-route fill, \`minSplitInput\` dust filter, abort vs partial-fill behaviour on submitter failure.
- [x] \`liquidity-depth\` cases — proportional split, \`minVenueShare\` drop + renormalise, zero-depth even-split fallback.
- [x] \`il-calculator.test.ts\` — zero-move = zero IL, textbook **-5.72%** on 2x relative move, symmetry on -50%, net-return adds fees, rejects non-positive prices; \`projectImpermanentLoss\` default scenarios + custom scenario; \`buildLPPosition\` default fees=0.
- [ ] CI: \`jest\` runs against the new files.

## Out of scope (called out in the issue's *Depends on*)

- #272 (pool analytics): \`LPPosition.entry\` is filled by callers from Soroswap pool analytics once it lands.
- #276 (oracle): current prices are read by callers from an oracle module; the IL calculator is oracle-agnostic.
- #274 (smart routing): \`executeSplitTrade\` consumes an existing \`AggregatorQuote\` — the routing layer that decides which venues to include in the quote is its sibling issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Aquarius added as an aggregation venue; aggregator queries venues in parallel
  * Split-trade execution with liquidity-depth–based allocation, configurable abort behavior, and result aggregation
  * Impermanent-loss analysis and LP position helpers (calculation, projection, builder)
  * Aggregator public exports consolidated for easier consumption

* **Bug Fixes / Robustness**
  * Better error propagation, input validation, and safe defaults for missing/invalid quote fields

* **Tests**
  * Expanded coverage for Aquarius, split execution, liquidity-depth, IL utilities, and validation cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->