### PR TITLE
Feat/add interactive mode with prompts

### DIFF
--- a/tools/cli/__tests__/interactive/menus.test.ts
+++ b/tools/cli/__tests__/interactive/menus.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Regression tests for the ROOT_MENU structure.
+ *
+ * Past bug (issue #270): ROOT_MENU referenced commands like `account info`,
+ * `payment send` and `defi add-liquidity` that did not exist in the program.
+ * These tests lock the menu against that regression by walking every entry
+ * and asserting it has a usable action (children, command, or promptFlow)
+ * and that every promptFlow id is registered in PROMPT_FLOWS.
+ */
+
+import { ROOT_MENU, MenuEntry } from '../../src/commands/interactive/menus';
+import { PROMPT_FLOWS } from '../../src/commands/interactive/prompts/index';
+
+function walk(entries: MenuEntry[], visit: (e: MenuEntry, path: string[]) => void, path: string[] = []) {
+  for (const e of entries) {
+    const next = [...path, e.label];
+    visit(e, next);
+    if (e.children) walk(e.children, visit, next);
+  }
+}
+
+describe('ROOT_MENU', () => {
+  it('every entry has either children, a command, or a promptFlow', () => {
+    walk(ROOT_MENU, (e, path) => {
+      const hasAction = (e.children?.length ?? 0) > 0 || !!e.command || !!e.promptFlow;
+      if (!hasAction) {
+        throw new Error(`Menu entry has no action: ${path.join(' > ')}`);
+      }
+    });
+  });
+
+  it('every promptFlow id referenced in the menu is registered in PROMPT_FLOWS', () => {
+    const seen: string[] = [];
+    walk(ROOT_MENU, (e) => {
+      if (e.promptFlow) seen.push(e.promptFlow);
+    });
+
+    expect(seen.length).toBeGreaterThan(0);
+
+    for (const id of seen) {
+      expect(PROMPT_FLOWS[id]).toBeDefined();
+    }
+  });
+
+  it('no entry uses a positional param without setting positional: true', () => {
+    // Positional command args (like `wallet info <target>`) must be flagged so
+    // buildCommandArgs emits them as bare values instead of `--target value`.
+    // This test snapshots the convention so future contributors don't break it.
+    walk(ROOT_MENU, (e) => {
+      if (!e.command || !e.params) return;
+      // Heuristic: if the command name implies a known positional, ensure at
+      // least one positional param is declared.
+      const commandWithPositional = e.command === 'wallet info' || e.command === 'oracle price';
+      if (commandWithPositional) {
+        const hasPositional = e.params.some((p) => p.positional);
+        expect(hasPositional).toBe(true);
+      }
+    });
+  });
+});

--- a/tools/cli/__tests__/interactive/prompts/defi-prompts.test.ts
+++ b/tools/cli/__tests__/interactive/prompts/defi-prompts.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for DeFi PromptFlow definitions.
+ *
+ * Verifies:
+ *   - registry contains every expected flow
+ *   - validators behave as advertised (asset codes, amounts, slippage)
+ *   - buildArgs matches the actual Commander subcommand signature
+ *     (positional args first, then flags, and `-y` to avoid double-prompts)
+ *   - destructive flows are flagged for the runner's confirmation gate
+ */
+
+import {
+  DEFI_PROMPTS,
+  blendSupplyFlow,
+  blendBorrowFlow,
+  swapFlow,
+  listPoolsFlow,
+} from '../../../src/commands/interactive/prompts/defi-prompts';
+
+function findStep(flow: typeof swapFlow, name: string) {
+  const step = flow.steps.find((s) => s.name === name);
+  if (!step) throw new Error(`Step ${name} not found in ${flow.id}`);
+  return step;
+}
+
+describe('DEFI_PROMPTS registry', () => {
+  it('exposes all expected flows', () => {
+    expect(DEFI_PROMPTS['defi:blend-supply']).toBe(blendSupplyFlow);
+    expect(DEFI_PROMPTS['defi:blend-borrow']).toBe(blendBorrowFlow);
+    expect(DEFI_PROMPTS['defi:swap']).toBe(swapFlow);
+    expect(DEFI_PROMPTS['defi:pools']).toBe(listPoolsFlow);
+  });
+
+  it('all transaction-emitting flows are marked destructive', () => {
+    expect(blendSupplyFlow.destructive).toBe(true);
+    expect(blendBorrowFlow.destructive).toBe(true);
+    expect(swapFlow.destructive).toBe(true);
+    // pools list is read-only — must not be destructive
+    expect(listPoolsFlow.destructive).toBeFalsy();
+  });
+});
+
+describe('blendSupplyFlow', () => {
+  it('rejects bad asset codes', () => {
+    const asset = findStep(blendSupplyFlow, 'asset');
+    expect(asset.validate?.('TOO LONG NAME WITH SPACES')).toMatch(/1-12 char/);
+    expect(asset.validate?.('USDC')).toBe(true);
+    expect(asset.validate?.('XLM')).toBe(true);
+  });
+
+  it('rejects non-positive amounts', () => {
+    const amount = findStep(blendSupplyFlow, 'amount');
+    expect(amount.validate?.('0')).toBe('Amount must be a positive decimal');
+    expect(amount.validate?.('100.5')).toBe(true);
+  });
+
+  it('emits positional args + --network + -y', () => {
+    const args = blendSupplyFlow.buildArgs({
+      asset: 'USDC',
+      amount: '100',
+      wallet: '',
+      network: 'testnet',
+    });
+    expect(args).toEqual([
+      'defi', 'blend', 'supply', 'USDC', '100', '--network', 'testnet', '-y',
+    ]);
+  });
+
+  it('passes --wallet through when set', () => {
+    const args = blendSupplyFlow.buildArgs({
+      asset: 'USDC',
+      amount: '100',
+      wallet: 'alice',
+      network: 'mainnet',
+    });
+    expect(args).toEqual([
+      'defi', 'blend', 'supply', 'USDC', '100',
+      '--wallet', 'alice', '--network', 'mainnet', '-y',
+    ]);
+  });
+});
+
+describe('blendBorrowFlow', () => {
+  it('emits borrow as subcommand', () => {
+    const args = blendBorrowFlow.buildArgs({
+      asset: 'XLM',
+      amount: '50',
+      wallet: '',
+      network: 'testnet',
+    });
+    expect(args.slice(0, 5)).toEqual(['defi', 'blend', 'borrow', 'XLM', '50']);
+  });
+});
+
+describe('swapFlow', () => {
+  it('validates slippage range', () => {
+    const slippage = findStep(swapFlow, 'slippage');
+    expect(slippage.validate?.('-1')).toBe('Slippage must be a non-negative decimal');
+    expect(slippage.validate?.('150')).toBe('Slippage must be between 0 and 100');
+    expect(slippage.validate?.('0.5')).toBe(true);
+    expect(slippage.validate?.('100')).toBe(true);
+  });
+
+  it('emits --slippage and --network with -y for executing swaps', () => {
+    const args = swapFlow.buildArgs({
+      fromAsset: 'XLM',
+      toAsset: 'USDC',
+      amount: '10',
+      slippage: '1',
+      wallet: '',
+      network: 'testnet',
+      quoteOnly: false,
+    });
+    expect(args).toEqual([
+      'defi', 'swap', 'XLM', 'USDC', '10',
+      '--slippage', '1', '--network', 'testnet', '-y',
+    ]);
+  });
+
+  it('emits --quote-only and drops -y when quoteOnly is true', () => {
+    const args = swapFlow.buildArgs({
+      fromAsset: 'XLM',
+      toAsset: 'USDC',
+      amount: '10',
+      slippage: '1',
+      wallet: '',
+      network: 'testnet',
+      quoteOnly: true,
+    });
+    expect(args).toContain('--quote-only');
+    expect(args).not.toContain('-y');
+  });
+});
+
+describe('listPoolsFlow', () => {
+  it('emits `defi pools list --network …`', () => {
+    expect(listPoolsFlow.buildArgs({ network: 'testnet', json: false })).toEqual([
+      'defi', 'pools', 'list', '--network', 'testnet',
+    ]);
+  });
+
+  it('appends --json when requested', () => {
+    expect(listPoolsFlow.buildArgs({ network: 'mainnet', json: true })).toEqual([
+      'defi', 'pools', 'list', '--network', 'mainnet', '--json',
+    ]);
+  });
+});

--- a/tools/cli/__tests__/interactive/prompts/runner.test.ts
+++ b/tools/cli/__tests__/interactive/prompts/runner.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Tests for the PromptFlow runner.
+ *
+ * The runner is the engine behind every guided prompt flow in the CLI.
+ * It orchestrates: header → steps (with validation + conditional `when`) →
+ * summary → optional confirm gate (destructive only) → executor.
+ */
+
+import {
+  runPromptFlow,
+  PromptFlow,
+} from '../../../src/commands/interactive/prompts/index';
+
+type Answer = Record<string, unknown>;
+
+/**
+ * Build a scripted prompt fn that returns answers in a specific order.
+ * Each call answers exactly one inquirer question. The fn records every
+ * question for assertion.
+ */
+function scriptedPrompt(answers: Answer[]) {
+  const calls: Answer[] = [];
+  let i = 0;
+  const fn = jest.fn(async (questions: any) => {
+    const list = Array.isArray(questions) ? questions : [questions];
+    const result: Answer = {};
+    for (const q of list) {
+      calls.push(q);
+      const next = answers[i++] ?? {};
+      result[q.name] = next[q.name];
+    }
+    return result;
+  });
+  return { fn: fn as unknown as PromptFlow['steps'] extends never[] ? never : any, calls };
+}
+
+const baseFlow: PromptFlow = {
+  id: 'test:basic',
+  title: 'Test Flow',
+  description: 'Just a test',
+  steps: [
+    {
+      name: 'name',
+      message: 'Name?',
+      type: 'input',
+      validate: (v) => (String(v ?? '').trim() ? true : 'Required'),
+    },
+    {
+      name: 'network',
+      message: 'Network?',
+      type: 'list',
+      choices: [
+        { name: 'Testnet', value: 'testnet', default: true },
+        { name: 'Mainnet', value: 'mainnet' },
+      ],
+      default: 'testnet',
+    },
+  ],
+  buildArgs: (a) => ['wallet', 'create', '--name', String(a.name), `--${a.network}`],
+};
+
+describe('runPromptFlow', () => {
+  it('collects answers in order and calls executor with buildArgs output', async () => {
+    const { fn } = scriptedPrompt([{ name: 'alice' }, { network: 'mainnet' }]);
+    const executor = jest.fn(async () => {});
+
+    const result = await runPromptFlow(baseFlow, executor, {
+      prompt: fn,
+      silent: true,
+    });
+
+    expect(result.executed).toBe(true);
+    expect(result.cancelled).toBe(false);
+    expect(result.argv).toEqual(['wallet', 'create', '--name', 'alice', '--mainnet']);
+    expect(executor).toHaveBeenCalledWith(['wallet', 'create', '--name', 'alice', '--mainnet']);
+  });
+
+  it('records each step answer in result.answers', async () => {
+    const { fn } = scriptedPrompt([{ name: 'bob' }, { network: 'testnet' }]);
+    const executor = jest.fn(async () => {});
+
+    const result = await runPromptFlow(baseFlow, executor, {
+      prompt: fn,
+      silent: true,
+    });
+
+    expect(result.answers).toEqual({ name: 'bob', network: 'testnet' });
+  });
+
+  it('skips steps whose `when` returns false', async () => {
+    const flow: PromptFlow = {
+      id: 'test:conditional',
+      title: 'Conditional',
+      description: '',
+      steps: [
+        { name: 'encrypt', message: 'Encrypt?', type: 'confirm', default: false },
+        {
+          name: 'password',
+          message: 'Password?',
+          type: 'password',
+          when: (a) => a.encrypt === true,
+        },
+        { name: 'tail', message: 'Tail?', type: 'input' },
+      ],
+      buildArgs: (a) => ['x', String(a.encrypt), String(a.tail ?? '')],
+    };
+
+    const { fn, calls } = scriptedPrompt([{ encrypt: false }, { tail: 'done' }]);
+    const executor = jest.fn(async () => {});
+
+    const result = await runPromptFlow(flow, executor, { prompt: fn, silent: true });
+
+    expect(result.executed).toBe(true);
+    expect(result.answers).toEqual({ encrypt: false, tail: 'done' });
+    // Password step never reached
+    expect(calls.find((q: any) => q.name === 'password')).toBeUndefined();
+    expect(executor).toHaveBeenCalledWith(['x', 'false', 'done']);
+  });
+
+  it('runs the conditional step when `when` returns true', async () => {
+    const flow: PromptFlow = {
+      id: 'test:conditional2',
+      title: 'Conditional2',
+      description: '',
+      steps: [
+        { name: 'encrypt', message: 'Encrypt?', type: 'confirm', default: true },
+        {
+          name: 'password',
+          message: 'Password?',
+          type: 'password',
+          when: (a) => a.encrypt === true,
+        },
+      ],
+      buildArgs: (a) => ['x', a.encrypt ? '1' : '0', String(a.password ?? '')],
+    };
+
+    const { fn, calls } = scriptedPrompt([{ encrypt: true }, { password: 'secret-123' }]);
+    const executor = jest.fn(async () => {});
+
+    await runPromptFlow(flow, executor, { prompt: fn, silent: true });
+
+    expect(calls.find((q: any) => q.name === 'password')).toBeDefined();
+    expect(executor).toHaveBeenCalledWith(['x', '1', 'secret-123']);
+  });
+
+  describe('confirmation gate for destructive flows', () => {
+    const destructiveFlow: PromptFlow = {
+      ...baseFlow,
+      id: 'test:destructive',
+      destructive: true,
+    };
+
+    it('asks for confirmation before executing destructive flow', async () => {
+      const { fn, calls } = scriptedPrompt([
+        { name: 'alice' },
+        { network: 'mainnet' },
+        { _confirm: true },
+      ]);
+      const executor = jest.fn(async () => {});
+
+      const result = await runPromptFlow(destructiveFlow, executor, {
+        prompt: fn,
+        silent: true,
+      });
+
+      expect(result.executed).toBe(true);
+      const confirmQ = calls.find((q: any) => q.name === '_confirm');
+      expect(confirmQ).toBeDefined();
+      expect((confirmQ as any).type).toBe('confirm');
+    });
+
+    it('aborts when user declines the confirmation', async () => {
+      const { fn } = scriptedPrompt([
+        { name: 'alice' },
+        { network: 'mainnet' },
+        { _confirm: false },
+      ]);
+      const executor = jest.fn(async () => {});
+
+      const result = await runPromptFlow(destructiveFlow, executor, {
+        prompt: fn,
+        silent: true,
+      });
+
+      expect(result.cancelled).toBe(true);
+      expect(result.executed).toBe(false);
+      expect(executor).not.toHaveBeenCalled();
+    });
+
+    it('skips confirmation when `yes: true` is passed', async () => {
+      const { fn, calls } = scriptedPrompt([{ name: 'alice' }, { network: 'mainnet' }]);
+      const executor = jest.fn(async () => {});
+
+      const result = await runPromptFlow(destructiveFlow, executor, {
+        prompt: fn,
+        yes: true,
+        silent: true,
+      });
+
+      expect(result.executed).toBe(true);
+      expect(calls.find((q: any) => q.name === '_confirm')).toBeUndefined();
+      expect(executor).toHaveBeenCalled();
+    });
+
+    it('non-destructive flows skip the confirmation gate by default', async () => {
+      const { fn, calls } = scriptedPrompt([{ name: 'alice' }, { network: 'testnet' }]);
+      const executor = jest.fn(async () => {});
+
+      await runPromptFlow(baseFlow, executor, { prompt: fn, silent: true });
+
+      expect(calls.find((q: any) => q.name === '_confirm')).toBeUndefined();
+      expect(executor).toHaveBeenCalled();
+    });
+  });
+
+  describe('user cancellation (Ctrl+C / inquirer abort)', () => {
+    it('returns cancelled when inquirer throws an abort error during steps', async () => {
+      const abortFn = jest.fn(async () => {
+        throw new Error('User force closed the prompt');
+      });
+      const executor = jest.fn(async () => {});
+
+      const result = await runPromptFlow(baseFlow, abortFn as any, {
+        prompt: abortFn as any,
+        silent: true,
+      });
+
+      expect(result.cancelled).toBe(true);
+      expect(result.executed).toBe(false);
+      expect(executor).not.toHaveBeenCalled();
+    });
+
+    it('re-throws non-abort errors from inquirer', async () => {
+      const boomFn = jest.fn(async () => {
+        throw new Error('Disk full');
+      });
+      const executor = jest.fn(async () => {});
+
+      await expect(
+        runPromptFlow(baseFlow, executor, { prompt: boomFn as any, silent: true }),
+      ).rejects.toThrow('Disk full');
+    });
+  });
+
+  describe('executor errors', () => {
+    it('captures executor errors into result.error without throwing', async () => {
+      const { fn } = scriptedPrompt([{ name: 'alice' }, { network: 'testnet' }]);
+      const executor = jest.fn(async () => {
+        throw new Error('Network down');
+      });
+
+      const result = await runPromptFlow(baseFlow, executor, {
+        prompt: fn,
+        silent: true,
+      });
+
+      expect(result.executed).toBe(false);
+      expect(result.cancelled).toBe(false);
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error?.message).toBe('Network down');
+    });
+  });
+
+  describe('validation', () => {
+    it('validators are attached to inquirer questions so inquirer enforces them', async () => {
+      const { fn, calls } = scriptedPrompt([{ name: 'alice' }, { network: 'testnet' }]);
+      const executor = jest.fn(async () => {});
+
+      await runPromptFlow(baseFlow, executor, { prompt: fn, silent: true });
+
+      const nameQ = calls.find((q: any) => q.name === 'name') as any;
+      expect(typeof nameQ.validate).toBe('function');
+      expect(nameQ.validate('')).toBe('Required');
+      expect(nameQ.validate('alice')).toBe(true);
+    });
+  });
+});

--- a/tools/cli/__tests__/interactive/prompts/wallet-prompts.test.ts
+++ b/tools/cli/__tests__/interactive/prompts/wallet-prompts.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for wallet PromptFlow definitions.
+ *
+ * Verifies:
+ *   - registry contains every expected flow
+ *   - validators reject invalid input and accept good input
+ *   - conditional `when` only triggers password prompts when --encrypt is on
+ *   - buildArgs emits commands matching the actual Commander signature
+ *   - destructive flows (send) are flagged so the runner shows confirm gate
+ */
+
+import {
+  WALLET_PROMPTS,
+  createWalletFlow,
+  importWalletFlow,
+  listWalletsFlow,
+  walletInfoFlow,
+  balanceWalletFlow,
+  fundWalletFlow,
+  sendPaymentFlow,
+} from '../../../src/commands/interactive/prompts/wallet-prompts';
+
+function findStep(flow: typeof createWalletFlow, name: string) {
+  const step = flow.steps.find((s) => s.name === name);
+  if (!step) throw new Error(`Step ${name} not found in ${flow.id}`);
+  return step;
+}
+
+describe('WALLET_PROMPTS registry', () => {
+  it('exposes all expected flows', () => {
+    expect(WALLET_PROMPTS['wallet:create']).toBe(createWalletFlow);
+    expect(WALLET_PROMPTS['wallet:import']).toBe(importWalletFlow);
+    expect(WALLET_PROMPTS['wallet:list']).toBe(listWalletsFlow);
+    expect(WALLET_PROMPTS['wallet:info']).toBe(walletInfoFlow);
+    expect(WALLET_PROMPTS['wallet:balance']).toBe(balanceWalletFlow);
+    expect(WALLET_PROMPTS['wallet:fund']).toBe(fundWalletFlow);
+    expect(WALLET_PROMPTS['wallet:send']).toBe(sendPaymentFlow);
+  });
+
+  it('every flow has a unique id, title, description and buildArgs', () => {
+    const ids = new Set<string>();
+    for (const flow of Object.values(WALLET_PROMPTS)) {
+      expect(flow.id).toBeTruthy();
+      expect(ids.has(flow.id)).toBe(false);
+      ids.add(flow.id);
+      expect(flow.title).toBeTruthy();
+      expect(flow.description).toBeTruthy();
+      expect(typeof flow.buildArgs).toBe('function');
+    }
+  });
+});
+
+describe('createWalletFlow', () => {
+  it('rejects invalid wallet names', () => {
+    const step = findStep(createWalletFlow, 'name');
+    expect(step.validate?.('')).toBe('Wallet name is required');
+    expect(step.validate?.('bad name!')).toBe('Only letters, numbers, dashes and underscores');
+    expect(step.validate?.('good-name_1')).toBe(true);
+  });
+
+  it('rejects passwords shorter than 8 chars', () => {
+    const step = findStep(createWalletFlow, 'password');
+    expect(step.validate?.('short')).toBe('Password must be at least 8 characters');
+    expect(step.validate?.('longenough')).toBe(true);
+  });
+
+  it('only prompts for password when encrypt is true', () => {
+    const step = findStep(createWalletFlow, 'password');
+    expect(step.when?.({ encrypt: true })).toBe(true);
+    expect(step.when?.({ encrypt: false })).toBe(false);
+  });
+
+  it('buildArgs emits --encrypt + --password when encrypting on testnet', () => {
+    const args = createWalletFlow.buildArgs({
+      name: 'dev',
+      network: 'testnet',
+      encrypt: true,
+      password: 'supersecret',
+    });
+    expect(args).toEqual([
+      'wallet', 'create', '--name', 'dev', '--testnet', '--encrypt', '--password', 'supersecret',
+    ]);
+  });
+
+  it('buildArgs emits --mainnet and omits --encrypt when disabled', () => {
+    const args = createWalletFlow.buildArgs({
+      name: 'prod',
+      network: 'mainnet',
+      encrypt: false,
+    });
+    expect(args).toEqual(['wallet', 'create', '--name', 'prod', '--mainnet']);
+  });
+});
+
+describe('importWalletFlow', () => {
+  it('passes the secret key as the first positional argument', () => {
+    const args = importWalletFlow.buildArgs({
+      name: 'imported',
+      secretKey: 'SABCDEF',
+      network: 'testnet',
+      encrypt: false,
+    });
+    expect(args[0]).toBe('wallet');
+    expect(args[1]).toBe('import');
+    expect(args[2]).toBe('SABCDEF');
+    expect(args).toContain('--name');
+    expect(args).toContain('imported');
+  });
+
+  it('summary hides the secret key', () => {
+    const summary = importWalletFlow.summarize!({
+      name: 'imported',
+      secretKey: 'SABCDEF',
+      network: 'testnet',
+      encrypt: true,
+    });
+    const secretLine = summary.find((l) => l.label === 'Secret');
+    expect(secretLine?.value).not.toContain('SABCDEF');
+    expect(secretLine?.value).toMatch(/hidden/);
+  });
+});
+
+describe('listWalletsFlow', () => {
+  it('has no steps and emits `wallet list`', () => {
+    expect(listWalletsFlow.steps).toEqual([]);
+    expect(listWalletsFlow.buildArgs({})).toEqual(['wallet', 'list']);
+  });
+});
+
+describe('walletInfoFlow', () => {
+  it('emits the target as a positional argument', () => {
+    expect(walletInfoFlow.buildArgs({ target: 'alice' })).toEqual(['wallet', 'info', 'alice']);
+  });
+});
+
+describe('balanceWalletFlow', () => {
+  it('uses --name when mode is "name"', () => {
+    const args = balanceWalletFlow.buildArgs({
+      mode: 'name',
+      wallet: 'alice',
+      network: 'testnet',
+    });
+    expect(args).toEqual(['wallet', 'balance', '--name', 'alice', '--network', 'testnet']);
+  });
+
+  it('uses positional address when mode is "address"', () => {
+    const addr = 'G' + 'A'.repeat(55);
+    const args = balanceWalletFlow.buildArgs({
+      mode: 'address',
+      address: addr,
+      network: 'mainnet',
+    });
+    expect(args).toEqual(['wallet', 'balance', addr, '--network', 'mainnet']);
+  });
+
+  it('wallet step only fires for "name" mode', () => {
+    const walletStep = findStep(balanceWalletFlow, 'wallet');
+    expect(walletStep.when?.({ mode: 'name' })).toBe(true);
+    expect(walletStep.when?.({ mode: 'address' })).toBe(false);
+  });
+
+  it('address step only fires for "address" mode', () => {
+    const addressStep = findStep(balanceWalletFlow, 'address');
+    expect(addressStep.when?.({ mode: 'address' })).toBe(true);
+    expect(addressStep.when?.({ mode: 'name' })).toBe(false);
+  });
+
+  it('rejects malformed public keys', () => {
+    const addressStep = findStep(balanceWalletFlow, 'address');
+    expect(addressStep.validate?.('not-a-key')).toMatch(/Invalid Stellar public key/);
+    expect(addressStep.validate?.('G' + 'A'.repeat(55))).toBe(true);
+  });
+});
+
+describe('fundWalletFlow', () => {
+  it('rejects non-positive amounts', () => {
+    const amount = findStep(fundWalletFlow, 'amount');
+    expect(amount.validate?.('0')).toBe('Amount must be a positive decimal');
+    expect(amount.validate?.('-5')).toBe('Amount must be a positive decimal');
+    expect(amount.validate?.('abc')).toBe('Amount must be a positive decimal');
+    expect(amount.validate?.('10.5')).toBe(true);
+  });
+
+  it('builds the fund command with --name and --amount', () => {
+    expect(fundWalletFlow.buildArgs({ name: 'dev', amount: '1000' })).toEqual([
+      'wallet', 'fund', '--name', 'dev', '--amount', '1000',
+    ]);
+  });
+});
+
+describe('sendPaymentFlow', () => {
+  it('is marked destructive (runner will require confirmation)', () => {
+    expect(sendPaymentFlow.destructive).toBe(true);
+  });
+
+  it('emits positional args in the exact order the send command expects', () => {
+    const addr = 'G' + 'A'.repeat(55);
+    const args = sendPaymentFlow.buildArgs({
+      from: 'alice',
+      to: addr,
+      amount: '5',
+      asset: 'XLM',
+      memo: '',
+      network: '',
+    });
+    expect(args).toEqual(['wallet', 'send', 'alice', addr, '5', 'XLM']);
+  });
+
+  it('appends --memo and --network when provided', () => {
+    const addr = 'G' + 'A'.repeat(55);
+    const args = sendPaymentFlow.buildArgs({
+      from: 'alice',
+      to: addr,
+      amount: '5',
+      asset: 'XLM',
+      memo: 'gift',
+      network: 'mainnet',
+    });
+    expect(args).toEqual([
+      'wallet', 'send', 'alice', addr, '5', 'XLM', '--memo', 'gift', '--network', 'mainnet',
+    ]);
+  });
+
+  it('validates the destination public key', () => {
+    const to = findStep(sendPaymentFlow, 'to');
+    expect(to.validate?.('not-a-key')).toMatch(/Invalid Stellar public key/);
+    expect(to.validate?.('G' + 'A'.repeat(55))).toBe(true);
+  });
+
+  it('validates asset format ("XLM" or "CODE:ISSUER")', () => {
+    const asset = findStep(sendPaymentFlow, 'asset');
+    expect(asset.validate?.('XLM')).toBe(true);
+    expect(asset.validate?.(`USDC:G${'A'.repeat(55)}`)).toBe(true);
+    expect(asset.validate?.('USDC')).toBe("Use 'XLM' or 'CODE:ISSUER'");
+    expect(asset.validate?.('bad asset')).toBe("Use 'XLM' or 'CODE:ISSUER'");
+  });
+
+  it('rejects memos longer than 28 UTF-8 bytes', () => {
+    const memo = findStep(sendPaymentFlow, 'memo');
+    expect(memo.validate?.('a'.repeat(29))).toBe('Memo must be 28 bytes or fewer (UTF-8)');
+    expect(memo.validate?.('hello')).toBe(true);
+  });
+});

--- a/tools/cli/src/commands/interactive/index.ts
+++ b/tools/cli/src/commands/interactive/index.ts
@@ -16,6 +16,14 @@ import { HistoryManager, getHistoryManager, resetHistoryManager } from './histor
 import { AutocompleteManager, getAutocompleteManager, resetAutocompleteManager, COMMAND_REGISTRY } from './autocomplete.js';
 import { WorkflowManager, getWorkflowManager, resetWorkflowManager, runWorkflow, WORKFLOWS, listWorkflows } from './workflows.js';
 import { attachMenuCommand, runInteractiveMenus, ROOT_MENU } from './menus.js';
+import {
+  runPromptFlow,
+  getPromptFlow,
+  listPromptFlows,
+  PROMPT_FLOWS,
+  WALLET_PROMPTS,
+  DEFI_PROMPTS,
+} from './prompts/index.js';
 
 // Re-export types
 export type {
@@ -63,6 +71,27 @@ export {
 };
 
 export type { MenuEntry, MenuParam } from './menus.js';
+export type {
+  PromptFlow,
+  PromptStep,
+  PromptChoice,
+  PromptStepType,
+  PromptExecutor,
+  PromptFlowResult,
+  RunPromptFlowOptions,
+  SummaryLine,
+  Summarizer,
+  ArgBuilder,
+} from './prompts/index.js';
+
+export {
+  runPromptFlow,
+  getPromptFlow,
+  listPromptFlows,
+  PROMPT_FLOWS,
+  WALLET_PROMPTS,
+  DEFI_PROMPTS,
+};
 
 /**
  * Create the interactive REPL command for Commander.js.

--- a/tools/cli/src/commands/interactive/menus.ts
+++ b/tools/cli/src/commands/interactive/menus.ts
@@ -11,6 +11,7 @@
 import inquirer from 'inquirer';
 import chalk from 'chalk';
 import { Command } from 'commander';
+import { getPromptFlow, runPromptFlow } from './prompts/index.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -22,16 +23,27 @@ export interface MenuParam {
   choices?: string[];
   // Accepts any runtime value (number, boolean, string) and supports async validators
   validate?: (value: any) => boolean | string | Promise<boolean | string>;
+  /**
+   * When true, emit the value as a positional argument instead of `--name value`.
+   * Positional params are appended in declaration order, after the base command
+   * tokens and before any flags.
+   */
+  positional?: boolean;
 }
 
 export interface MenuEntry {
   /** Display label shown in the list */
   label: string;
-  /** CLI command string to execute, e.g. "account info" — required if children is absent */
+  /** CLI command string to execute, e.g. "wallet info" — required if children and promptFlow are absent */
   command?: string;
+  /**
+   * Id of a guided PromptFlow to run (see prompts/index.ts). When set,
+   * `command` and `params` are ignored — the flow drives its own prompts.
+   */
+  promptFlow?: string;
   /** Parameters to collect before running the command */
   params?: MenuParam[];
-  /** Nested submenu entries — required if command is absent */
+  /** Nested submenu entries — required if command and promptFlow are absent */
   children?: MenuEntry[];
   /** Human-readable description shown as a hint */
   description?: string;
@@ -52,174 +64,90 @@ const EXIT = '__EXIT__';
 /**
  * Top-level menu structure.
  * Extend this array to register new commands in the interactive UI.
- * Every entry must have either `children` (submenu) or `command` (action).
+ * Every entry must have one of: `children` (submenu), `command` (direct), or `promptFlow` (guided).
+ *
+ * Use `promptFlow` for multi-step guided flows with validation + confirmation
+ * (see prompts/index.ts). Use `command` + `params` for simple one-shot inputs.
  */
 export const ROOT_MENU: MenuEntry[] = [
   {
-    label: '🔑  Account',
-    description: 'Manage Stellar accounts and keypairs',
+    label: '🔑  Wallet',
+    description: 'Create, import and manage local wallets',
     children: [
       {
-        label: 'Show account info',
-        command: 'account info',
+        label: 'Create wallet (guided)',
+        description: 'Generate a new keypair with optional encryption',
+        promptFlow: 'wallet:create',
+      },
+      {
+        label: 'Import wallet (guided)',
+        description: 'Import from a secret key',
+        promptFlow: 'wallet:import',
+      },
+      {
+        label: 'List wallets',
+        command: 'wallet list',
+      },
+      {
+        label: 'Wallet info',
+        command: 'wallet info',
         params: [
           {
-            name: 'address',
-            message: 'Stellar account address (G…):',
+            name: 'target',
+            message: 'Wallet name or public key:',
             type: 'input',
+            positional: true,
             validate: (v: string) =>
-              v.startsWith('G') && v.length === 56
-                ? true
-                : 'Enter a valid Stellar public key (56 chars, starts with G)',
+              v && v.trim().length > 0 ? true : 'Required',
           },
         ],
       },
       {
-        label: 'Generate new keypair',
-        command: 'account generate',
+        label: 'Check balance (guided)',
+        description: 'Lookup by wallet name or address',
+        promptFlow: 'wallet:balance',
       },
       {
-        label: 'Fund account (testnet friendbot)',
-        command: 'account fund',
-        params: [
-          {
-            name: 'address',
-            message: 'Account address to fund:',
-            type: 'input',
-            validate: (v: string) =>
-              v.startsWith('G') && v.length === 56
-                ? true
-                : 'Enter a valid Stellar public key',
-          },
-        ],
+        label: 'Fund testnet wallet (guided)',
+        description: 'Request XLM from friendbot',
+        promptFlow: 'wallet:fund',
       },
     ],
   },
   {
     label: '💸  Payments',
-    description: 'Send payments and manage assets',
+    description: 'Send XLM and issued assets',
     children: [
       {
-        label: 'Send XLM payment',
-        command: 'payment send',
-        params: [
-          {
-            name: 'from',
-            message: 'Source account (G…):',
-            type: 'input',
-            validate: (v: string) => (v.length > 0 ? true : 'Required'),
-          },
-          {
-            name: 'to',
-            message: 'Destination account (G…):',
-            type: 'input',
-            validate: (v: string) => (v.length > 0 ? true : 'Required'),
-          },
-          {
-            name: 'amount',
-            message: 'Amount (XLM):',
-            type: 'number',
-            // inquirer number prompt returns NaN for empty/invalid input
-            validate: (v: number) =>
-              !isNaN(v) && v > 0 ? true : 'Must be a positive number',
-          },
-          {
-            name: 'memo',
-            message: 'Memo (optional):',
-            type: 'input',
-            default: '',
-          },
-        ],
-      },
-      {
-        label: 'Check payment history',
-        command: 'payment history',
-        params: [
-          {
-            name: 'address',
-            message: 'Account address:',
-            type: 'input',
-            validate: (v: string) => (v.length > 0 ? true : 'Required'),
-          },
-          {
-            name: 'limit',
-            message: 'Number of records:',
-            type: 'number',
-            default: 10,
-            validate: (v: number) =>
-              !isNaN(v) && v > 0 ? true : 'Must be a positive number',
-          },
-        ],
+        label: 'Send payment (guided)',
+        description: 'Transfer XLM or an issued asset — asks for confirmation',
+        promptFlow: 'wallet:send',
       },
     ],
   },
   {
     label: '🌊  DeFi / Liquidity',
-    description: 'Interact with AMMs, liquidity pools, and swap protocols',
+    description: 'Soroswap swaps, Blend lending, liquidity pools',
     children: [
       {
+        label: 'Swap tokens (Soroswap, guided)',
+        description: 'Swap with quote preview + confirmation',
+        promptFlow: 'defi:swap',
+      },
+      {
+        label: 'Blend — supply (guided)',
+        description: 'Supply assets to Blend Protocol',
+        promptFlow: 'defi:blend-supply',
+      },
+      {
+        label: 'Blend — borrow (guided)',
+        description: 'Borrow assets from Blend Protocol',
+        promptFlow: 'defi:blend-borrow',
+      },
+      {
         label: 'List liquidity pools',
-        command: 'defi pools',
-        params: [
-          {
-            name: 'asset',
-            message: 'Filter by asset (leave blank for all):',
-            type: 'input',
-            default: '',
-          },
-        ],
-      },
-      {
-        label: 'Swap assets',
-        command: 'defi swap',
-        params: [
-          {
-            name: 'sell',
-            message: 'Asset to sell (e.g. XLM):',
-            type: 'input',
-            validate: (v: string) => (v.length > 0 ? true : 'Required'),
-          },
-          {
-            name: 'buy',
-            message: 'Asset to buy (e.g. USDC):',
-            type: 'input',
-            validate: (v: string) => (v.length > 0 ? true : 'Required'),
-          },
-          {
-            name: 'amount',
-            message: 'Amount to sell:',
-            type: 'number',
-            validate: (v: number) =>
-              !isNaN(v) && v > 0 ? true : 'Must be a positive number',
-          },
-          {
-            name: 'slippage',
-            message: 'Max slippage % (e.g. 0.5):',
-            type: 'number',
-            default: 0.5,
-            validate: (v: number) =>
-              !isNaN(v) && v >= 0 ? true : 'Must be a non-negative number',
-          },
-        ],
-      },
-      {
-        label: 'Add liquidity',
-        command: 'defi add-liquidity',
-        params: [
-          {
-            name: 'pool',
-            message: 'Pool ID or asset pair (e.g. XLM/USDC):',
-            type: 'input',
-            validate: (v: string) => (v.length > 0 ? true : 'Required'),
-          },
-          {
-            name: 'amount',
-            message: 'Amount to deposit:',
-            type: 'number',
-            validate: (v: number) =>
-              !isNaN(v) && v > 0 ? true : 'Must be a positive number',
-          },
-        ],
+        description: 'Show TVL and APY across Soroswap pools',
+        promptFlow: 'defi:pools',
       },
     ],
   },
@@ -232,43 +160,36 @@ export const ROOT_MENU: MenuEntry[] = [
         command: 'oracle price',
         params: [
           {
-            name: 'asset',
-            message: 'Asset symbol (e.g. XLM, BTC):',
+            name: 'symbol',
+            message: 'Asset symbol (e.g. XLM/USD):',
             type: 'input',
-            validate: (v: string) => (v.length > 0 ? true : 'Required'),
+            positional: true,
+            default: 'XLM/USD',
+            validate: (v: string) => (v && v.length > 0 ? true : 'Required'),
           },
-        ],
-      },
-      {
-        label: 'List supported assets',
-        command: 'oracle assets',
-      },
-    ],
-  },
-  {
-    label: '⚙️   Network',
-    description: 'Switch networks and inspect ledger state',
-    children: [
-      {
-        label: 'Switch network',
-        command: 'network switch',
-        params: [
+          {
+            name: 'strategy',
+            message: 'Aggregation strategy:',
+            type: 'list',
+            choices: ['median', 'mean', 'twap', 'weighted'],
+            default: 'median',
+          },
           {
             name: 'network',
-            message: 'Select network:',
+            message: 'Network:',
             type: 'list',
-            choices: ['mainnet', 'testnet', 'futurenet', 'localnet'],
+            choices: ['testnet', 'mainnet'],
             default: 'testnet',
           },
         ],
       },
       {
-        label: 'Show current network',
-        command: 'network current',
+        label: 'List configured oracle sources',
+        command: 'oracle sources list',
       },
       {
-        label: 'Ledger info',
-        command: 'network ledger',
+        label: 'List supported strategies',
+        command: 'oracle strategies',
       },
     ],
   },
@@ -337,7 +258,11 @@ function isAbortError(err: unknown): boolean {
  * Returns string[] safe to pass directly into Commander's parseAsync —
  * no shell splitting needed, whitespace in values is fully preserved.
  *
- * e.g. ['payment', 'send', '--from', 'G...', '--to', 'G...', '--amount', '10']
+ * Params marked `positional: true` are emitted in declaration order, immediately
+ * after the base command tokens. Remaining params become `--flag value` pairs.
+ *
+ * e.g. for `wallet send <from> <to> <amount> <asset> [--memo X]`:
+ *   ['wallet', 'send', 'alice', 'G...', '10', 'XLM', '--memo', 'gift']
  *
  * For human-readable display use buildCommandPreview() instead.
  */
@@ -347,21 +272,35 @@ function buildCommandArgs(
 ): string[] {
   if (!entry.command) return [];
 
-  // Split the base command into individual tokens (e.g. "payment send" → ['payment', 'send'])
   const base = entry.command.split(/\s+/).filter(Boolean);
+  const positionals: string[] = [];
   const flags: string[] = [];
 
+  // Walk declared params in order so positionals stay aligned with the command signature.
+  const positionalNames = new Set<string>(
+    (entry.params ?? []).filter((p) => p.positional).map((p) => p.name),
+  );
+
+  if (entry.params) {
+    for (const p of entry.params) {
+      if (!p.positional) continue;
+      const v = params[p.name];
+      if (v === '' || v === undefined || v === null) continue;
+      positionals.push(String(v));
+    }
+  }
+
   for (const [k, v] of Object.entries(params)) {
+    if (positionalNames.has(k)) continue;
     if (v === '' || v === undefined || v === null) continue;
     if (typeof v === 'boolean') {
-      if (v) flags.push(`--${k}`); // omit the flag entirely when false
+      if (v) flags.push(`--${k}`);
       continue;
     }
-    // Push key and value as separate array elements — whitespace in v is preserved
     flags.push(`--${k}`, String(v));
   }
 
-  return [...base, ...flags];
+  return [...base, ...positionals, ...flags];
 }
 
 /**
@@ -461,8 +400,7 @@ async function stepRoot(
   const selected = ROOT_MENU[Number(answer.choice)];
 
   if (!selected.children || selected.children.length === 0) {
-    // Guard: entry with no children must have a command registered
-    if (!selected.command) {
+    if (!selected.command && !selected.promptFlow) {
       console.log(chalk.yellow(`\n  ⚠  No command registered for "${selected.label}". Skipping.\n`));
       return { tag: 'root' };
     }
@@ -513,8 +451,7 @@ async function stepSubmenu(
     return { tag: 'submenu', parent: selected, entries: selected.children };
   }
 
-  // Guard: entry with no children must have a command registered
-  if (!selected.command) {
+  if (!selected.command && !selected.promptFlow) {
     console.log(chalk.yellow(`\n  ⚠  No command registered for "${selected.label}". Skipping.\n`));
     return { tag: 'submenu', parent: state.parent, entries: state.entries };
   }
@@ -526,13 +463,29 @@ async function stepSubmenu(
 }
 
 /**
- * Collect params (if any) for an entry and forward a structured string[]
- * to the executor — no shell splitting at the call site.
+ * Run an entry: either delegate to a registered PromptFlow (guided multi-step
+ * flow with confirmation) or collect params and run a direct command.
  */
 async function executeEntry(
   entry: MenuEntry,
   executor: (args: string[]) => Promise<void>,
 ): Promise<void> {
+  if (entry.promptFlow) {
+    const flow = getPromptFlow(entry.promptFlow);
+    if (!flow) {
+      console.log(chalk.yellow(`\n  ⚠  Unknown prompt flow: ${entry.promptFlow}\n`));
+      return;
+    }
+    hr();
+    const result = await runPromptFlow(flow, executor);
+    if (result.error) {
+      console.error(chalk.red(`\n  ✖  Error: ${result.error.message}\n`));
+    }
+    hr();
+    console.log('');
+    return;
+  }
+
   const params = await collectParams(entry);
 
   if (params === null) {
@@ -540,7 +493,6 @@ async function executeEntry(
     return;
   }
 
-  // entry.command is guaranteed to be set by all callers (checked before this call)
   const args = buildCommandArgs(entry, params);
   const preview = buildCommandPreview(entry, params);
 

--- a/tools/cli/src/commands/interactive/prompts/defi-prompts.ts
+++ b/tools/cli/src/commands/interactive/prompts/defi-prompts.ts
@@ -1,0 +1,270 @@
+/**
+ * @fileoverview Guided DeFi prompt flows.
+ * @description PromptFlow definitions for DeFi operations on top of the
+ *   existing `galaxy defi …` commands (Blend, Soroswap).
+ *   Transaction-emitting flows are marked destructive so the runner shows
+ *   an explicit confirmation gate before signing — and we forward `-y`
+ *   downstream so the underlying command doesn't re-prompt the user.
+ * @since 2026-06-28
+ */
+
+import type { PromptFlow, SummaryLine } from './index.js';
+
+const ASSET_CODE = /^[A-Za-z0-9]{1,12}$/;
+const POSITIVE_DECIMAL = /^\d+(\.\d+)?$/;
+const NON_NEGATIVE_DECIMAL = /^\d+(\.\d+)?$/;
+const WALLET_NAME = /^[A-Za-z0-9_-]+$/;
+
+function validateAssetCode(value: unknown): true | string {
+  const v = String(value ?? '').trim();
+  if (!ASSET_CODE.test(v)) return 'Use a 1-12 char alphanumeric code (e.g. XLM, USDC)';
+  return true;
+}
+
+function validateAmount(value: unknown): true | string {
+  const v = String(value ?? '').trim();
+  if (!POSITIVE_DECIMAL.test(v) || Number(v) <= 0) return 'Amount must be a positive decimal';
+  return true;
+}
+
+function validateSlippage(value: unknown): true | string {
+  const v = String(value ?? '').trim();
+  if (!NON_NEGATIVE_DECIMAL.test(v)) return 'Slippage must be a non-negative decimal';
+  const n = Number(v);
+  if (n < 0 || n > 100) return 'Slippage must be between 0 and 100';
+  return true;
+}
+
+function validateOptionalWallet(value: unknown): true | string {
+  const v = String(value ?? '').trim();
+  if (!v) return true;
+  if (!WALLET_NAME.test(v)) return 'Only letters, numbers, dashes and underscores';
+  return true;
+}
+
+function pushFlag(out: string[], flag: string, value: unknown): void {
+  if (value === undefined || value === null) return;
+  const str = String(value).trim();
+  if (!str) return;
+  out.push(flag, str);
+}
+
+const networkChoices = [
+  { name: 'Testnet', value: 'testnet', default: true },
+  { name: 'Mainnet', value: 'mainnet' },
+];
+
+export const blendSupplyFlow: PromptFlow = {
+  id: 'defi:blend-supply',
+  title: '🟢 Blend — Supply',
+  description: 'Supply assets to Blend Protocol',
+  destructive: true,
+  steps: [
+    {
+      name: 'asset',
+      message: 'Asset code (e.g. USDC, XLM):',
+      type: 'input',
+      default: 'USDC',
+      validate: validateAssetCode,
+    },
+    {
+      name: 'amount',
+      message: 'Amount to supply:',
+      type: 'input',
+      validate: validateAmount,
+    },
+    {
+      name: 'wallet',
+      message: 'Wallet name (leave blank to be prompted by command):',
+      type: 'input',
+      default: '',
+      validate: validateOptionalWallet,
+    },
+    {
+      name: 'network',
+      message: 'Network:',
+      type: 'list',
+      choices: networkChoices,
+      default: 'testnet',
+    },
+  ],
+  buildArgs: (a) => {
+    const args = ['defi', 'blend', 'supply', String(a.asset), String(a.amount)];
+    pushFlag(args, '--wallet', a.wallet);
+    args.push('--network', String(a.network), '-y');
+    return args;
+  },
+  summarize: (a): SummaryLine[] => [
+    { label: 'Operation', value: 'supply' },
+    { label: 'Asset', value: String(a.asset) },
+    { label: 'Amount', value: String(a.amount) },
+    { label: 'Wallet', value: String(a.wallet || 'prompt') },
+    { label: 'Network', value: String(a.network) },
+  ],
+};
+
+export const blendBorrowFlow: PromptFlow = {
+  id: 'defi:blend-borrow',
+  title: '🟡 Blend — Borrow',
+  description: 'Borrow assets from Blend Protocol',
+  destructive: true,
+  steps: [
+    {
+      name: 'asset',
+      message: 'Asset code (e.g. USDC, XLM):',
+      type: 'input',
+      validate: validateAssetCode,
+    },
+    {
+      name: 'amount',
+      message: 'Amount to borrow:',
+      type: 'input',
+      validate: validateAmount,
+    },
+    {
+      name: 'wallet',
+      message: 'Wallet name (leave blank to be prompted by command):',
+      type: 'input',
+      default: '',
+      validate: validateOptionalWallet,
+    },
+    {
+      name: 'network',
+      message: 'Network:',
+      type: 'list',
+      choices: networkChoices,
+      default: 'testnet',
+    },
+  ],
+  buildArgs: (a) => {
+    const args = ['defi', 'blend', 'borrow', String(a.asset), String(a.amount)];
+    pushFlag(args, '--wallet', a.wallet);
+    args.push('--network', String(a.network), '-y');
+    return args;
+  },
+  summarize: (a): SummaryLine[] => [
+    { label: 'Operation', value: 'borrow' },
+    { label: 'Asset', value: String(a.asset) },
+    { label: 'Amount', value: String(a.amount) },
+    { label: 'Wallet', value: String(a.wallet || 'prompt') },
+    { label: 'Network', value: String(a.network) },
+  ],
+};
+
+export const swapFlow: PromptFlow = {
+  id: 'defi:swap',
+  title: '🔄 Swap (Soroswap)',
+  description: 'Swap tokens via the Soroswap DEX',
+  destructive: true,
+  steps: [
+    {
+      name: 'fromAsset',
+      message: 'Asset to sell (e.g. XLM):',
+      type: 'input',
+      default: 'XLM',
+      validate: validateAssetCode,
+    },
+    {
+      name: 'toAsset',
+      message: 'Asset to buy (e.g. USDC):',
+      type: 'input',
+      default: 'USDC',
+      validate: validateAssetCode,
+    },
+    {
+      name: 'amount',
+      message: 'Amount to swap:',
+      type: 'input',
+      validate: validateAmount,
+    },
+    {
+      name: 'slippage',
+      message: 'Max slippage (%):',
+      type: 'input',
+      default: '1',
+      validate: validateSlippage,
+    },
+    {
+      name: 'wallet',
+      message: 'Wallet name (leave blank to be prompted by command):',
+      type: 'input',
+      default: '',
+      validate: validateOptionalWallet,
+    },
+    {
+      name: 'network',
+      message: 'Network:',
+      type: 'list',
+      choices: networkChoices,
+      default: 'testnet',
+    },
+    {
+      name: 'quoteOnly',
+      message: 'Only fetch quote, do not execute swap?',
+      type: 'confirm',
+      default: false,
+    },
+  ],
+  buildArgs: (a) => {
+    const args = [
+      'defi',
+      'swap',
+      String(a.fromAsset),
+      String(a.toAsset),
+      String(a.amount),
+      '--slippage',
+      String(a.slippage),
+    ];
+    pushFlag(args, '--wallet', a.wallet);
+    args.push('--network', String(a.network));
+    if (a.quoteOnly) args.push('--quote-only');
+    else args.push('-y');
+    return args;
+  },
+  summarize: (a): SummaryLine[] => [
+    { label: 'From', value: String(a.fromAsset) },
+    { label: 'To', value: String(a.toAsset) },
+    { label: 'Amount', value: String(a.amount) },
+    { label: 'Slippage', value: `${a.slippage}%` },
+    { label: 'Wallet', value: String(a.wallet || 'prompt') },
+    { label: 'Network', value: String(a.network) },
+    { label: 'Mode', value: a.quoteOnly ? 'quote only' : 'execute' },
+  ],
+};
+
+export const listPoolsFlow: PromptFlow = {
+  id: 'defi:pools',
+  title: '🌊 Liquidity Pools',
+  description: 'List Soroswap liquidity pools with TVL and APY',
+  steps: [
+    {
+      name: 'network',
+      message: 'Network:',
+      type: 'list',
+      choices: networkChoices,
+      default: 'testnet',
+    },
+    {
+      name: 'json',
+      message: 'Output as JSON?',
+      type: 'confirm',
+      default: false,
+    },
+  ],
+  buildArgs: (a) => {
+    const args = ['defi', 'pools', 'list', '--network', String(a.network)];
+    if (a.json) args.push('--json');
+    return args;
+  },
+  summarize: (a) => [
+    { label: 'Network', value: String(a.network) },
+    { label: 'Format', value: a.json ? 'json' : 'table' },
+  ],
+};
+
+export const DEFI_PROMPTS: Record<string, PromptFlow> = {
+  [blendSupplyFlow.id]: blendSupplyFlow,
+  [blendBorrowFlow.id]: blendBorrowFlow,
+  [swapFlow.id]: swapFlow,
+  [listPoolsFlow.id]: listPoolsFlow,
+};

--- a/tools/cli/src/commands/interactive/prompts/index.ts
+++ b/tools/cli/src/commands/interactive/prompts/index.ts
@@ -1,0 +1,252 @@
+/**
+ * @fileoverview PromptFlow runner — guided prompt orchestration for the CLI.
+ * @description Declarative step-by-step prompt flows with real-time validation,
+ *   a summary screen, and a confirmation gate before destructive actions.
+ *   Flows execute by emitting a structured argv array that is fed into the
+ *   existing Commander program — so business logic is reused, not duplicated.
+ * @since 2026-06-28
+ */
+
+import inquirer from 'inquirer';
+import chalk from 'chalk';
+
+export type PromptStepType =
+  | 'input'
+  | 'password'
+  | 'number'
+  | 'confirm'
+  | 'list'
+  | 'checkbox';
+
+export interface PromptChoice {
+  name: string;
+  value: string | number | boolean;
+  description?: string;
+  default?: boolean;
+}
+
+export interface PromptStep {
+  name: string;
+  message: string;
+  type: PromptStepType;
+  default?: string | number | boolean;
+  choices?: PromptChoice[];
+  validate?: (value: unknown) => boolean | string | Promise<boolean | string>;
+  when?: (answers: Record<string, unknown>) => boolean;
+  mask?: string;
+}
+
+export type ArgBuilder = (answers: Record<string, unknown>) => string[];
+
+export interface SummaryLine {
+  label: string;
+  value: string;
+}
+
+export type Summarizer = (answers: Record<string, unknown>) => SummaryLine[];
+
+export interface PromptFlow {
+  /** Stable id used to register and look up the flow */
+  id: string;
+  /** Short imperative title shown at the top of the flow */
+  title: string;
+  /** One-line description shown below the title */
+  description: string;
+  /** Marks the flow as destructive — forces an explicit confirmation gate */
+  destructive?: boolean;
+  /** Question steps collected from the user, in order */
+  steps: PromptStep[];
+  /** Build the Commander argv (e.g. ['wallet', 'send', 'alice', 'G...', '1', 'XLM']) */
+  buildArgs: ArgBuilder;
+  /** Optional custom summary; falls back to the raw answers if omitted */
+  summarize?: Summarizer;
+}
+
+/** Function that runs a Commander argv against the existing program. */
+export type PromptExecutor = (argv: string[]) => Promise<void>;
+
+/** Inquirer-compatible prompt function — injectable for testing. */
+export type PromptFn = typeof inquirer.prompt;
+
+export interface RunPromptFlowOptions {
+  /** Override the prompt function (used by tests). */
+  prompt?: PromptFn;
+  /** Skip the confirmation gate (equivalent to passing -y to the command). */
+  yes?: boolean;
+  /** Silence summary / header output (used by tests). */
+  silent?: boolean;
+}
+
+export interface PromptFlowResult {
+  cancelled: boolean;
+  executed: boolean;
+  answers: Record<string, unknown>;
+  argv: string[];
+  error?: Error;
+}
+
+const ABORT_MARKERS = [
+  'User force closed',
+  'AbortError',
+  'force closed the prompt',
+];
+
+function isAbortError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return ABORT_MARKERS.some((marker) => err.message.includes(marker));
+}
+
+function defaultSummary(answers: Record<string, unknown>): SummaryLine[] {
+  return Object.entries(answers)
+    .filter(([key]) => !key.startsWith('_'))
+    .map(([key, value]) => ({
+      label: key,
+      value: value === undefined || value === null ? '' : String(value),
+    }));
+}
+
+function buildInquirerQuestion(step: PromptStep): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    name: step.name,
+    message: step.message,
+    type: step.type,
+    default: step.default,
+    when: step.when,
+    validate: step.validate,
+  };
+
+  if (step.type === 'password') {
+    base.mask = step.mask ?? '*';
+  }
+
+  if (step.type === 'list' || step.type === 'checkbox') {
+    base.choices = (step.choices ?? []).map((c) => ({
+      name: c.description ? `${c.name} — ${c.description}` : c.name,
+      value: c.value,
+      checked: c.default,
+    }));
+  }
+
+  return base;
+}
+
+function printHeader(flow: PromptFlow): void {
+  console.log('');
+  console.log(chalk.cyan(`  ${flow.title}`));
+  console.log(chalk.dim(`  ${flow.description}`));
+  console.log('');
+}
+
+function printSummary(flow: PromptFlow, answers: Record<string, unknown>): void {
+  const lines = (flow.summarize ?? defaultSummary)(answers);
+  if (lines.length === 0) return;
+  console.log('');
+  console.log(chalk.bold('  Summary'));
+  for (const { label, value } of lines) {
+    console.log(`  ${chalk.gray(label.padEnd(12, ' '))} ${value}`);
+  }
+  console.log('');
+}
+
+/**
+ * Run a PromptFlow end-to-end.
+ *
+ * Steps:
+ *   1. Print the flow header.
+ *   2. Collect each step's answer (validation runs inside inquirer).
+ *   3. Print a summary of the collected values.
+ *   4. For destructive flows (and when `yes` is not set), require an explicit
+ *      "Proceed?" confirmation. Non-destructive flows skip this step.
+ *   5. Build argv and hand off to the Commander executor.
+ *
+ * The function never throws on user cancellation (Ctrl+C / inquirer abort).
+ * It returns `{ cancelled: true }` so callers can decide what to do next.
+ */
+export async function runPromptFlow(
+  flow: PromptFlow,
+  executor: PromptExecutor,
+  options: RunPromptFlowOptions = {},
+): Promise<PromptFlowResult> {
+  const prompt = options.prompt ?? inquirer.prompt;
+  const answers: Record<string, unknown> = {};
+
+  if (!options.silent) printHeader(flow);
+
+  for (const step of flow.steps) {
+    if (step.when && !step.when(answers)) continue;
+    try {
+      const result = await prompt([buildInquirerQuestion(step)] as Parameters<PromptFn>[0]);
+      answers[step.name] = (result as Record<string, unknown>)[step.name];
+    } catch (err) {
+      if (isAbortError(err)) {
+        if (!options.silent) console.log(chalk.yellow('\n  Cancelled.\n'));
+        return { cancelled: true, executed: false, answers, argv: [] };
+      }
+      throw err;
+    }
+  }
+
+  if (!options.silent) printSummary(flow, answers);
+
+  if (flow.destructive && !options.yes) {
+    try {
+      const confirmAnswer = await prompt([
+        {
+          name: '_confirm',
+          message: 'Proceed?',
+          type: 'confirm',
+          default: false,
+        },
+      ] as Parameters<PromptFn>[0]);
+      if (!(confirmAnswer as Record<string, boolean>)._confirm) {
+        if (!options.silent) console.log(chalk.yellow('  Aborted by user.\n'));
+        return { cancelled: true, executed: false, answers, argv: [] };
+      }
+    } catch (err) {
+      if (isAbortError(err)) {
+        if (!options.silent) console.log(chalk.yellow('\n  Cancelled.\n'));
+        return { cancelled: true, executed: false, answers, argv: [] };
+      }
+      throw err;
+    }
+  }
+
+  const argv = flow.buildArgs(answers);
+
+  try {
+    await executor(argv);
+    return { cancelled: false, executed: true, answers, argv };
+  } catch (err) {
+    return {
+      cancelled: false,
+      executed: false,
+      answers,
+      argv,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}
+
+import { WALLET_PROMPTS } from './wallet-prompts.js';
+import { DEFI_PROMPTS } from './defi-prompts.js';
+
+export { WALLET_PROMPTS } from './wallet-prompts.js';
+export { DEFI_PROMPTS } from './defi-prompts.js';
+
+/** Combined registry of every prompt flow shipped with the CLI. */
+export const PROMPT_FLOWS: Record<string, PromptFlow> = {
+  ...WALLET_PROMPTS,
+  ...DEFI_PROMPTS,
+};
+
+export function getPromptFlow(id: string): PromptFlow | undefined {
+  return PROMPT_FLOWS[id];
+}
+
+export function listPromptFlows(): Array<{ id: string; title: string; description: string }> {
+  return Object.values(PROMPT_FLOWS).map((f) => ({
+    id: f.id,
+    title: f.title,
+    description: f.description,
+  }));
+}

--- a/tools/cli/src/commands/interactive/prompts/wallet-prompts.ts
+++ b/tools/cli/src/commands/interactive/prompts/wallet-prompts.ts
@@ -1,0 +1,366 @@
+/**
+ * @fileoverview Guided wallet prompt flows.
+ * @description PromptFlow definitions for wallet management operations.
+ *   Each flow collects parameters with real-time validation and forwards
+ *   a structured argv array to the existing `galaxy wallet …` commands.
+ * @since 2026-06-28
+ */
+
+import type { PromptFlow, SummaryLine } from './index.js';
+
+const STELLAR_PUBLIC_KEY = /^G[A-Z2-7]{55}$/;
+const WALLET_NAME = /^[A-Za-z0-9_-]+$/;
+const POSITIVE_DECIMAL = /^\d+(\.\d+)?$/;
+const ASSET_FORMAT = /^(XLM|[A-Za-z0-9]{1,12}:G[A-Z2-7]{55})$/;
+
+function validateWalletName(value: unknown): true | string {
+  const v = String(value ?? '').trim();
+  if (!v) return 'Wallet name is required';
+  if (!WALLET_NAME.test(v)) return 'Only letters, numbers, dashes and underscores';
+  return true;
+}
+
+function validatePublicKey(value: unknown): true | string {
+  const v = String(value ?? '').trim();
+  if (!v) return 'Address is required';
+  if (!STELLAR_PUBLIC_KEY.test(v)) return 'Invalid Stellar public key (56 chars, starts with G)';
+  return true;
+}
+
+function validateAmount(value: unknown): true | string {
+  const v = String(value ?? '').trim();
+  if (!POSITIVE_DECIMAL.test(v) || Number(v) <= 0) return 'Amount must be a positive decimal';
+  return true;
+}
+
+function validateAsset(value: unknown): true | string {
+  const v = String(value ?? '').trim();
+  if (!ASSET_FORMAT.test(v)) return "Use 'XLM' or 'CODE:ISSUER'";
+  return true;
+}
+
+function validatePassword(value: unknown): true | string {
+  const v = String(value ?? '');
+  if (v.length < 8) return 'Password must be at least 8 characters';
+  return true;
+}
+
+function validateMemo(value: unknown): true | string {
+  const v = String(value ?? '');
+  if (Buffer.byteLength(v, 'utf8') > 28) return 'Memo must be 28 bytes or fewer (UTF-8)';
+  return true;
+}
+
+function networkFlag(network: unknown): string[] {
+  return network === 'mainnet' ? ['--mainnet'] : ['--testnet'];
+}
+
+function pushFlag(out: string[], flag: string, value: unknown): void {
+  if (value === undefined || value === null) return;
+  const str = String(value).trim();
+  if (!str) return;
+  out.push(flag, str);
+}
+
+export const createWalletFlow: PromptFlow = {
+  id: 'wallet:create',
+  title: '🔑 Create Wallet',
+  description: 'Generate a new keypair and store it locally',
+  steps: [
+    {
+      name: 'name',
+      message: 'Wallet name:',
+      type: 'input',
+      default: 'default',
+      validate: validateWalletName,
+    },
+    {
+      name: 'network',
+      message: 'Network:',
+      type: 'list',
+      choices: [
+        { name: 'Testnet', value: 'testnet', default: true },
+        { name: 'Mainnet', value: 'mainnet' },
+      ],
+      default: 'testnet',
+    },
+    {
+      name: 'encrypt',
+      message: 'Encrypt the secret key with a password?',
+      type: 'confirm',
+      default: true,
+    },
+    {
+      name: 'password',
+      message: 'Password (min 8 chars):',
+      type: 'password',
+      when: (a) => a.encrypt === true,
+      validate: validatePassword,
+    },
+  ],
+  buildArgs: (a) => {
+    const args = ['wallet', 'create', '--name', String(a.name), ...networkFlag(a.network)];
+    if (a.encrypt) {
+      args.push('--encrypt');
+      pushFlag(args, '--password', a.password);
+    }
+    return args;
+  },
+  summarize: (a): SummaryLine[] => [
+    { label: 'Name', value: String(a.name) },
+    { label: 'Network', value: String(a.network) },
+    { label: 'Encrypted', value: a.encrypt ? 'yes' : 'no' },
+  ],
+};
+
+export const importWalletFlow: PromptFlow = {
+  id: 'wallet:import',
+  title: '📥 Import Wallet',
+  description: 'Import an existing wallet from its secret key',
+  steps: [
+    {
+      name: 'name',
+      message: 'Wallet name:',
+      type: 'input',
+      default: 'imported-wallet',
+      validate: validateWalletName,
+    },
+    {
+      name: 'secretKey',
+      message: 'Secret key (S…):',
+      type: 'password',
+      validate: (v) => (String(v ?? '').trim() ? true : 'Secret key is required'),
+    },
+    {
+      name: 'network',
+      message: 'Network:',
+      type: 'list',
+      choices: [
+        { name: 'Testnet', value: 'testnet', default: true },
+        { name: 'Mainnet', value: 'mainnet' },
+      ],
+      default: 'testnet',
+    },
+    {
+      name: 'encrypt',
+      message: 'Encrypt at rest with a password?',
+      type: 'confirm',
+      default: true,
+    },
+    {
+      name: 'password',
+      message: 'Password (min 8 chars):',
+      type: 'password',
+      when: (a) => a.encrypt === true,
+      validate: validatePassword,
+    },
+  ],
+  buildArgs: (a) => {
+    const args = [
+      'wallet',
+      'import',
+      String(a.secretKey),
+      '--name',
+      String(a.name),
+      ...networkFlag(a.network),
+    ];
+    if (a.encrypt) {
+      args.push('--encrypt');
+      pushFlag(args, '--password', a.password);
+    }
+    return args;
+  },
+  summarize: (a): SummaryLine[] => [
+    { label: 'Name', value: String(a.name) },
+    { label: 'Network', value: String(a.network) },
+    { label: 'Encrypted', value: a.encrypt ? 'yes' : 'no' },
+    { label: 'Secret', value: '••• (hidden)' },
+  ],
+};
+
+export const listWalletsFlow: PromptFlow = {
+  id: 'wallet:list',
+  title: '📒 List Wallets',
+  description: 'Show all wallets stored locally',
+  steps: [],
+  buildArgs: () => ['wallet', 'list'],
+};
+
+export const walletInfoFlow: PromptFlow = {
+  id: 'wallet:info',
+  title: 'ℹ️  Wallet Info',
+  description: 'Show details of a stored wallet or any Stellar address',
+  steps: [
+    {
+      name: 'target',
+      message: 'Wallet name or public key:',
+      type: 'input',
+      validate: (v) => (String(v ?? '').trim() ? true : 'Target is required'),
+    },
+  ],
+  buildArgs: (a) => ['wallet', 'info', String(a.target)],
+  summarize: (a) => [{ label: 'Target', value: String(a.target) }],
+};
+
+export const balanceWalletFlow: PromptFlow = {
+  id: 'wallet:balance',
+  title: '💰 Wallet Balance',
+  description: 'Show XLM and asset balances for an address',
+  steps: [
+    {
+      name: 'mode',
+      message: 'How do you want to look it up?',
+      type: 'list',
+      choices: [
+        { name: 'By stored wallet name', value: 'name', default: true },
+        { name: 'By public address', value: 'address' },
+      ],
+      default: 'name',
+    },
+    {
+      name: 'wallet',
+      message: 'Wallet name:',
+      type: 'input',
+      when: (a) => a.mode === 'name',
+      validate: validateWalletName,
+    },
+    {
+      name: 'address',
+      message: 'Stellar public key (G…):',
+      type: 'input',
+      when: (a) => a.mode === 'address',
+      validate: validatePublicKey,
+    },
+    {
+      name: 'network',
+      message: 'Network:',
+      type: 'list',
+      choices: [
+        { name: 'Testnet', value: 'testnet', default: true },
+        { name: 'Mainnet', value: 'mainnet' },
+      ],
+      default: 'testnet',
+    },
+  ],
+  buildArgs: (a) => {
+    const args = ['wallet', 'balance'];
+    if (a.mode === 'address') args.push(String(a.address));
+    if (a.mode === 'name') args.push('--name', String(a.wallet));
+    args.push('--network', String(a.network));
+    return args;
+  },
+  summarize: (a) => {
+    const lines: SummaryLine[] = [{ label: 'Network', value: String(a.network) }];
+    if (a.mode === 'name') lines.unshift({ label: 'Wallet', value: String(a.wallet) });
+    else lines.unshift({ label: 'Address', value: String(a.address) });
+    return lines;
+  },
+};
+
+export const fundWalletFlow: PromptFlow = {
+  id: 'wallet:fund',
+  title: '🚰 Fund Wallet (testnet)',
+  description: 'Request XLM from the Stellar friendbot for a testnet wallet',
+  steps: [
+    {
+      name: 'name',
+      message: 'Wallet name to fund:',
+      type: 'input',
+      validate: validateWalletName,
+    },
+    {
+      name: 'amount',
+      message: 'Amount (XLM):',
+      type: 'input',
+      default: '10000',
+      validate: validateAmount,
+    },
+  ],
+  buildArgs: (a) => ['wallet', 'fund', '--name', String(a.name), '--amount', String(a.amount)],
+  summarize: (a) => [
+    { label: 'Wallet', value: String(a.name) },
+    { label: 'Amount', value: `${a.amount} XLM` },
+  ],
+};
+
+export const sendPaymentFlow: PromptFlow = {
+  id: 'wallet:send',
+  title: '💸 Send Payment',
+  description: 'Transfer XLM or an issued asset from a stored wallet',
+  destructive: true,
+  steps: [
+    {
+      name: 'from',
+      message: 'Source wallet (stored locally):',
+      type: 'input',
+      validate: validateWalletName,
+    },
+    {
+      name: 'to',
+      message: 'Destination public key (G…):',
+      type: 'input',
+      validate: validatePublicKey,
+    },
+    {
+      name: 'asset',
+      message: "Asset ('XLM' or 'CODE:ISSUER'):",
+      type: 'input',
+      default: 'XLM',
+      validate: validateAsset,
+    },
+    {
+      name: 'amount',
+      message: 'Amount:',
+      type: 'input',
+      validate: validateAmount,
+    },
+    {
+      name: 'memo',
+      message: 'Memo (optional, max 28 bytes):',
+      type: 'input',
+      default: '',
+      validate: validateMemo,
+    },
+    {
+      name: 'network',
+      message: 'Network override (leave on wallet default if unsure):',
+      type: 'list',
+      choices: [
+        { name: 'Use wallet default', value: '', default: true },
+        { name: 'Testnet', value: 'testnet' },
+        { name: 'Mainnet', value: 'mainnet' },
+      ],
+      default: '',
+    },
+  ],
+  buildArgs: (a) => {
+    const args = [
+      'wallet',
+      'send',
+      String(a.from),
+      String(a.to),
+      String(a.amount),
+      String(a.asset),
+    ];
+    pushFlag(args, '--memo', a.memo);
+    pushFlag(args, '--network', a.network);
+    return args;
+  },
+  summarize: (a) => [
+    { label: 'From', value: String(a.from) },
+    { label: 'To', value: String(a.to) },
+    { label: 'Amount', value: `${a.amount} ${a.asset}` },
+    { label: 'Memo', value: String(a.memo || '—') },
+    { label: 'Network', value: String(a.network || 'wallet default') },
+  ],
+};
+
+export const WALLET_PROMPTS: Record<string, PromptFlow> = {
+  [createWalletFlow.id]: createWalletFlow,
+  [importWalletFlow.id]: importWalletFlow,
+  [listWalletsFlow.id]: listWalletsFlow,
+  [walletInfoFlow.id]: walletInfoFlow,
+  [balanceWalletFlow.id]: balanceWalletFlow,
+  [fundWalletFlow.id]: fundWalletFlow,
+  [sendPaymentFlow.id]: sendPaymentFlow,
+};

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -23,6 +23,7 @@ import {
   createInteractiveCommand,
   launchInteractiveMode,
   shouldLaunchInteractive,
+  attachMenuCommand,
 } from './commands/interactive/index.js';
 
 const program = new Command();
@@ -40,8 +41,9 @@ program.addCommand(protocolCommand);
 program.addCommand(blendCommand);
 program.addCommand(defiCommand);
 
-// Register interactive command
+// Register interactive command (raw REPL) and the guided menu command
 program.addCommand(createInteractiveCommand(program));
+attachMenuCommand(program);
 
 // Watch command
 import { watchCommand } from './commands/watch/index.js';
@@ -134,8 +136,10 @@ program
     console.log(chalk.blue('🌟 Galaxy DevKit CLI'));
     console.log(chalk.gray('Build Stellar applications with ease\n'));
     console.log(chalk.yellow('Available commands:'));
-    console.log(chalk.gray('  galaxy                 Launch interactive mode'));
-    console.log(chalk.gray('  galaxy interactive     Launch interactive mode (explicit)'));
+    console.log(chalk.gray('  galaxy                 Launch interactive REPL (raw)'));
+    console.log(chalk.gray('  galaxy -i              Launch guided menu (recommended for new users)'));
+    console.log(chalk.gray('  galaxy menu            Launch guided menu (explicit)'));
+    console.log(chalk.gray('  galaxy interactive     Launch interactive REPL (explicit)'));
     console.log(chalk.gray('  galaxy create <name>   Create new project'));
     console.log(chalk.gray('  galaxy init            Initialize in current dir'));
     console.log(chalk.gray('  galaxy build           Build project'));
@@ -150,15 +154,26 @@ program
     console.log(chalk.gray('\nRun galaxy <command> --help for detailed command help.'));
   });
 
+function wantsGuidedMenu(argv: string[]): boolean {
+  const args = argv.slice(2);
+  return args.some((a) => a === '-i' || a === '--interactive');
+}
+
 // Main execution
 async function main(): Promise<void> {
-  // Check if we should launch interactive mode
+  // `galaxy -i` and `--interactive` launch the guided menu — the experience
+  // promised by the AC: "All major operations available through prompts".
+  if (wantsGuidedMenu(process.argv)) {
+    await program.parseAsync(['node', 'galaxy', 'menu']);
+    return;
+  }
+
+  // No arguments at all → raw REPL (back-compat with existing usage and tests).
   if (shouldLaunchInteractive(process.argv)) {
     await launchInteractiveMode(program);
     return;
   }
 
-  // Parse command line arguments normally
   await program.parseAsync();
 }
 


### PR DESCRIPTION
  # Pull Request: Feat/add interactive mode with prompts

  ## 📋 Description

  Adds an interactive guided-prompt mode to the Galaxy CLI, fulfilling issue
  #270. Introduces a declarative `PromptFlow` system that orchestrates
  step-by-step inquirer prompts with real-time validation, a summary screen,
  and a confirmation gate before destructive actions. Ships seven wallet
  flows and four DeFi flows, and wires `galaxy -i` / `--interactive` to
  launch the guided menu.

  Also fixes a pre-existing bug in `commands/interactive/menus.ts`:
  `ROOT_MENU` referenced commands that do not exist in the program
  (`account info`, `payment send`, `network switch`, `defi add-liquidity`,
  `oracle assets`). The menu now points at the real commands and supports
  positional arguments and delegation to `PromptFlow`s.

  ## 🔗 Related Issues

  Closes #270

  ## 🧪 Testing

  - [x] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [ ] Manual testing completed
  - [x] All tests passing locally

  `npx jest __tests__/interactive` → **8 suites, 159 tests, 0 fails** (45
  new tests across `runner`, `wallet-prompts`, `defi-prompts`, `menus`).
  Pre-existing suites (`repl`, `session`, `history`, `autocomplete`) still
  green — no regressions.

  Type-check: the new files have zero TS errors. Pre-existing errors in
  `blend/`, `protocol/`, `utils/protocol-registry.ts`, `wallet/info.ts`
  remain — they exist on `main` and are out of scope for this PR.

  ## 📚 Documentation Updates (Required)

  - [ ] Updated `docs/AI.md` with new patterns/examples
  - [ ] Updated API reference in relevant package README
  - [ ] Added/updated code examples
  - [ ] Updated ARCHITECTURE.md (if architecture changed)
  - [x] Added inline JSDoc/TSDoc comments
  - [ ] Updated ROADMAP.md progress (mark issue as completed)

  ### Documentation Checklist by Component:

  #### If you modified `tools/cli/`:
  - [ ] Updated CLI command documentation
  - [ ] Added command examples to README
  - [x] Updated help text in command definitions

  (Other component checklists do not apply — only `tools/cli/` was
  modified.)

  ## 🤖 AI-Friendly Documentation

  ### New Files Created

  tools/cli/src/commands/interactive/prompts/index.ts
      PromptFlow types, runner (runPromptFlow), and combined registry.
  tools/cli/src/commands/interactive/prompts/wallet-prompts.ts
      Seven wallet flows: create, import, list, info, balance, fund, send.
      send is marked destructive so the runner shows a confirm gate.
  tools/cli/src/commands/interactive/prompts/defi-prompts.ts
      Four DeFi flows: blend supply, blend borrow, swap, pools list.
      Transaction-emitting flows are destructive and forward -y downstream.
  tools/cli/tests/interactive/prompts/runner.test.ts
      12 tests for the orchestrator (validation, conditional when,
      destructive confirm gate, Ctrl+C abort, executor errors).
  tools/cli/tests/interactive/prompts/wallet-prompts.test.ts
      22 tests verifying validators and buildArgs argv shape.
  tools/cli/tests/interactive/prompts/defi-prompts.test.ts
      11 tests verifying validators and buildArgs argv shape.
  tools/cli/tests/interactive/menus.test.ts
      Regression tests that walk ROOT_MENU and assert every entry has a
      usable action and every promptFlow id resolves in PROMPT_FLOWS.

  ### Key Functions/Classes Added

  ```typescript
  export interface PromptFlow {
    id: string;
    title: string;
    description: string;
    destructive?: boolean;
    steps: PromptStep[];
    buildArgs: (answers: Record<string, unknown>) => string[];
    summarize?: (answers: Record<string, unknown>) => SummaryLine[];
  }

  export interface PromptStep {
    name: string;
    message: string;
    type: 'input' | 'password' | 'number' | 'confirm' | 'list' | 'checkbox';
    default?: string | number | boolean;
    choices?: PromptChoice[];
    validate?: (v: unknown) => boolean | string | Promise<boolean | string>;
    when?: (answers: Record<string, unknown>) => boolean;
    mask?: string;
  }

  export type PromptExecutor = (argv: string[]) => Promise<void>;

  export async function runPromptFlow(
    flow: PromptFlow,
    executor: PromptExecutor,
    options?: { prompt?: PromptFn; yes?: boolean; silent?: boolean },
  ): Promise<PromptFlowResult>;

  export const PROMPT_FLOWS: Record<string, PromptFlow>;
  export const WALLET_PROMPTS: Record<string, PromptFlow>;
  export const DEFI_PROMPTS: Record<string, PromptFlow>;

  MenuParam and MenuEntry gained two fields:

  interface MenuParam { /* … */ positional?: boolean; }
  interface MenuEntry { /* … */ promptFlow?: string; }
 ```
##  Patterns Used

  - Declarative flow definition: every guided flow is a value, not a
  function. Steps describe what to ask; buildArgs describes how to
  translate answers into argv. This keeps validation, conditional logic
  and command-shape co-located and unit-testable without spawning a CLI.
  - Reuse, don't duplicate: flows execute by emitting an argv array
  that is fed back into the existing Commander program. Business logic
  in each wallet/* and defi/* command is not duplicated.
  - Destructive gate: destructive: true is the single source of
  truth for "ask Proceed? before executing." Read-only flows (list,
  info, balance, pools) deliberately skip the prompt so they
  don't add friction.
  - Forward -y downstream: once the runner has confirmation, it
  appends -y to the argv it builds for defi subcommands so the
  underlying command does not re-prompt the user.
  - Positional args in menus: real commands like
  wallet send <from> <to> <amount> <asset> are positional. Marking a
  MenuParam with positional: true makes buildCommandArgs emit it
  in declaration order before any flag.

##  📸 Screenshots (if applicable)

  N/A — terminal-only CLI feature.

##  ⚠️ Breaking Changes

  - [x] No breaking changes
  - [ ] Breaking changes documented in CHANGELOG.md

  galaxy with no arguments still launches the raw REPL exactly as
  before (preserves repl.test.ts expectations). The new entry points
  (galaxy -i, galaxy --interactive, galaxy menu) are additive.

##  🔄 Deployment Notes

  None. No new runtime dependencies — inquirer, chalk and ora were
  already present in tools/cli/package.json.

#  ✅ Final Checklist

  - [x] Code follows project style guidelines
  - [x] Self-review completed
  - [x] No console.log or debug code left
  - [x] Error handling implemented
  - [x] Performance considered
  - [x] Security reviewed
  - [ ] Documentation updated (required)
  - [ ] ROADMAP.md updated with progress

  ---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guided interactive menu flows for wallet and DeFi actions, with clearer prompts, summaries, and safer confirmation handling for destructive actions.
  * Updated CLI help and startup behavior to highlight a new guided menu mode alongside the existing raw interactive mode.
* **Bug Fixes**
  * Improved menu consistency and validation, including better command argument handling, required menu actions, and stricter input checks for interactive flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->