### PR TITLE
feat(api): add compliance reporting tools for regulatory requirements

### DIFF
--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -441,6 +441,133 @@ socket.on('automation:executed', (result) => console.log(result));
 
 ---
 
+## Compliance reporting
+
+Regulatory-ready reports generated from audit log data (Issue #335 / Roadmap #67). All endpoints require authentication.
+
+Base path: `/api/v1/compliance`
+
+### Report types
+
+| Type | Description |
+|------|-------------|
+| `transaction` | On-chain transactions (counterparties, amounts, timestamps) |
+| `defi_activity` | Lending/borrowing, liquidity, swaps |
+| `user_activity` | Login history, permission changes, wallet operations |
+| `risk_exposure` | DeFi risk signals, collateral ratios, liquidation-related events |
+
+### Export formats
+
+`json`, `csv`, `pdf` (minimal text PDF, no headless browser)
+
+### GET /api/v1/compliance/templates
+
+List available report templates and column schemas.
+
+**Response 200**
+
+```json
+{
+  "templates": [
+    {
+      "type": "transaction",
+      "name": "Transaction Report",
+      "description": "...",
+      "columns": ["timestamp", "action", "resource", "counterparty", "amount", "asset", "success", "txHash"]
+    }
+  ]
+}
+```
+
+### POST /api/v1/compliance/reports
+
+Generate an on-demand report. Requests are **idempotent**: the same user, type, period, format, and redaction flag returns the existing completed report.
+
+**Request body**
+
+```json
+{
+  "reportType": "transaction",
+  "format": "csv",
+  "from": "2026-07-01T00:00:00.000Z",
+  "to": "2026-07-31T23:59:59.999Z",
+  "redactPii": true
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `reportType` | string | Yes | One of the four report types |
+| `format` | string | No | `json` (default), `csv`, or `pdf` |
+| `from` | ISO datetime | Yes | Period start |
+| `to` | ISO datetime | Yes | Period end (`>= from`) |
+| `redactPii` | boolean | No | Default `true` — redacts emails/IPs |
+
+**Response 200** — completed report (includes `content`)
+
+### GET /api/v1/compliance/reports
+
+List reports for the authenticated user.
+
+**Query:** `reportType?`, `limit` (default 50), `offset` (default 0)
+
+### GET /api/v1/compliance/reports/:id
+
+Fetch one report including stored export content.
+
+### GET /api/v1/compliance/reports/:id/download
+
+Download raw export body with appropriate `Content-Type` and `Content-Disposition`.
+
+### POST /api/v1/compliance/schedules
+
+Create a scheduled report job (`daily` | `weekly` | `monthly`). The compliance worker process evaluates due schedules and generates idempotent period reports.
+
+**Request body**
+
+```json
+{
+  "reportType": "user_activity",
+  "format": "json",
+  "cadence": "weekly",
+  "redactPii": true
+}
+```
+
+### GET /api/v1/compliance/schedules
+
+List schedules for the authenticated user.
+
+### DELETE /api/v1/compliance/schedules/:id
+
+Delete a schedule owned by the authenticated user.
+
+### Worker
+
+Scheduled generation runs inside the REST package worker entrypoint:
+
+```bash
+npm run worker --workspace=@galaxy-kj/api-rest
+```
+
+Environment:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `COMPLIANCE_SCHEDULER_INTERVAL_MS` | `60000` | Poll interval |
+| `COMPLIANCE_SCHEDULER_BATCH_SIZE` | `50` | Max due schedules per tick |
+
+### Data model
+
+Supabase migration `20260717120000_compliance_reports.sql` creates:
+
+- `compliance_reports` — generated report artifacts + idempotency key
+- `compliance_schedules` — recurring jobs with `next_run_at`
+
+Primary source data: `audit_logs` via `AuditLogger.query`.
+
+---
+
 ## Related docs
 
 - [Getting Started](../guides/getting-started.md)

--- a/packages/api/rest/src/index.ts
+++ b/packages/api/rest/src/index.ts
@@ -37,6 +37,7 @@ import { setupTransactionMonitoringRoutes } from './routes/monitoring/transactio
 
 import { setupApprovalsRoutes } from './routes/approvals';
 import { setupTeamRoutes } from './routes/teams';
+import { setupComplianceRoutes } from './routes/compliance';
 import { globalCache } from '@galaxy-kj/core-stellar-sdk';
 
 /**
@@ -158,6 +159,8 @@ class RestApiServer {
     // Organization team management
     router.use('/teams', setupTeamRoutes());
 
+    // Compliance reporting tools (Issue #335 / Roadmap #67)
+    router.use('/compliance', setupComplianceRoutes());
 
     // Add more routes here as needed
 

--- a/packages/api/rest/src/repositories/compliance-report.repository.ts
+++ b/packages/api/rest/src/repositories/compliance-report.repository.ts
@@ -1,0 +1,317 @@
+/**
+ * @fileoverview Persistence for compliance_reports and compliance_schedules.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-17
+ */
+
+import { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseClient } from '../utils/supabase';
+import {
+  ComplianceError,
+  ComplianceReportRecord,
+  ComplianceSchedule,
+  CreateScheduleInput,
+  ReportFormat,
+  ReportStatus,
+  ReportType,
+  ScheduleCadence,
+} from '../types/compliance-types';
+import { computeNextRunAt } from '../services/compliance/schedule-utils';
+
+interface ReportRow {
+  id: string;
+  user_id: string;
+  report_type: ReportType;
+  format: ReportFormat;
+  status: ReportStatus;
+  period_start: string;
+  period_end: string;
+  schedule_id: string | null;
+  idempotency_key: string;
+  redact_pii: boolean;
+  row_count: number;
+  content: string | null;
+  content_type: string | null;
+  error_message: string | null;
+  created_at: string;
+  completed_at: string | null;
+}
+
+interface ScheduleRow {
+  id: string;
+  user_id: string;
+  report_type: ReportType;
+  format: ReportFormat;
+  cadence: ScheduleCadence;
+  redact_pii: boolean;
+  enabled: boolean;
+  next_run_at: string;
+  last_run_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+const REPORTS_TABLE = 'compliance_reports';
+const SCHEDULES_TABLE = 'compliance_schedules';
+
+function rowToReport(row: ReportRow): ComplianceReportRecord {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    reportType: row.report_type,
+    format: row.format,
+    status: row.status,
+    periodStart: new Date(row.period_start),
+    periodEnd: new Date(row.period_end),
+    scheduleId: row.schedule_id,
+    idempotencyKey: row.idempotency_key,
+    redactPii: row.redact_pii,
+    rowCount: row.row_count,
+    content: row.content,
+    contentType: row.content_type,
+    errorMessage: row.error_message,
+    createdAt: new Date(row.created_at),
+    completedAt: row.completed_at ? new Date(row.completed_at) : null,
+  };
+}
+
+function rowToSchedule(row: ScheduleRow): ComplianceSchedule {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    reportType: row.report_type,
+    format: row.format,
+    cadence: row.cadence,
+    redactPii: row.redact_pii,
+    enabled: row.enabled,
+    nextRunAt: new Date(row.next_run_at),
+    lastRunAt: row.last_run_at ? new Date(row.last_run_at) : null,
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at),
+  };
+}
+
+export class ComplianceReportRepository {
+  private client: SupabaseClient;
+
+  constructor(client?: SupabaseClient) {
+    this.client = client ?? getSupabaseClient();
+  }
+
+  async findByIdempotencyKey(key: string): Promise<ComplianceReportRecord | null> {
+    const { data, error } = await this.client
+      .from(REPORTS_TABLE)
+      .select('*')
+      .eq('idempotency_key', key)
+      .maybeSingle();
+
+    if (error) {
+      throw new ComplianceError('REPOSITORY_ERROR', error.message, 500);
+    }
+    return data ? rowToReport(data as ReportRow) : null;
+  }
+
+  async createPending(input: {
+    userId: string;
+    reportType: ReportType;
+    format: ReportFormat;
+    periodStart: Date;
+    periodEnd: Date;
+    idempotencyKey: string;
+    redactPii: boolean;
+    scheduleId?: string | null;
+  }): Promise<ComplianceReportRecord> {
+    const { data, error } = await this.client
+      .from(REPORTS_TABLE)
+      .insert({
+        user_id: input.userId,
+        report_type: input.reportType,
+        format: input.format,
+        status: 'pending',
+        period_start: input.periodStart.toISOString(),
+        period_end: input.periodEnd.toISOString(),
+        schedule_id: input.scheduleId ?? null,
+        idempotency_key: input.idempotencyKey,
+        redact_pii: input.redactPii,
+        row_count: 0,
+      })
+      .select('*')
+      .single();
+
+    if (error) {
+      throw new ComplianceError('REPOSITORY_ERROR', error.message, 500);
+    }
+    return rowToReport(data as ReportRow);
+  }
+
+  async markCompleted(
+    id: string,
+    userId: string,
+    update: {
+      content: string;
+      contentType: string;
+      rowCount: number;
+    }
+  ): Promise<ComplianceReportRecord> {
+    const { data, error } = await this.client
+      .from(REPORTS_TABLE)
+      .update({
+        status: 'completed',
+        content: update.content,
+        content_type: update.contentType,
+        row_count: update.rowCount,
+        completed_at: new Date().toISOString(),
+        error_message: null,
+      })
+      .eq('id', id)
+      .eq('user_id', userId)
+      .select('*')
+      .single();
+
+    if (error) {
+      throw new ComplianceError('REPOSITORY_ERROR', error.message, 500);
+    }
+    return rowToReport(data as ReportRow);
+  }
+
+  async markFailed(id: string, userId: string, message: string): Promise<void> {
+    const { error } = await this.client
+      .from(REPORTS_TABLE)
+      .update({
+        status: 'failed',
+        error_message: message,
+        completed_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+      .eq('user_id', userId);
+
+    if (error) {
+      throw new ComplianceError('REPOSITORY_ERROR', error.message, 500);
+    }
+  }
+
+  async getForUser(id: string, userId: string): Promise<ComplianceReportRecord> {
+    const { data, error } = await this.client
+      .from(REPORTS_TABLE)
+      .select('*')
+      .eq('id', id)
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (error) {
+      throw new ComplianceError('REPOSITORY_ERROR', error.message, 500);
+    }
+    if (!data) {
+      throw new ComplianceError('NOT_FOUND', 'Report not found', 404);
+    }
+    return rowToReport(data as ReportRow);
+  }
+
+  async listForUser(
+    userId: string,
+    opts: { reportType?: ReportType; limit: number; offset: number }
+  ): Promise<ComplianceReportRecord[]> {
+    let query = this.client
+      .from(REPORTS_TABLE)
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .range(opts.offset, opts.offset + opts.limit - 1);
+
+    if (opts.reportType) {
+      query = query.eq('report_type', opts.reportType);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      throw new ComplianceError('REPOSITORY_ERROR', error.message, 500);
+    }
+    return (data || []).map((row) => rowToReport(row as ReportRow));
+  }
+
+  async createSchedule(userId: string, input: CreateScheduleInput): Promise<ComplianceSchedule> {
+    const nextRunAt = computeNextRunAt(input.cadence);
+    const { data, error } = await this.client
+      .from(SCHEDULES_TABLE)
+      .insert({
+        user_id: userId,
+        report_type: input.reportType,
+        format: input.format,
+        cadence: input.cadence,
+        redact_pii: input.redactPii ?? true,
+        enabled: true,
+        next_run_at: nextRunAt.toISOString(),
+      })
+      .select('*')
+      .single();
+
+    if (error) {
+      throw new ComplianceError('REPOSITORY_ERROR', error.message, 500);
+    }
+    return rowToSchedule(data as ScheduleRow);
+  }
+
+  async listSchedules(userId: string): Promise<ComplianceSchedule[]> {
+    const { data, error } = await this.client
+      .from(SCHEDULES_TABLE)
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      throw new ComplianceError('REPOSITORY_ERROR', error.message, 500);
+    }
+    return (data || []).map((row) => rowToSchedule(row as ScheduleRow));
+  }
+
+  async deleteSchedule(id: string, userId: string): Promise<void> {
+    const { data, error } = await this.client
+      .from(SCHEDULES_TABLE)
+      .delete()
+      .eq('id', id)
+      .eq('user_id', userId)
+      .select('id')
+      .maybeSingle();
+
+    if (error) {
+      throw new ComplianceError('REPOSITORY_ERROR', error.message, 500);
+    }
+    if (!data) {
+      throw new ComplianceError('NOT_FOUND', 'Schedule not found', 404);
+    }
+  }
+
+  async listDueSchedules(now: Date = new Date(), limit = 50): Promise<ComplianceSchedule[]> {
+    const { data, error } = await this.client
+      .from(SCHEDULES_TABLE)
+      .select('*')
+      .eq('enabled', true)
+      .lte('next_run_at', now.toISOString())
+      .order('next_run_at', { ascending: true })
+      .limit(limit);
+
+    if (error) {
+      throw new ComplianceError('REPOSITORY_ERROR', error.message, 500);
+    }
+    return (data || []).map((row) => rowToSchedule(row as ScheduleRow));
+  }
+
+  async markScheduleRun(
+    id: string,
+    nextRunAt: Date,
+    lastRunAt: Date = new Date()
+  ): Promise<void> {
+    const { error } = await this.client
+      .from(SCHEDULES_TABLE)
+      .update({
+        next_run_at: nextRunAt.toISOString(),
+        last_run_at: lastRunAt.toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', id);
+
+    if (error) {
+      throw new ComplianceError('REPOSITORY_ERROR', error.message, 500);
+    }
+  }
+}

--- a/packages/api/rest/src/routes/compliance/__tests__/compliance.routes.test.ts
+++ b/packages/api/rest/src/routes/compliance/__tests__/compliance.routes.test.ts
@@ -1,0 +1,154 @@
+import express from 'express';
+import request from 'supertest';
+import { setupComplianceRoutes } from '../index';
+import { ComplianceError } from '../../../types/compliance-types';
+
+jest.mock('../../../middleware/auth', () => ({
+  authenticate: () => (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.user = {
+      userId: 'user-1',
+      email: 'user@example.com',
+    } as never;
+    next();
+  },
+}));
+
+jest.mock('../../../middleware/audit', () => ({
+  auditRequest: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+    next(),
+}));
+
+function buildApp(engine: unknown, repository: unknown = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/compliance', setupComplianceRoutes(engine as never, repository as never));
+  app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(500).json({ error: { code: 'INTERNAL', message: err.message, details: {} } });
+  });
+  return app;
+}
+
+describe('compliance routes', () => {
+  const sampleReport = {
+    id: 'rep-1',
+    userId: 'user-1',
+    reportType: 'transaction' as const,
+    format: 'json' as const,
+    status: 'completed' as const,
+    periodStart: new Date('2026-07-01T00:00:00.000Z'),
+    periodEnd: new Date('2026-07-31T23:59:59.999Z'),
+    scheduleId: null,
+    idempotencyKey: 'key',
+    redactPii: true,
+    rowCount: 1,
+    content: '{"rows":[]}',
+    contentType: 'application/json',
+    errorMessage: null,
+    createdAt: new Date('2026-07-17T00:00:00.000Z'),
+    completedAt: new Date('2026-07-17T00:00:01.000Z'),
+  };
+
+  it('lists templates', async () => {
+    const engine = {
+      listTemplates: jest.fn().mockReturnValue([
+        { type: 'transaction', name: 'Transaction Report', description: 'd', columns: [] },
+      ]),
+    };
+    const res = await request(buildApp(engine)).get('/api/v1/compliance/templates');
+    expect(res.status).toBe(200);
+    expect(res.body.templates).toHaveLength(1);
+  });
+
+  it('generates a report on demand', async () => {
+    const engine = {
+      generate: jest.fn().mockResolvedValue(sampleReport),
+      listTemplates: jest.fn(),
+    };
+    const res = await request(buildApp(engine))
+      .post('/api/v1/compliance/reports')
+      .send({
+        reportType: 'transaction',
+        format: 'json',
+        from: '2026-07-01T00:00:00.000Z',
+        to: '2026-07-31T23:59:59.999Z',
+        redactPii: true,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.report.id).toBe('rep-1');
+    expect(engine.generate).toHaveBeenCalled();
+  });
+
+  it('rejects invalid generate body', async () => {
+    const engine = { generate: jest.fn() };
+    const res = await request(buildApp(engine))
+      .post('/api/v1/compliance/reports')
+      .send({ reportType: 'nope' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('lists reports', async () => {
+    const engine = {
+      listReports: jest.fn().mockResolvedValue([sampleReport]),
+    };
+    const res = await request(buildApp(engine)).get('/api/v1/compliance/reports');
+    expect(res.status).toBe(200);
+    expect(res.body.reports).toHaveLength(1);
+    expect(res.body.reports[0].content).toBeUndefined();
+  });
+
+  it('downloads completed report content', async () => {
+    const engine = {
+      getReport: jest.fn().mockResolvedValue(sampleReport),
+    };
+    const res = await request(buildApp(engine)).get('/api/v1/compliance/reports/rep-1/download');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    expect(res.text).toContain('rows');
+  });
+
+  it('maps compliance errors to http status', async () => {
+    const engine = {
+      getReport: jest
+        .fn()
+        .mockRejectedValue(new ComplianceError('NOT_FOUND', 'Report not found', 404)),
+    };
+    const res = await request(buildApp(engine)).get('/api/v1/compliance/reports/missing');
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('creates and lists schedules', async () => {
+    const engine = {};
+    const repository = {
+      createSchedule: jest.fn().mockResolvedValue({
+        id: 'sched-1',
+        userId: 'user-1',
+        reportType: 'user_activity',
+        format: 'csv',
+        cadence: 'weekly',
+        redactPii: true,
+        enabled: true,
+        nextRunAt: new Date('2026-07-24T00:00:00.000Z'),
+        lastRunAt: null,
+        createdAt: new Date('2026-07-17T00:00:00.000Z'),
+        updatedAt: new Date('2026-07-17T00:00:00.000Z'),
+      }),
+      listSchedules: jest.fn().mockResolvedValue([]),
+    };
+
+    const app = buildApp(engine, repository);
+    const createRes = await request(app).post('/api/v1/compliance/schedules').send({
+      reportType: 'user_activity',
+      format: 'csv',
+      cadence: 'weekly',
+    });
+    expect(createRes.status).toBe(201);
+    expect(createRes.body.schedule.id).toBe('sched-1');
+
+    const listRes = await request(app).get('/api/v1/compliance/schedules');
+    expect(listRes.status).toBe(200);
+    expect(listRes.body.schedules).toEqual([]);
+  });
+});

--- a/packages/api/rest/src/routes/compliance/index.ts
+++ b/packages/api/rest/src/routes/compliance/index.ts
@@ -1,0 +1,257 @@
+/**
+ * @fileoverview REST routes for compliance reporting (Issue #335 / Roadmap #67).
+ * @author Galaxy DevKit Team
+ * @since 2026-07-17
+ */
+
+import express, { NextFunction, Request, Response } from 'express';
+import { authenticate } from '../../middleware/auth';
+import { auditRequest } from '../../middleware/audit';
+import { validate } from '../../middleware/validate';
+import { ComplianceReportEngine } from '../../services/compliance/report-engine';
+import { ComplianceReportRepository } from '../../repositories/compliance-report.repository';
+import {
+  ComplianceError,
+  ComplianceReportRecord,
+  CreateScheduleInput,
+  GenerateReportInput,
+} from '../../types/compliance-types';
+import {
+  createScheduleSchema,
+  generateReportSchema,
+  listReportsQuerySchema,
+  reportIdParamSchema,
+  scheduleIdParamSchema,
+} from '../../validators/compliance-validators';
+
+function requireUser(req: Request, res: Response): string | null {
+  if (!req.user) {
+    res.status(401).json({
+      error: { code: 'AUTH_ERROR', message: 'Authentication required', details: {} },
+    });
+    return null;
+  }
+  return req.user.userId;
+}
+
+function handleComplianceError(err: unknown, res: Response, next: NextFunction): void {
+  if (err instanceof ComplianceError) {
+    res.status(err.statusCode).json({
+      error: { code: err.code, message: err.message, details: err.details },
+    });
+    return;
+  }
+  next(err);
+}
+
+function serializeReport(report: ComplianceReportRecord, includeContent = false) {
+  return {
+    id: report.id,
+    reportType: report.reportType,
+    format: report.format,
+    status: report.status,
+    periodStart: report.periodStart.toISOString(),
+    periodEnd: report.periodEnd.toISOString(),
+    scheduleId: report.scheduleId,
+    redactPii: report.redactPii,
+    rowCount: report.rowCount,
+    contentType: report.contentType,
+    errorMessage: report.errorMessage,
+    createdAt: report.createdAt.toISOString(),
+    completedAt: report.completedAt ? report.completedAt.toISOString() : null,
+    ...(includeContent ? { content: report.content } : {}),
+  };
+}
+
+export function setupComplianceRoutes(
+  engine: ComplianceReportEngine = new ComplianceReportEngine(),
+  repository: ComplianceReportRepository = new ComplianceReportRepository()
+): express.Router {
+  const router = express.Router();
+
+  router.use(authenticate(), auditRequest());
+
+  // GET /templates — list available report types
+  router.get('/templates', (_req, res) => {
+    res.json({ templates: engine.listTemplates() });
+  });
+
+  // POST /reports — generate on-demand report (idempotent)
+  router.post(
+    '/reports',
+    validate(generateReportSchema, 'body'),
+    async (req, res, next) => {
+      const userId = requireUser(req, res);
+      if (!userId) return;
+      try {
+        const body = req.body as {
+          reportType: GenerateReportInput['reportType'];
+          format: GenerateReportInput['format'];
+          from: Date;
+          to: Date;
+          redactPii: boolean;
+        };
+        const report = await engine.generate(userId, {
+          reportType: body.reportType,
+          format: body.format,
+          from: new Date(body.from),
+          to: new Date(body.to),
+          redactPii: body.redactPii,
+        });
+        res.status(report.status === 'completed' ? 200 : 202).json({
+          report: serializeReport(report, true),
+        });
+      } catch (err) {
+        handleComplianceError(err, res, next);
+      }
+    }
+  );
+
+  // GET /reports — list user reports
+  router.get(
+    '/reports',
+    validate(listReportsQuerySchema, 'query'),
+    async (req, res, next) => {
+      const userId = requireUser(req, res);
+      if (!userId) return;
+      try {
+        const query = req.query as unknown as {
+          reportType?: GenerateReportInput['reportType'];
+          limit: number;
+          offset: number;
+        };
+        const reports = await engine.listReports(userId, {
+          reportType: query.reportType,
+          limit: Number(query.limit),
+          offset: Number(query.offset),
+        });
+        res.json({ reports: reports.map((r) => serializeReport(r, false)) });
+      } catch (err) {
+        handleComplianceError(err, res, next);
+      }
+    }
+  );
+
+  // GET /reports/:id — metadata + content
+  router.get(
+    '/reports/:id',
+    validate(reportIdParamSchema, 'params'),
+    async (req, res, next) => {
+      const userId = requireUser(req, res);
+      if (!userId) return;
+      try {
+        const report = await engine.getReport(userId, req.params.id);
+        res.json({ report: serializeReport(report, true) });
+      } catch (err) {
+        handleComplianceError(err, res, next);
+      }
+    }
+  );
+
+  // GET /reports/:id/download — raw export body
+  router.get(
+    '/reports/:id/download',
+    validate(reportIdParamSchema, 'params'),
+    async (req, res, next) => {
+      const userId = requireUser(req, res);
+      if (!userId) return;
+      try {
+        const report = await engine.getReport(userId, req.params.id);
+        if (report.status !== 'completed' || !report.content || !report.contentType) {
+          res.status(409).json({
+            error: {
+              code: 'REPORT_NOT_READY',
+              message: 'Report is not ready for download',
+              details: { status: report.status },
+            },
+          });
+          return;
+        }
+        res.setHeader('Content-Type', report.contentType);
+        res.setHeader(
+          'Content-Disposition',
+          `attachment; filename="compliance-${report.reportType}-${report.id}.${report.format}"`
+        );
+        res.status(200).send(report.content);
+      } catch (err) {
+        handleComplianceError(err, res, next);
+      }
+    }
+  );
+
+  // POST /schedules — create scheduled generation
+  router.post(
+    '/schedules',
+    validate(createScheduleSchema, 'body'),
+    async (req, res, next) => {
+      const userId = requireUser(req, res);
+      if (!userId) return;
+      try {
+        const body = req.body as CreateScheduleInput;
+        const schedule = await repository.createSchedule(userId, {
+          reportType: body.reportType,
+          format: body.format,
+          cadence: body.cadence,
+          redactPii: body.redactPii,
+        });
+        res.status(201).json({
+          schedule: {
+            id: schedule.id,
+            reportType: schedule.reportType,
+            format: schedule.format,
+            cadence: schedule.cadence,
+            redactPii: schedule.redactPii,
+            enabled: schedule.enabled,
+            nextRunAt: schedule.nextRunAt.toISOString(),
+            lastRunAt: schedule.lastRunAt ? schedule.lastRunAt.toISOString() : null,
+            createdAt: schedule.createdAt.toISOString(),
+          },
+        });
+      } catch (err) {
+        handleComplianceError(err, res, next);
+      }
+    }
+  );
+
+  // GET /schedules
+  router.get('/schedules', async (req, res, next) => {
+    const userId = requireUser(req, res);
+    if (!userId) return;
+    try {
+      const schedules = await repository.listSchedules(userId);
+      res.json({
+        schedules: schedules.map((s) => ({
+          id: s.id,
+          reportType: s.reportType,
+          format: s.format,
+          cadence: s.cadence,
+          redactPii: s.redactPii,
+          enabled: s.enabled,
+          nextRunAt: s.nextRunAt.toISOString(),
+          lastRunAt: s.lastRunAt ? s.lastRunAt.toISOString() : null,
+          createdAt: s.createdAt.toISOString(),
+        })),
+      });
+    } catch (err) {
+      handleComplianceError(err, res, next);
+    }
+  });
+
+  // DELETE /schedules/:id
+  router.delete(
+    '/schedules/:id',
+    validate(scheduleIdParamSchema, 'params'),
+    async (req, res, next) => {
+      const userId = requireUser(req, res);
+      if (!userId) return;
+      try {
+        await repository.deleteSchedule(req.params.id, userId);
+        res.status(204).send();
+      } catch (err) {
+        handleComplianceError(err, res, next);
+      }
+    }
+  );
+
+  return router;
+}

--- a/packages/api/rest/src/services/compliance/__tests__/compliance-report.worker.test.ts
+++ b/packages/api/rest/src/services/compliance/__tests__/compliance-report.worker.test.ts
@@ -1,0 +1,68 @@
+import { ComplianceReportWorker } from '../../../worker/compliance-report.worker';
+import { ComplianceSchedule } from '../../../types/compliance-types';
+
+describe('ComplianceReportWorker', () => {
+  const schedule: ComplianceSchedule = {
+    id: 'sched-1',
+    userId: 'user-1',
+    reportType: 'user_activity',
+    format: 'json',
+    cadence: 'daily',
+    redactPii: true,
+    enabled: true,
+    nextRunAt: new Date('2026-07-17T00:00:00.000Z'),
+    lastRunAt: null,
+    createdAt: new Date('2026-07-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+  };
+
+  it('processes due schedules and advances next_run_at', async () => {
+    const engine = {
+      generate: jest.fn().mockResolvedValue({ id: 'rep-1', status: 'completed' }),
+    };
+    const repository = {
+      listDueSchedules: jest.fn().mockResolvedValue([schedule]),
+      markScheduleRun: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const worker = new ComplianceReportWorker(engine as never, repository as never, {
+      pollIntervalMs: 60_000,
+      batchSize: 10,
+    });
+
+    const now = new Date('2026-07-17T15:00:00.000Z');
+    const processed = await worker.tick(now);
+
+    expect(processed).toBe(1);
+    expect(engine.generate).toHaveBeenCalledWith(
+      'user-1',
+      expect.objectContaining({
+        reportType: 'user_activity',
+        format: 'json',
+        redactPii: true,
+      }),
+      { scheduleId: 'sched-1' }
+    );
+    expect(repository.markScheduleRun).toHaveBeenCalledWith(
+      'sched-1',
+      expect.any(Date),
+      now
+    );
+  });
+
+  it('still advances schedule when generation fails', async () => {
+    const engine = {
+      generate: jest.fn().mockRejectedValue(new Error('boom')),
+    };
+    const repository = {
+      listDueSchedules: jest.fn().mockResolvedValue([schedule]),
+      markScheduleRun: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const worker = new ComplianceReportWorker(engine as never, repository as never);
+    const processed = await worker.tick(new Date('2026-07-17T15:00:00.000Z'));
+
+    expect(processed).toBe(0);
+    expect(repository.markScheduleRun).toHaveBeenCalled();
+  });
+});

--- a/packages/api/rest/src/services/compliance/__tests__/exporters.test.ts
+++ b/packages/api/rest/src/services/compliance/__tests__/exporters.test.ts
@@ -1,0 +1,73 @@
+import { exportCsv, exportJson, exportPdf, exportReport } from '../exporters';
+import { GeneratedReportPayload } from '../../../types/compliance-types';
+
+const samplePayload: GeneratedReportPayload = {
+  reportType: 'transaction',
+  generatedAt: '2026-07-17T12:00:00.000Z',
+  period: {
+    from: '2026-07-01T00:00:00.000Z',
+    to: '2026-07-31T23:59:59.999Z',
+  },
+  redactPii: true,
+  rowCount: 2,
+  rows: [
+    {
+      timestamp: '2026-07-02T10:00:00.000Z',
+      action: 'wallet.transfer',
+      amount: '10',
+      success: true,
+    },
+    {
+      timestamp: '2026-07-03T11:00:00.000Z',
+      action: 'wallet.transfer',
+      amount: '5',
+      success: false,
+    },
+  ],
+  summary: { matchedRows: 2, successCount: 1, failCount: 1 },
+};
+
+describe('compliance exporters', () => {
+  it('exports JSON with payload fields', () => {
+    const result = exportJson(samplePayload);
+    expect(result.contentType).toBe('application/json');
+    const parsed = JSON.parse(result.content);
+    expect(parsed.reportType).toBe('transaction');
+    expect(parsed.rowCount).toBe(2);
+    expect(parsed.rows).toHaveLength(2);
+  });
+
+  it('exports CSV with header and rows', () => {
+    const result = exportCsv(samplePayload);
+    expect(result.contentType).toBe('text/csv');
+    const lines = result.content.trim().split('\n');
+    expect(lines[0]).toContain('timestamp');
+    expect(lines).toHaveLength(3);
+    expect(result.content).toContain('wallet.transfer');
+  });
+
+  it('exports empty CSV with period metadata when no rows', () => {
+    const empty: GeneratedReportPayload = {
+      ...samplePayload,
+      rowCount: 0,
+      rows: [],
+    };
+    const result = exportCsv(empty);
+    expect(result.content).toContain('reportType,periodFrom,periodTo,rowCount');
+    expect(result.content).toContain('transaction');
+  });
+
+  it('exports a valid minimal PDF document', () => {
+    const result = exportPdf(samplePayload);
+    expect(result.contentType).toBe('application/pdf');
+    expect(result.content.startsWith('%PDF-1.4')).toBe(true);
+    expect(result.content).toContain('%%EOF');
+    expect(result.content).toContain('Galaxy DevKit Compliance Report');
+  });
+
+  it('dispatches by format', () => {
+    expect(exportReport('json', samplePayload).contentType).toBe('application/json');
+    expect(exportReport('csv', samplePayload).contentType).toBe('text/csv');
+    expect(exportReport('pdf', samplePayload).contentType).toBe('application/pdf');
+  });
+});

--- a/packages/api/rest/src/services/compliance/__tests__/pii-redaction.test.ts
+++ b/packages/api/rest/src/services/compliance/__tests__/pii-redaction.test.ts
@@ -1,0 +1,29 @@
+import { redactReportRow, redactReportRows } from '../pii-redaction';
+
+describe('pii redaction', () => {
+  it('redacts emails and ip addresses', () => {
+    const row = redactReportRow({
+      email: 'alice@example.com',
+      ipAddress: '203.0.113.45',
+      note: 'contact bob@corp.io from 10.1.2.3',
+      amount: 12,
+      success: true,
+    });
+
+    expect(row.email).toBe('a***@example.com');
+    expect(row.ipAddress).toBe('203.0.*.*');
+    expect(String(row.note)).toContain('b***@corp.io');
+    expect(String(row.note)).toContain('10.1.*.*');
+    expect(row.amount).toBe(12);
+    expect(row.success).toBe(true);
+  });
+
+  it('maps over arrays of rows', () => {
+    const rows = redactReportRows([
+      { ipAddress: '1.2.3.4' },
+      { ipAddress: '5.6.7.8' },
+    ]);
+    expect(rows[0].ipAddress).toBe('1.2.*.*');
+    expect(rows[1].ipAddress).toBe('5.6.*.*');
+  });
+});

--- a/packages/api/rest/src/services/compliance/__tests__/report-engine.test.ts
+++ b/packages/api/rest/src/services/compliance/__tests__/report-engine.test.ts
@@ -1,0 +1,147 @@
+import { buildIdempotencyKey, ComplianceReportEngine } from '../report-engine';
+import { ComplianceReportRecord } from '../../../types/compliance-types';
+
+describe('buildIdempotencyKey', () => {
+  it('is stable for the same inputs', () => {
+    const input = {
+      userId: 'user-1',
+      reportType: 'transaction',
+      format: 'json',
+      from: new Date('2026-07-01T00:00:00.000Z'),
+      to: new Date('2026-07-31T23:59:59.999Z'),
+      redactPii: true,
+      scheduleId: null as string | null,
+    };
+    const a = buildIdempotencyKey(input);
+    const b = buildIdempotencyKey(input);
+    expect(a).toBe(b);
+    expect(a).toHaveLength(64);
+  });
+
+  it('changes when period or format changes', () => {
+    const base = {
+      userId: 'user-1',
+      reportType: 'transaction',
+      format: 'json',
+      from: new Date('2026-07-01T00:00:00.000Z'),
+      to: new Date('2026-07-31T23:59:59.999Z'),
+      redactPii: true,
+    };
+    const a = buildIdempotencyKey(base);
+    const b = buildIdempotencyKey({ ...base, format: 'csv' });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('ComplianceReportEngine', () => {
+  const completed: ComplianceReportRecord = {
+    id: 'rep-1',
+    userId: 'user-1',
+    reportType: 'transaction',
+    format: 'json',
+    status: 'completed',
+    periodStart: new Date('2026-07-01T00:00:00.000Z'),
+    periodEnd: new Date('2026-07-31T23:59:59.999Z'),
+    scheduleId: null,
+    idempotencyKey: 'abc',
+    redactPii: true,
+    rowCount: 1,
+    content: '{"ok":true}',
+    contentType: 'application/json',
+    errorMessage: null,
+    createdAt: new Date('2026-07-17T00:00:00.000Z'),
+    completedAt: new Date('2026-07-17T00:00:01.000Z'),
+  };
+
+  it('returns existing completed report for identical requests (idempotent)', async () => {
+    const auditLogger = {
+      query: jest.fn(),
+    };
+    const repository = {
+      findByIdempotencyKey: jest.fn().mockResolvedValue(completed),
+      createPending: jest.fn(),
+      markCompleted: jest.fn(),
+      markFailed: jest.fn(),
+    };
+
+    const engine = new ComplianceReportEngine(auditLogger as never, repository as never);
+    const result = await engine.generate('user-1', {
+      reportType: 'transaction',
+      format: 'json',
+      from: new Date('2026-07-01T00:00:00.000Z'),
+      to: new Date('2026-07-31T23:59:59.999Z'),
+      redactPii: true,
+    });
+
+    expect(result.id).toBe('rep-1');
+    expect(auditLogger.query).not.toHaveBeenCalled();
+    expect(repository.createPending).not.toHaveBeenCalled();
+  });
+
+  it('generates and persists a new report from audit events', async () => {
+    const auditLogger = {
+      query: jest.fn().mockResolvedValue([
+        {
+          id: '1',
+          timestamp: '2026-07-02T10:00:00.000Z',
+          user_id: 'user-1',
+          action: 'wallet.transfer',
+          resource: '/tx',
+          ip_address: '1.2.3.4',
+          success: true,
+          metadata: { amount: '1', txHash: 'h1' },
+        },
+      ]),
+    };
+
+    const pending: ComplianceReportRecord = {
+      ...completed,
+      id: 'rep-new',
+      status: 'pending',
+      content: null,
+      contentType: null,
+      completedAt: null,
+      rowCount: 0,
+    };
+
+    const repository = {
+      findByIdempotencyKey: jest.fn().mockResolvedValue(null),
+      createPending: jest.fn().mockResolvedValue(pending),
+      markCompleted: jest.fn().mockImplementation(async (_id, _userId, update) => ({
+        ...pending,
+        status: 'completed',
+        content: update.content,
+        contentType: update.contentType,
+        rowCount: update.rowCount,
+        completedAt: new Date(),
+      })),
+      markFailed: jest.fn(),
+    };
+
+    const engine = new ComplianceReportEngine(auditLogger as never, repository as never);
+    const result = await engine.generate('user-1', {
+      reportType: 'transaction',
+      format: 'csv',
+      from: new Date('2026-07-01T00:00:00.000Z'),
+      to: new Date('2026-07-31T23:59:59.999Z'),
+      redactPii: true,
+    });
+
+    expect(result.status).toBe('completed');
+    expect(result.contentType).toBe('text/csv');
+    expect(result.content).toContain('wallet.transfer');
+    expect(repository.markCompleted).toHaveBeenCalledTimes(1);
+  });
+
+  it('lists the four built-in templates', () => {
+    const engine = new ComplianceReportEngine(
+      { query: jest.fn() } as never,
+      {} as never
+    );
+    const templates = engine.listTemplates();
+    expect(templates).toHaveLength(4);
+    expect(templates.map((t) => t.type).sort()).toEqual(
+      ['defi_activity', 'risk_exposure', 'transaction', 'user_activity'].sort()
+    );
+  });
+});

--- a/packages/api/rest/src/services/compliance/__tests__/schedule-utils.test.ts
+++ b/packages/api/rest/src/services/compliance/__tests__/schedule-utils.test.ts
@@ -1,0 +1,38 @@
+import {
+  computeClosedPeriod,
+  computeNextRunAt,
+  isScheduleDue,
+} from '../schedule-utils';
+
+describe('schedule utils', () => {
+  const now = new Date('2026-07-17T15:30:00.000Z');
+
+  it('computes daily closed period as previous UTC day', () => {
+    const period = computeClosedPeriod('daily', now);
+    expect(period.from.toISOString()).toBe('2026-07-16T00:00:00.000Z');
+    expect(period.to.toISOString()).toBe('2026-07-16T23:59:59.999Z');
+  });
+
+  it('computes weekly closed period', () => {
+    const period = computeClosedPeriod('weekly', now);
+    expect(period.from.toISOString()).toBe('2026-07-10T00:00:00.000Z');
+    expect(period.to.toISOString()).toBe('2026-07-16T23:59:59.999Z');
+  });
+
+  it('computes monthly closed period', () => {
+    const period = computeClosedPeriod('monthly', now);
+    expect(period.from.toISOString()).toBe('2026-06-17T00:00:00.000Z');
+    expect(period.to.toISOString()).toBe('2026-07-16T23:59:59.999Z');
+  });
+
+  it('computes next run at utc midnight boundaries', () => {
+    expect(computeNextRunAt('daily', now).toISOString()).toBe('2026-07-18T00:00:00.000Z');
+    expect(computeNextRunAt('weekly', now).toISOString()).toBe('2026-07-24T00:00:00.000Z');
+    expect(computeNextRunAt('monthly', now).toISOString()).toBe('2026-08-17T00:00:00.000Z');
+  });
+
+  it('detects due schedules', () => {
+    expect(isScheduleDue(new Date('2026-07-17T00:00:00.000Z'), now)).toBe(true);
+    expect(isScheduleDue(new Date('2026-07-18T00:00:00.000Z'), now)).toBe(false);
+  });
+});

--- a/packages/api/rest/src/services/compliance/__tests__/templates.test.ts
+++ b/packages/api/rest/src/services/compliance/__tests__/templates.test.ts
@@ -1,0 +1,102 @@
+import { buildReportPayload } from '../templates';
+import { AuditEvent } from '../../audit-logger';
+
+const baseEvents: AuditEvent[] = [
+  {
+    id: '1',
+    timestamp: '2026-07-02T10:00:00.000Z',
+    user_id: 'user-1',
+    action: 'wallet.transfer',
+    resource: '/api/v1/wallets/submit-tx',
+    ip_address: '10.0.0.1',
+    success: true,
+    metadata: {
+      amount: '12.5',
+      asset: 'USDC',
+      counterparty: 'GABC',
+      txHash: 'hash1',
+    },
+  },
+  {
+    id: '2',
+    timestamp: '2026-07-02T11:00:00.000Z',
+    user_id: 'user-1',
+    action: 'defi.swap',
+    resource: '/api/v1/defi/swap',
+    ip_address: '10.0.0.1',
+    success: true,
+    metadata: {
+      protocol: 'soroswap',
+      assetIn: 'XLM',
+      assetOut: 'USDC',
+      amount: '100',
+    },
+  },
+  {
+    id: '3',
+    timestamp: '2026-07-02T12:00:00.000Z',
+    user_id: 'user-1',
+    action: 'auth.login',
+    resource: '/api/v1/auth/login',
+    ip_address: '203.0.113.10',
+    success: true,
+  },
+  {
+    id: '4',
+    timestamp: '2026-07-02T13:00:00.000Z',
+    user_id: 'user-1',
+    action: 'monitoring.alert.triggered',
+    resource: 'alert-1',
+    ip_address: null,
+    success: true,
+    metadata: {
+      protocol: 'blend',
+      healthFactor: '0.9',
+      account: 'GXYZ',
+    },
+  },
+];
+
+const period = {
+  from: new Date('2026-07-01T00:00:00.000Z'),
+  to: new Date('2026-07-31T23:59:59.999Z'),
+};
+
+describe('buildReportPayload', () => {
+  it('builds transaction report rows', () => {
+    const payload = buildReportPayload('transaction', baseEvents, period, true);
+    expect(payload.reportType).toBe('transaction');
+    expect(payload.rowCount).toBeGreaterThanOrEqual(1);
+    expect(payload.rows.some((r) => r.action === 'wallet.transfer')).toBe(true);
+    expect(payload.summary.matchedRows).toBe(payload.rowCount);
+  });
+
+  it('builds defi activity report rows', () => {
+    const payload = buildReportPayload('defi_activity', baseEvents, period, true);
+    expect(payload.rows).toHaveLength(1);
+    expect(payload.rows[0].protocol).toBe('soroswap');
+  });
+
+  it('builds user activity report rows', () => {
+    const payload = buildReportPayload('user_activity', baseEvents, period, true);
+    expect(payload.rows.some((r) => r.action === 'auth.login')).toBe(true);
+  });
+
+  it('builds risk exposure report with severity', () => {
+    const payload = buildReportPayload('risk_exposure', baseEvents, period, true);
+    expect(payload.rows).toHaveLength(1);
+    expect(payload.rows[0].severity).toBe('critical');
+    expect(payload.summary.criticalCount).toBe(1);
+  });
+
+  it('returns empty rows when no events match', () => {
+    const payload = buildReportPayload(
+      'defi_activity',
+      [baseEvents[2]],
+      period,
+      true
+    );
+    expect(payload.rowCount).toBe(0);
+    expect(payload.rows).toEqual([]);
+  });
+});

--- a/packages/api/rest/src/services/compliance/exporters.ts
+++ b/packages/api/rest/src/services/compliance/exporters.ts
@@ -1,0 +1,166 @@
+/**
+ * @fileoverview Report exporters for JSON, CSV, and minimal PDF.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-17
+ */
+
+import { GeneratedReportPayload, ReportFormat, ReportRow } from '../../types/compliance-types';
+
+export interface ExportResult {
+  content: string;
+  contentType: string;
+}
+
+function escapeCsvCell(value: string | number | boolean | null): string {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (/[",\n\r]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+export function exportJson(payload: GeneratedReportPayload): ExportResult {
+  return {
+    content: JSON.stringify(payload, null, 2),
+    contentType: 'application/json',
+  };
+}
+
+export function exportCsv(payload: GeneratedReportPayload): ExportResult {
+  const rows = payload.rows;
+  if (rows.length === 0) {
+    return {
+      content: 'reportType,periodFrom,periodTo,rowCount\n' +
+        `${payload.reportType},${payload.period.from},${payload.period.to},0\n`,
+      contentType: 'text/csv',
+    };
+  }
+
+  const columns = Array.from(
+    rows.reduce((set, row) => {
+      Object.keys(row).forEach((k) => set.add(k));
+      return set;
+    }, new Set<string>())
+  );
+
+  const lines: string[] = [columns.map(escapeCsvCell).join(',')];
+  for (const row of rows) {
+    lines.push(columns.map((col) => escapeCsvCell(row[col] ?? null)).join(','));
+  }
+
+  return {
+    content: lines.join('\n') + '\n',
+    contentType: 'text/csv',
+  };
+}
+
+/**
+ * Minimal PDF writer (text-only, no external deps). Produces a valid single-page
+ * PDF with a title and tabular lines truncated for readability.
+ */
+export function exportPdf(payload: GeneratedReportPayload): ExportResult {
+  const lines: string[] = [
+    `Galaxy DevKit Compliance Report`,
+    `Type: ${payload.reportType}`,
+    `Period: ${payload.period.from} -> ${payload.period.to}`,
+    `Generated: ${payload.generatedAt}`,
+    `Rows: ${payload.rowCount}`,
+    `PII redacted: ${payload.redactPii}`,
+    '',
+    ...Object.entries(payload.summary).map(([k, v]) => `${k}: ${String(v)}`),
+    '',
+    '--- rows (first 40) ---',
+  ];
+
+  const preview = payload.rows.slice(0, 40);
+  for (const row of preview) {
+    lines.push(formatRowLine(row));
+  }
+  if (payload.rows.length > 40) {
+    lines.push(`... ${payload.rows.length - 40} more rows omitted`);
+  }
+
+  const contentStream = buildPdfContentStream(lines);
+  const pdf = assemblePdf(contentStream);
+
+  return {
+    content: pdf,
+    contentType: 'application/pdf',
+  };
+}
+
+function formatRowLine(row: ReportRow): string {
+  return Object.entries(row)
+    .map(([k, v]) => `${k}=${v === null || v === undefined ? '' : String(v)}`)
+    .join(' | ')
+    .slice(0, 110);
+}
+
+function buildPdfContentStream(lines: string[]): string {
+  const escaped = lines.map((line) =>
+    line.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)')
+  );
+
+  const ops: string[] = ['BT', '/F1 10 Tf', '50 780 Td', '12 TL'];
+  escaped.forEach((line, index) => {
+    if (index === 0) {
+      ops.push(`(${line}) Tj`);
+    } else {
+      ops.push('T*');
+      ops.push(`(${line}) Tj`);
+    }
+  });
+  ops.push('ET');
+  return ops.join('\n');
+}
+
+function assemblePdf(streamBody: string): string {
+  const objects: string[] = [];
+
+  objects.push('1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n');
+  objects.push('2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n');
+  objects.push(
+    '3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n'
+  );
+
+  const stream = `4 0 obj\n<< /Length ${Buffer.byteLength(streamBody, 'utf8')} >>\nstream\n${streamBody}\nendstream\nendobj\n`;
+  objects.push(stream);
+  objects.push('5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n');
+
+  let pdf = '%PDF-1.4\n';
+  const offsets: number[] = [0];
+
+  for (const obj of objects) {
+    offsets.push(Buffer.byteLength(pdf, 'utf8'));
+    pdf += obj;
+  }
+
+  const xrefStart = Buffer.byteLength(pdf, 'utf8');
+  pdf += `xref\n0 ${objects.length + 1}\n`;
+  pdf += '0000000000 65535 f \n';
+  for (let i = 1; i < offsets.length; i++) {
+    pdf += `${String(offsets[i]).padStart(10, '0')} 00000 n \n`;
+  }
+  pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n`;
+  pdf += `startxref\n${xrefStart}\n%%EOF\n`;
+  return pdf;
+}
+
+export function exportReport(
+  format: ReportFormat,
+  payload: GeneratedReportPayload
+): ExportResult {
+  switch (format) {
+    case 'json':
+      return exportJson(payload);
+    case 'csv':
+      return exportCsv(payload);
+    case 'pdf':
+      return exportPdf(payload);
+    default: {
+      const _exhaustive: never = format;
+      throw new Error(`Unsupported format: ${_exhaustive}`);
+    }
+  }
+}

--- a/packages/api/rest/src/services/compliance/pii-redaction.ts
+++ b/packages/api/rest/src/services/compliance/pii-redaction.ts
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview PII redaction helpers for compliance report rows.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-17
+ */
+
+import { ReportRow } from '../../types/compliance-types';
+
+const EMAIL_RE = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi;
+const IP_RE = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g;
+
+function redactEmail(value: string): string {
+  return value.replace(EMAIL_RE, (match) => {
+    const [local, domain] = match.split('@');
+    if (!domain) return '[REDACTED_EMAIL]';
+    const safeLocal = local.length <= 1 ? '*' : `${local[0]}***`;
+    return `${safeLocal}@${domain}`;
+  });
+}
+
+function redactIp(value: string): string {
+  return value.replace(IP_RE, (ip) => {
+    const parts = ip.split('.');
+    if (parts.length !== 4) return '[REDACTED_IP]';
+    return `${parts[0]}.${parts[1]}.*.*`;
+  });
+}
+
+function redactString(value: string): string {
+  return redactIp(redactEmail(value));
+}
+
+/**
+ * Redact PII-like values in a report row. Keys known to hold IPs/emails are
+ * always scrubbed; free-text fields are pattern-scanned.
+ */
+export function redactReportRow(row: ReportRow): ReportRow {
+  const out: ReportRow = {};
+  for (const [key, value] of Object.entries(row)) {
+    if (value === null || typeof value === 'number' || typeof value === 'boolean') {
+      out[key] = value;
+      continue;
+    }
+    if (typeof value !== 'string') {
+      out[key] = value;
+      continue;
+    }
+
+    const lower = key.toLowerCase();
+    if (lower.includes('ip')) {
+      out[key] = redactIp(value);
+      continue;
+    }
+    if (lower.includes('email')) {
+      out[key] = redactEmail(value);
+      continue;
+    }
+    out[key] = redactString(value);
+  }
+  return out;
+}
+
+export function redactReportRows(rows: ReportRow[]): ReportRow[] {
+  return rows.map(redactReportRow);
+}

--- a/packages/api/rest/src/services/compliance/report-engine.ts
+++ b/packages/api/rest/src/services/compliance/report-engine.ts
@@ -1,0 +1,154 @@
+/**
+ * @fileoverview Compliance report generation engine.
+ * @description Aggregates audit logs into regulatory-ready reports with
+ *              idempotent persistence and multi-format export.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-17
+ */
+
+import { createHash } from 'crypto';
+import { AuditEvent, AuditLogger } from '../audit-logger';
+import { ComplianceReportRepository } from '../../repositories/compliance-report.repository';
+import {
+  ComplianceError,
+  ComplianceReportRecord,
+  GenerateReportInput,
+  REPORT_TEMPLATES,
+  ReportTemplateMeta,
+} from '../../types/compliance-types';
+import { buildReportPayload } from './templates';
+import { redactReportRows } from './pii-redaction';
+import { exportReport } from './exporters';
+
+export function buildIdempotencyKey(input: {
+  userId: string;
+  reportType: string;
+  format: string;
+  from: Date;
+  to: Date;
+  redactPii: boolean;
+  scheduleId?: string | null;
+}): string {
+  const raw = [
+    input.userId,
+    input.reportType,
+    input.format,
+    input.from.toISOString(),
+    input.to.toISOString(),
+    input.redactPii ? '1' : '0',
+    input.scheduleId ?? 'on-demand',
+  ].join('|');
+
+  return createHash('sha256').update(raw).digest('hex');
+}
+
+export class ComplianceReportEngine {
+  constructor(
+    private readonly auditLogger: AuditLogger = new AuditLogger(),
+    private readonly repository: ComplianceReportRepository = new ComplianceReportRepository()
+  ) {}
+
+  listTemplates(): ReportTemplateMeta[] {
+    return REPORT_TEMPLATES;
+  }
+
+  /**
+   * Generate (or return existing) report for the given user and input.
+   * Idempotent: same parameters return the same completed report.
+   */
+  async generate(
+    userId: string,
+    input: GenerateReportInput,
+    options: { scheduleId?: string | null } = {}
+  ): Promise<ComplianceReportRecord> {
+    if (input.from.getTime() > input.to.getTime()) {
+      throw new ComplianceError(
+        'VALIDATION_ERROR',
+        '`from` must be earlier than or equal to `to`',
+        400
+      );
+    }
+
+    const redactPii = input.redactPii !== false;
+    const idempotencyKey = buildIdempotencyKey({
+      userId,
+      reportType: input.reportType,
+      format: input.format,
+      from: input.from,
+      to: input.to,
+      redactPii,
+      scheduleId: options.scheduleId ?? null,
+    });
+
+    const existing = await this.repository.findByIdempotencyKey(idempotencyKey);
+    if (existing && existing.status === 'completed') {
+      return existing;
+    }
+    if (existing && existing.status === 'pending') {
+      // Another worker may be generating; return pending record as-is.
+      return existing;
+    }
+
+    const pending =
+      existing ??
+      (await this.repository.createPending({
+        userId,
+        reportType: input.reportType,
+        format: input.format,
+        periodStart: input.from,
+        periodEnd: input.to,
+        idempotencyKey,
+        redactPii,
+        scheduleId: options.scheduleId ?? null,
+      }));
+
+    try {
+      const events = await this.auditLogger.query({
+        userId,
+        from: input.from,
+        to: input.to,
+      });
+
+      const payload = buildReportPayload(
+        input.reportType,
+        events as AuditEvent[],
+        { from: input.from, to: input.to },
+        redactPii
+      );
+
+      if (redactPii) {
+        payload.rows = redactReportRows(payload.rows);
+      }
+
+      // Freeze generatedAt for reproducibility when re-exporting from stored content
+      // is not applicable; content itself is the source of truth after completion.
+      const exported = exportReport(input.format, payload);
+
+      return await this.repository.markCompleted(pending.id, userId, {
+        content: exported.content,
+        contentType: exported.contentType,
+        rowCount: payload.rowCount,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Report generation failed';
+      await this.repository.markFailed(pending.id, userId, message);
+      if (err instanceof ComplianceError) throw err;
+      throw new ComplianceError('GENERATION_FAILED', message, 500);
+    }
+  }
+
+  async getReport(userId: string, reportId: string): Promise<ComplianceReportRecord> {
+    return this.repository.getForUser(reportId, userId);
+  }
+
+  async listReports(
+    userId: string,
+    opts: { reportType?: GenerateReportInput['reportType']; limit?: number; offset?: number } = {}
+  ): Promise<ComplianceReportRecord[]> {
+    return this.repository.listForUser(userId, {
+      reportType: opts.reportType,
+      limit: opts.limit ?? 50,
+      offset: opts.offset ?? 0,
+    });
+  }
+}

--- a/packages/api/rest/src/services/compliance/schedule-utils.ts
+++ b/packages/api/rest/src/services/compliance/schedule-utils.ts
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview Schedule period and next-run helpers for compliance reports.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-17
+ */
+
+import { ScheduleCadence } from '../../types/compliance-types';
+
+export interface ClosedPeriod {
+  from: Date;
+  to: Date;
+}
+
+/**
+ * Compute the closed reporting period that just ended for a cadence, relative
+ * to `now`. Periods are UTC calendar boundaries for determinism.
+ */
+export function computeClosedPeriod(cadence: ScheduleCadence, now: Date = new Date()): ClosedPeriod {
+  const end = new Date(now);
+  end.setUTCMilliseconds(0);
+  end.setUTCSeconds(0);
+  end.setUTCMinutes(0);
+  end.setUTCHours(0);
+
+  const start = new Date(end);
+
+  switch (cadence) {
+    case 'daily':
+      start.setUTCDate(start.getUTCDate() - 1);
+      break;
+    case 'weekly':
+      start.setUTCDate(start.getUTCDate() - 7);
+      break;
+    case 'monthly':
+      start.setUTCMonth(start.getUTCMonth() - 1);
+      break;
+    default: {
+      const _exhaustive: never = cadence;
+      throw new Error(`Unknown cadence: ${_exhaustive}`);
+    }
+  }
+
+  // period end is exclusive at midnight; store inclusive last microsecond of previous day
+  const to = new Date(end.getTime() - 1);
+  return { from: start, to };
+}
+
+/**
+ * Next run after a successful generation. Anchored to UTC midnight.
+ */
+export function computeNextRunAt(cadence: ScheduleCadence, from: Date = new Date()): Date {
+  const next = new Date(from);
+  next.setUTCMilliseconds(0);
+  next.setUTCSeconds(0);
+  next.setUTCMinutes(0);
+  next.setUTCHours(0);
+
+  switch (cadence) {
+    case 'daily':
+      next.setUTCDate(next.getUTCDate() + 1);
+      break;
+    case 'weekly':
+      next.setUTCDate(next.getUTCDate() + 7);
+      break;
+    case 'monthly':
+      next.setUTCMonth(next.getUTCMonth() + 1);
+      break;
+    default: {
+      const _exhaustive: never = cadence;
+      throw new Error(`Unknown cadence: ${_exhaustive}`);
+    }
+  }
+
+  return next;
+}
+
+export function isScheduleDue(nextRunAt: Date, now: Date = new Date()): boolean {
+  return nextRunAt.getTime() <= now.getTime();
+}

--- a/packages/api/rest/src/services/compliance/templates.ts
+++ b/packages/api/rest/src/services/compliance/templates.ts
@@ -1,0 +1,194 @@
+/**
+ * @fileoverview Report templates that map audit log events to compliance rows.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-17
+ */
+
+import { AuditEvent } from '../audit-logger';
+import { GeneratedReportPayload, ReportRow, ReportType } from '../../types/compliance-types';
+
+const TX_ACTION_PREFIXES = ['wallet.', 'tx.', 'transaction.', 'stellar.'];
+const DEFI_ACTION_PREFIXES = ['defi.', 'swap.', 'lend.', 'borrow.', 'liquidity.', 'blend.', 'soroswap.'];
+const USER_ACTION_PREFIXES = ['auth.', 'user.', 'permission.', 'api-key.', 'session.', 'team.'];
+const RISK_ACTION_PREFIXES = ['monitoring.', 'risk.', 'liquidation.', 'alert.'];
+
+function metaString(meta: Record<string, unknown> | undefined, ...keys: string[]): string | null {
+  if (!meta) return null;
+  for (const key of keys) {
+    const value = meta[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+    if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  }
+  return null;
+}
+
+function matchesPrefix(action: string, prefixes: string[]): boolean {
+  const lower = action.toLowerCase();
+  return prefixes.some((p) => lower.startsWith(p) || lower.includes(`.${p.slice(0, -1)}.`));
+}
+
+function toTransactionRow(event: AuditEvent): ReportRow {
+  const meta = event.metadata ?? {};
+  return {
+    timestamp: event.timestamp,
+    action: event.action,
+    resource: event.resource,
+    counterparty: metaString(meta, 'counterparty', 'to', 'destination', 'recipient'),
+    amount: metaString(meta, 'amount', 'amountIn', 'value'),
+    asset: metaString(meta, 'asset', 'assetIn', 'code'),
+    success: event.success,
+    txHash: metaString(meta, 'txHash', 'transactionHash', 'hash'),
+  };
+}
+
+function toDefiRow(event: AuditEvent): ReportRow {
+  const meta = event.metadata ?? {};
+  return {
+    timestamp: event.timestamp,
+    activity: event.action,
+    protocol: metaString(meta, 'protocol', 'protocolId') ?? inferProtocol(event.action),
+    assetIn: metaString(meta, 'assetIn', 'asset', 'collateralAsset'),
+    assetOut: metaString(meta, 'assetOut', 'borrowAsset'),
+    amount: metaString(meta, 'amount', 'amountIn', 'amountOut'),
+    success: event.success,
+    resource: event.resource,
+  };
+}
+
+function toUserActivityRow(event: AuditEvent): ReportRow {
+  return {
+    timestamp: event.timestamp,
+    action: event.action,
+    resource: event.resource,
+    ipAddress: event.ip_address,
+    success: event.success,
+    errorCode: event.error_code ?? null,
+  };
+}
+
+function toRiskRow(event: AuditEvent): ReportRow {
+  const meta = event.metadata ?? {};
+  const health = metaString(meta, 'healthFactor', 'health_factor');
+  const ratio = metaString(meta, 'collateralRatio', 'collateral_ratio', 'ltv');
+  return {
+    timestamp: event.timestamp,
+    riskType: event.action,
+    protocol: metaString(meta, 'protocol', 'protocolId') ?? 'unknown',
+    account: metaString(meta, 'account', 'accountAddress', 'address') ?? event.resource,
+    healthFactor: health,
+    collateralRatio: ratio,
+    severity: classifySeverity(health, event.success),
+    resource: event.resource,
+  };
+}
+
+function inferProtocol(action: string): string {
+  const lower = action.toLowerCase();
+  if (lower.includes('blend')) return 'blend';
+  if (lower.includes('soroswap') || lower.includes('swap')) return 'soroswap';
+  return 'unknown';
+}
+
+function classifySeverity(healthFactor: string | null, success: boolean): string {
+  if (!success) return 'high';
+  if (!healthFactor) return 'info';
+  const n = Number(healthFactor);
+  if (!Number.isFinite(n)) return 'info';
+  if (n < 1) return 'critical';
+  if (n < 1.2) return 'high';
+  if (n < 1.5) return 'medium';
+  return 'low';
+}
+
+function filterEvents(events: AuditEvent[], type: ReportType): AuditEvent[] {
+  switch (type) {
+    case 'transaction':
+      return events.filter(
+        (e) =>
+          matchesPrefix(e.action, TX_ACTION_PREFIXES) ||
+          Boolean(e.metadata && (e.metadata.txHash || e.metadata.transactionHash || e.metadata.amount))
+      );
+    case 'defi_activity':
+      return events.filter((e) => matchesPrefix(e.action, DEFI_ACTION_PREFIXES));
+    case 'user_activity':
+      return events.filter((e) => matchesPrefix(e.action, USER_ACTION_PREFIXES));
+    case 'risk_exposure':
+      return events.filter(
+        (e) =>
+          matchesPrefix(e.action, RISK_ACTION_PREFIXES) ||
+          Boolean(
+            e.metadata &&
+              (e.metadata.healthFactor !== undefined ||
+                e.metadata.health_factor !== undefined ||
+                e.metadata.collateralRatio !== undefined)
+          )
+      );
+    default: {
+      const _exhaustive: never = type;
+      throw new Error(`Unknown report type: ${_exhaustive}`);
+    }
+  }
+}
+
+function mapRows(events: AuditEvent[], type: ReportType): ReportRow[] {
+  switch (type) {
+    case 'transaction':
+      return events.map(toTransactionRow);
+    case 'defi_activity':
+      return events.map(toDefiRow);
+    case 'user_activity':
+      return events.map(toUserActivityRow);
+    case 'risk_exposure':
+      return events.map(toRiskRow);
+    default: {
+      const _exhaustive: never = type;
+      throw new Error(`Unknown report type: ${_exhaustive}`);
+    }
+  }
+}
+
+function buildSummary(type: ReportType, rows: ReportRow[], allEvents: number): Record<string, string | number | boolean | null> {
+  const successCount = rows.filter((r) => r.success === true).length;
+  const failCount = rows.filter((r) => r.success === false).length;
+
+  const base = {
+    sourceEventsScanned: allEvents,
+    matchedRows: rows.length,
+    successCount,
+    failCount,
+  };
+
+  if (type === 'risk_exposure') {
+    const critical = rows.filter((r) => r.severity === 'critical').length;
+    const high = rows.filter((r) => r.severity === 'high').length;
+    return { ...base, criticalCount: critical, highCount: high };
+  }
+
+  return base;
+}
+
+/**
+ * Build a deterministic, reproducible report payload from audit events.
+ */
+export function buildReportPayload(
+  type: ReportType,
+  events: AuditEvent[],
+  period: { from: Date; to: Date },
+  redactPii: boolean
+): GeneratedReportPayload {
+  const filtered = filterEvents(events, type);
+  const rows = mapRows(filtered, type);
+
+  return {
+    reportType: type,
+    generatedAt: new Date().toISOString(),
+    period: {
+      from: period.from.toISOString(),
+      to: period.to.toISOString(),
+    },
+    redactPii,
+    rowCount: rows.length,
+    rows,
+    summary: buildSummary(type, rows, events.length),
+  };
+}

--- a/packages/api/rest/src/types/compliance-types.ts
+++ b/packages/api/rest/src/types/compliance-types.ts
@@ -1,0 +1,175 @@
+/**
+ * @fileoverview Types for compliance reporting tools (Issue #335 / Roadmap #67).
+ * @author Galaxy DevKit Team
+ * @since 2026-07-17
+ */
+
+export type ReportType =
+  | 'transaction'
+  | 'defi_activity'
+  | 'user_activity'
+  | 'risk_exposure';
+
+export type ReportFormat = 'json' | 'csv' | 'pdf';
+
+export type ReportStatus = 'pending' | 'completed' | 'failed';
+
+export type ScheduleCadence = 'daily' | 'weekly' | 'monthly';
+
+export interface ReportPeriod {
+  from: Date;
+  to: Date;
+}
+
+export interface GenerateReportInput {
+  reportType: ReportType;
+  format: ReportFormat;
+  from: Date;
+  to: Date;
+  redactPii?: boolean;
+}
+
+export interface ComplianceReportRecord {
+  id: string;
+  userId: string;
+  reportType: ReportType;
+  format: ReportFormat;
+  status: ReportStatus;
+  periodStart: Date;
+  periodEnd: Date;
+  scheduleId: string | null;
+  idempotencyKey: string;
+  redactPii: boolean;
+  rowCount: number;
+  content: string | null;
+  contentType: string | null;
+  errorMessage: string | null;
+  createdAt: Date;
+  completedAt: Date | null;
+}
+
+export interface ComplianceSchedule {
+  id: string;
+  userId: string;
+  reportType: ReportType;
+  format: ReportFormat;
+  cadence: ScheduleCadence;
+  redactPii: boolean;
+  enabled: boolean;
+  nextRunAt: Date;
+  lastRunAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateScheduleInput {
+  reportType: ReportType;
+  format: ReportFormat;
+  cadence: ScheduleCadence;
+  redactPii?: boolean;
+}
+
+export interface ReportTemplateMeta {
+  type: ReportType;
+  name: string;
+  description: string;
+  columns: string[];
+}
+
+export interface ReportRow {
+  [key: string]: string | number | boolean | null;
+}
+
+export interface GeneratedReportPayload {
+  reportType: ReportType;
+  generatedAt: string;
+  period: { from: string; to: string };
+  redactPii: boolean;
+  rowCount: number;
+  rows: ReportRow[];
+  summary: Record<string, string | number | boolean | null>;
+}
+
+export class ComplianceError extends Error {
+  readonly code: string;
+  readonly statusCode: number;
+  readonly details: Record<string, unknown>;
+
+  constructor(
+    code: string,
+    message: string,
+    statusCode = 400,
+    details: Record<string, unknown> = {}
+  ) {
+    super(message);
+    this.name = 'ComplianceError';
+    this.code = code;
+    this.statusCode = statusCode;
+    this.details = details;
+  }
+}
+
+export const REPORT_TEMPLATES: ReportTemplateMeta[] = [
+  {
+    type: 'transaction',
+    name: 'Transaction Report',
+    description:
+      'On-chain transaction activity with counterparties, amounts, and timestamps derived from audit logs.',
+    columns: [
+      'timestamp',
+      'action',
+      'resource',
+      'counterparty',
+      'amount',
+      'asset',
+      'success',
+      'txHash',
+    ],
+  },
+  {
+    type: 'defi_activity',
+    name: 'DeFi Activity Report',
+    description:
+      'Lending, borrowing, liquidity provision, and swap activity from audit metadata.',
+    columns: [
+      'timestamp',
+      'activity',
+      'protocol',
+      'assetIn',
+      'assetOut',
+      'amount',
+      'success',
+      'resource',
+    ],
+  },
+  {
+    type: 'user_activity',
+    name: 'User Activity Report',
+    description:
+      'Login history, permission changes, wallet operations, and authentication events.',
+    columns: [
+      'timestamp',
+      'action',
+      'resource',
+      'ipAddress',
+      'success',
+      'errorCode',
+    ],
+  },
+  {
+    type: 'risk_exposure',
+    name: 'Risk Exposure Report',
+    description:
+      'Current DeFi risk signals including collateral ratios and liquidation-related audit events.',
+    columns: [
+      'timestamp',
+      'riskType',
+      'protocol',
+      'account',
+      'healthFactor',
+      'collateralRatio',
+      'severity',
+      'resource',
+    ],
+  },
+];

--- a/packages/api/rest/src/validators/compliance-validators.ts
+++ b/packages/api/rest/src/validators/compliance-validators.ts
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Joi schemas for compliance reporting routes.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-17
+ */
+
+import Joi from 'joi';
+
+const reportType = Joi.string()
+  .valid('transaction', 'defi_activity', 'user_activity', 'risk_exposure')
+  .required();
+
+const reportFormat = Joi.string().valid('json', 'csv', 'pdf').default('json');
+
+export const generateReportSchema = Joi.object({
+  reportType,
+  format: reportFormat,
+  from: Joi.date().iso().required(),
+  to: Joi.date().iso().min(Joi.ref('from')).required(),
+  redactPii: Joi.boolean().default(true),
+}).unknown(false);
+
+export const listReportsQuerySchema = Joi.object({
+  reportType: Joi.string()
+    .valid('transaction', 'defi_activity', 'user_activity', 'risk_exposure')
+    .optional(),
+  limit: Joi.number().integer().min(1).max(100).default(50),
+  offset: Joi.number().integer().min(0).default(0),
+}).unknown(false);
+
+export const reportIdParamSchema = Joi.object({
+  id: Joi.string().min(1).required(),
+}).unknown(false);
+
+export const createScheduleSchema = Joi.object({
+  reportType,
+  format: reportFormat,
+  cadence: Joi.string().valid('daily', 'weekly', 'monthly').required(),
+  redactPii: Joi.boolean().default(true),
+}).unknown(false);
+
+export const scheduleIdParamSchema = Joi.object({
+  id: Joi.string().min(1).required(),
+}).unknown(false);

--- a/packages/api/rest/src/worker/compliance-report.worker.ts
+++ b/packages/api/rest/src/worker/compliance-report.worker.ts
@@ -1,0 +1,103 @@
+/**
+ * @fileoverview Worker that runs due compliance report schedules.
+ * @description Separate process from the REST API so schedule ticks do not
+ *              duplicate under horizontal scaling of the API.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-17
+ */
+
+import { ComplianceReportRepository } from '../repositories/compliance-report.repository';
+import { ComplianceReportEngine } from '../services/compliance/report-engine';
+import {
+  computeClosedPeriod,
+  computeNextRunAt,
+} from '../services/compliance/schedule-utils';
+
+export interface ComplianceReportWorkerOptions {
+  pollIntervalMs?: number;
+  batchSize?: number;
+}
+
+export class ComplianceReportWorker {
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+  private readonly pollIntervalMs: number;
+  private readonly batchSize: number;
+
+  constructor(
+    private readonly engine: ComplianceReportEngine = new ComplianceReportEngine(),
+    private readonly repository: ComplianceReportRepository = new ComplianceReportRepository(),
+    options: ComplianceReportWorkerOptions = {}
+  ) {
+    this.pollIntervalMs = options.pollIntervalMs ?? 60_000;
+    this.batchSize = options.batchSize ?? 50;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    console.log(
+      `[compliance] worker started (interval=${this.pollIntervalMs}ms batch=${this.batchSize})`
+    );
+    void this.tick();
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, this.pollIntervalMs);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    console.log('[compliance] worker stopped');
+  }
+
+  async tick(now: Date = new Date()): Promise<number> {
+    if (this.running) return 0;
+    this.running = true;
+    let processed = 0;
+
+    try {
+      const due = await this.repository.listDueSchedules(now, this.batchSize);
+      for (const schedule of due) {
+        try {
+          const period = computeClosedPeriod(schedule.cadence, now);
+          await this.engine.generate(
+            schedule.userId,
+            {
+              reportType: schedule.reportType,
+              format: schedule.format,
+              from: period.from,
+              to: period.to,
+              redactPii: schedule.redactPii,
+            },
+            { scheduleId: schedule.id }
+          );
+
+          const nextRunAt = computeNextRunAt(schedule.cadence, now);
+          await this.repository.markScheduleRun(schedule.id, nextRunAt, now);
+          processed += 1;
+        } catch (err) {
+          console.warn(
+            `[compliance] failed schedule ${schedule.id}:`,
+            err instanceof Error ? err.message : err
+          );
+          // Still advance next_run_at to avoid hot-looping a permanently broken schedule
+          try {
+            const nextRunAt = computeNextRunAt(schedule.cadence, now);
+            await this.repository.markScheduleRun(schedule.id, nextRunAt, now);
+          } catch (advanceErr) {
+            console.warn(
+              `[compliance] failed to advance schedule ${schedule.id}:`,
+              advanceErr instanceof Error ? advanceErr.message : advanceErr
+            );
+          }
+        }
+      }
+    } finally {
+      this.running = false;
+    }
+
+    return processed;
+  }
+}

--- a/packages/api/rest/src/worker/index.ts
+++ b/packages/api/rest/src/worker/index.ts
@@ -23,6 +23,7 @@ try {
 import { PositionMonitorWorker } from './position-monitor.worker';
 import { StellarNetworkName } from '../types/monitoring-types';
 import { TransactionMonitorWorker } from './transaction-monitor.worker';
+import { ComplianceReportWorker } from './compliance-report.worker';
 
 function envInt(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -43,14 +44,20 @@ async function main(): Promise<void> {
     accountRefreshIntervalMs: envInt('TRANSACTION_MONITOR_ACCOUNT_REFRESH_MS', 30_000),
     maxConcurrency: envInt('TRANSACTION_MONITOR_CONCURRENCY', 16),
   });
+  const complianceWorker = new ComplianceReportWorker(undefined, undefined, {
+    pollIntervalMs: envInt('COMPLIANCE_SCHEDULER_INTERVAL_MS', 60_000),
+    batchSize: envInt('COMPLIANCE_SCHEDULER_BATCH_SIZE', 50),
+  });
 
   worker.start();
   await transactionWorker.start();
+  complianceWorker.start();
 
   const shutdown = (signal: string): void => {
     console.log(`\n[monitor] received ${signal}, shutting down...`);
     worker.stop();
     transactionWorker.stop();
+    complianceWorker.stop();
     process.exit(0);
   };
 
@@ -65,4 +72,4 @@ if (require.main === module) {
   });
 }
 
-export { PositionMonitorWorker, TransactionMonitorWorker };
+export { PositionMonitorWorker, TransactionMonitorWorker, ComplianceReportWorker };

--- a/supabase/migrations/20260717120000_compliance_reports.sql
+++ b/supabase/migrations/20260717120000_compliance_reports.sql
@@ -1,0 +1,57 @@
+-- Compliance reporting tables (Issue #335 / Roadmap #67)
+-- Stores generated reports and scheduled report jobs.
+
+create table if not exists compliance_reports (
+  id               text primary key default gen_random_uuid()::text,
+  user_id          text not null,
+  report_type      text not null
+                   check (report_type in ('transaction', 'defi_activity', 'user_activity', 'risk_exposure')),
+  format           text not null
+                   check (format in ('json', 'csv', 'pdf')),
+  status           text not null default 'pending'
+                   check (status in ('pending', 'completed', 'failed')),
+  period_start     timestamptz not null,
+  period_end       timestamptz not null,
+  schedule_id      text,
+  idempotency_key  text not null,
+  redact_pii       boolean not null default true,
+  row_count        integer not null default 0,
+  content          text,
+  content_type     text,
+  error_message    text,
+  created_at       timestamptz not null default now(),
+  completed_at     timestamptz
+);
+
+create unique index if not exists compliance_reports_idempotency_key_uidx
+  on compliance_reports (idempotency_key);
+
+create index if not exists compliance_reports_user_id_idx
+  on compliance_reports (user_id);
+
+create index if not exists compliance_reports_user_type_created_idx
+  on compliance_reports (user_id, report_type, created_at desc);
+
+create table if not exists compliance_schedules (
+  id               text primary key default gen_random_uuid()::text,
+  user_id          text not null,
+  report_type      text not null
+                   check (report_type in ('transaction', 'defi_activity', 'user_activity', 'risk_exposure')),
+  format           text not null
+                   check (format in ('json', 'csv', 'pdf')),
+  cadence          text not null
+                   check (cadence in ('daily', 'weekly', 'monthly')),
+  redact_pii       boolean not null default true,
+  enabled          boolean not null default true,
+  next_run_at      timestamptz not null,
+  last_run_at      timestamptz,
+  created_at       timestamptz not null default now(),
+  updated_at       timestamptz not null default now()
+);
+
+create index if not exists compliance_schedules_user_id_idx
+  on compliance_schedules (user_id);
+
+create index if not exists compliance_schedules_due_idx
+  on compliance_schedules (enabled, next_run_at)
+  where enabled = true;


### PR DESCRIPTION
# Pull Request: Compliance reporting tools

## 📋 Description

Adds compliance reporting tools to the Galaxy REST API so enterprise operators can generate regulatory-ready reports from audit log data (Roadmap #67 / Issue #335).

Architecture follows the existing monitoring/approvals pattern:

- Thin Express routes → `ComplianceReportEngine` → `ComplianceReportRepository` (Supabase)
- Templates map `audit_logs` into four report types with deterministic, reproducible rows
- Exporters: JSON, CSV, and a minimal dependency-free PDF
- PII redaction (emails / IPs) enabled by default
- Idempotency key (`sha256` of user + type + period + format + redact flag + schedule) so re-generation returns the same completed report
- `ComplianceReportWorker` runs inside the package worker process and evaluates daily/weekly/monthly schedules without duplicating work when the API scales horizontally

## 🔗 Related Issues

Closes #335

## ✅ What shipped

### Report types
1. **Transaction** — on-chain activity, counterparties, amounts, timestamps
2. **DeFi Activity** — lending/borrowing, liquidity, swaps
3. **User Activity** — logins, permissions, wallet operations
4. **Risk Exposure** — health factors, collateral signals, severity

### REST API (`/api/v1/compliance`, authenticated + audited)
| Method | Path | Purpose |
|--------|------|---------|
| GET | `/templates` | List report types |
| POST | `/reports` | On-demand generation (idempotent) |
| GET | `/reports` | List reports |
| GET | `/reports/:id` | Report + content |
| GET | `/reports/:id/download` | Raw export download |
| POST | `/schedules` | Create daily/weekly/monthly job |
| GET | `/schedules` | List schedules |
| DELETE | `/schedules/:id` | Delete schedule |

### Persistence
- Migration `supabase/migrations/20260717120000_compliance_reports.sql`
- Tables: `compliance_reports`, `compliance_schedules`

### Docs
- `docs/api/api-reference.md` — full endpoint contract (OpenAPI-style reference used by this repo)

## 🧪 Testing

- [x] Unit tests: templates, exporters, PII redaction, schedule utils, report engine, worker
- [x] Integration-style route tests with supertest (auth mocked): generate, list, download, schedules, validation errors
- [x] `npx jest --testPathPatterns=compliance` → **31/31 passed**
- [x] No TypeScript errors in compliance sources
- [x] `eslint` on package: no new errors (pre-existing warnings only)
- [x] GHA matrix package `packages/core/defi-protocols` `test:coverage` → **98.09% lines** (≥ 90%)
- [x] Root `package.json` JSON validity check
- [x] No new runtime dependencies (PDF is a minimal pure writer)

### Local commands run

```bash
cd packages/api/rest && npx jest --testPathPatterns=compliance
cd packages/core/defi-protocols && npm run test:coverage   # coverage 98.09%
# root scripts (soft-exit as in package.json; still executed):
npm run type-check && npm run lint && npm run build
```

## 🧱 Design notes / non-goals

- Primary data source is `AuditLogger` / `audit_logs` (issue #66). Templates return empty structured rows when no matching events exist — they do not invent balances.
- PDF export is text-only (no Puppeteer/Playwright) to avoid heavy deps and CI fragility.
- KYC/AML hooks, suspicious-activity monitoring, and cryptographic audit-trail export remain out of scope (issues #68–#70).

## 📦 Commits

1. `feat(api): add compliance report types and supabase migration`
2. `feat(api): implement compliance report engine and exporters`
3. `feat(api): add compliance rest endpoints and schedule worker`
4. `docs(api): document compliance reporting endpoints`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compliance reporting through the REST API.
  * Generate, list, view, and download reports in JSON, CSV, or PDF formats.
  * Added transaction, DeFi activity, user activity, and risk exposure report templates.
  * Added optional PII redaction for generated reports.
  * Added daily, weekly, and monthly scheduled reporting.

* **Documentation**
  * Documented compliance endpoints, report formats, scheduling, and configuration.

* **Tests**
  * Added coverage for report generation, exports, validation, redaction, and scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->