### PR TITLE
feat: Comprehensive analytics dashboard with portfolio tracking (#339)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -165,7 +165,7 @@ gantt
 
 ### Analytics & Monitoring (5 issues)
 
-- [ ] **#71** Build comprehensive analytics dashboard
+- [x] **#71** Build comprehensive analytics dashboard (delivered via #339)
 - [ ] **#72** Add real-time performance monitoring
 - [ ] **#73** Implement alerting system
 - [ ] **#74** Create custom metrics and KPIs

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -993,6 +993,14 @@ export class BlendProtocol extends BaseProtocol {
 }
 ```
 
+### Adding a new frontend playground panel
+
+1. Put testable logic in a pure module under `packages/frontend/src/services/` or `src/charts/` (data in → value or `SVGElement` out, no DOM state) and write its TDD test first in `src/tests/`. The global jest coverage gate (90% functions/lines) is only satisfiable when logic lives outside the panel.
+2. Create the panel in `src/panels/[name].ts` as a thin render layer that writes `innerHTML` and delegates to the pure modules. Accept injectable dependencies (clients, stores, socket factories) with production defaults so the panel is testable in jsdom.
+3. Mount it in `src/app.ts` inside a `safeMount(label, fn)` call and add a matching sidebar link plus a `.panel` div — `safeMount` keeps one failing panel from aborting `renderPlayground` and unbinding navigation.
+4. Style it in `src/styles.css` with the `:root` tokens; keep it responsive (tables scroll in their own container, KPIs/charts reflow) and accessible (SVG `role="img"` + `aria-label`, data-table alternative, never colour-alone).
+5. Label data honestly: any simulated/mock value must render with a visible `simulated` badge; client-observed series are labelled `since first load`; real on-chain/API values carry no badge.
+
 ### Adding a new CLI command
 
 1. Create command file: `tools/cli/src/commands/[command-name].ts`

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -996,7 +996,7 @@ export class BlendProtocol extends BaseProtocol {
 ### Adding a new frontend playground panel
 
 1. Put testable logic in a pure module under `packages/frontend/src/services/` or `src/charts/` (data in → value or `SVGElement` out, no DOM state) and write its TDD test first in `src/tests/`. The global jest coverage gate (90% functions/lines) is only satisfiable when logic lives outside the panel.
-2. Create the panel in `src/panels/[name].ts` as a thin render layer that writes `innerHTML` and delegates to the pure modules. Accept injectable dependencies (clients, stores, socket factories) with production defaults so the panel is testable in jsdom.
+2. Create the panel in `src/panels/[name].ts` as a thin render layer that delegates to the pure modules. Use `innerHTML` only for static scaffolding; assign any API-, socket-, or user-derived value through `textContent` (or explicit `createElement`/`append`) so dynamic data is never interpolated into an HTML string. Accept injectable dependencies (clients, stores, socket factories) with production defaults so the panel is testable in jsdom.
 3. Mount it in `src/app.ts` inside a `safeMount(label, fn)` call and add a matching sidebar link plus a `.panel` div — `safeMount` keeps one failing panel from aborting `renderPlayground` and unbinding navigation.
 4. Style it in `src/styles.css` with the `:root` tokens; keep it responsive (tables scroll in their own container, KPIs/charts reflow) and accessible (SVG `role="img"` + `aria-label`, data-table alternative, never colour-alone).
 5. Label data honestly: any simulated/mock value must render with a visible `simulated` badge; client-observed series are labelled `since first load`; real on-chain/API values carry no badge.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1923,7 +1923,6 @@
       "deprecated": "Use @eslint/config-array instead",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
@@ -1953,8 +1952,7 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
@@ -10421,7 +10419,6 @@
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -14015,7 +14012,6 @@
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -20437,7 +20433,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -20454,7 +20449,6 @@
       "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -20466,7 +20460,6 @@
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -20488,7 +20481,6 @@
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.2"
       },
@@ -22014,8 +22006,7 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -23676,7 +23667,6 @@
       "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -23701,7 +23691,6 @@
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -23975,7 +23964,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -23994,7 +23982,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -24051,7 +24038,6 @@
       "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -24082,7 +24068,6 @@
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
@@ -24101,7 +24086,6 @@
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -24115,7 +24099,6 @@
       "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.3",
@@ -24131,7 +24114,6 @@
       "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -24148,7 +24130,6 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -24162,7 +24143,6 @@
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -24176,7 +24156,6 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -24358,7 +24337,8 @@
         "bignumber.js": "^9.1.2",
         "blessed": "^0.1.81",
         "blessed-contrib": "^4.11.0",
-        "buffer": "^6.0.3"
+        "buffer": "^6.0.3",
+        "socket.io-client": "^4.8.3"
       },
       "devDependencies": {
         "@types/blessed": "^0.1.25",

--- a/packages/api/rest/src/routes/defi.routes.test.ts
+++ b/packages/api/rest/src/routes/defi.routes.test.ts
@@ -3,6 +3,8 @@ import express from 'express';
 import { setupDefiRoutes } from './defi.routes';
 import { DexAggregatorService } from '@galaxy-kj/core-defi-protocols';
 
+const mockGetSupplyAPY = jest.fn();
+
 // Mock ProtocolFactory and the protocols
 jest.mock('@galaxy-kj/core-defi-protocols', () => {
     const originalModule = jest.requireActual('@galaxy-kj/core-defi-protocols');
@@ -70,6 +72,7 @@ jest.mock('@galaxy-kj/core-defi-protocols', () => {
                                 supplied: [],
                                 borrowed: []
                             }),
+                            getSupplyAPY: mockGetSupplyAPY,
                             supply: jest.fn().mockResolvedValue({ hash: 'mock-unsigned-xdr-supply' }),
                             withdraw: jest.fn().mockResolvedValue({ hash: 'mock-unsigned-xdr-withdraw' }),
                             borrow: jest.fn().mockResolvedValue({ hash: 'mock-unsigned-xdr-borrow' }),
@@ -187,6 +190,29 @@ describe('DeFi Routes', () => {
 
             expect(response.status).toBe(200);
             expect(response.body).toHaveProperty('address', 'mock-address');
+        });
+
+        it('GET /api/v1/defi/blend/position/:publicKey should include APY when available', async () => {
+            mockGetSupplyAPY.mockResolvedValueOnce({ supplyAPY: '4.20', borrowAPY: '6.10' });
+
+            const response = await request(app)
+                .get('/api/v1/defi/blend/position/GB...USER');
+
+            expect(response.status).toBe(200);
+            expect(response.body).toHaveProperty('address', 'mock-address');
+            expect(response.body).toHaveProperty('supplyAPY', '4.20');
+            expect(response.body).toHaveProperty('borrowAPY', '6.10');
+        });
+
+        it('GET /api/v1/defi/blend/position/:publicKey should keep the position when APY lookup fails', async () => {
+            mockGetSupplyAPY.mockRejectedValueOnce(new Error('rpc unreachable'));
+
+            const response = await request(app)
+                .get('/api/v1/defi/blend/position/GB...USER');
+
+            expect(response.status).toBe(200);
+            expect(response.body).toHaveProperty('address', 'mock-address');
+            expect(response.body.supplyAPY).toBeUndefined();
         });
 
         it('POST /api/v1/defi/blend/supply should return unsigned XDR', async () => {

--- a/packages/api/rest/src/routes/defi.routes.ts
+++ b/packages/api/rest/src/routes/defi.routes.ts
@@ -225,7 +225,21 @@ export function setupDefiRoutes(): express.Router {
 
             const position = await protocol.getPosition(publicKey);
 
-            res.json(position);
+            // APY is best-effort: it needs an extra RPC round-trip that can fail,
+            // and a failure must never break the position payload.
+            const blend = protocol as unknown as {
+                getSupplyAPY?: (asset: Asset) => Promise<{ supplyAPY: string; borrowAPY: string }>;
+            };
+            let apy: { supplyAPY: string; borrowAPY: string } | undefined;
+            try {
+                if (blend.getSupplyAPY) {
+                    apy = await blend.getSupplyAPY({ code: 'XLM', type: 'native' });
+                }
+            } catch {
+                apy = undefined;
+            }
+
+            res.json(apy ? { ...position, supplyAPY: apy.supplyAPY, borrowAPY: apy.borrowAPY } : position);
         } catch (error) {
             next(error);
         }

--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -32,6 +32,15 @@ Builds, simulates, signs, and submits payment transactions while tracking each s
 ### TxHistoryPanel
 Renders persistent transaction history from local storage with status badges, Stellar Expert links, and failed-transaction re-simulation.
 
+### AnalyticsDashboardPanel
+Aggregates a wallet's Blend position into a portfolio summary (KPIs, allocation pie, historical value line chart), a cross-protocol positions table, risk indicators, and an activity feed. Simulated metrics carry a visible `simulated` badge; client-observed series are labelled `since first load`.
+
+### SoroswapBrowserPanel
+Reads a wallet's Soroswap liquidity-pool shares directly from Horizon (the terminal `SoroswapPanel` is CLI-only).
+
+### LiveMarketFeedPanel
+Streams simulated market prices over WebSocket (`market:price_update`); the header carries a `simulated` badge since the backend generates the ticks.
+
 ## Services
 
 ### SmartWalletClient
@@ -39,6 +48,12 @@ A browser-ready wrapper around `SmartWalletService` that manages WebAuthn creden
 
 ### TxTrackerService
 Persistent local transaction store used by the transaction panel and history panel.
+
+### PortfolioSnapshotStore
+`localStorage`-backed two-series store (portfolio value + observed price) mirroring `TxTrackerService`; exposes delta-vs-first-snapshot and windowed (24h) change helpers for the analytics dashboard.
+
+### MarketSocketClient
+`socket.io-client` wrapper that subscribes to the public `market:*` rooms and forwards `market:price_update` ticks to the live feed panel. Its socket factory is injectable for tests.
 
 ## Testing
 Run tests with:
@@ -54,3 +69,4 @@ Coverage is maintained at 90%+.
 - Prepare add-signer and remove-signer XDR from the signer management panel.
 - Confirm the playground can import `@galaxy-kj/core-stellar-sdk` by checking the generated testnet public key on load.
 - Submit transactions and verify they appear in the persistent history panel with status updates.
+- Open the Analytics panel, load a wallet, and review its portfolio value, cross-protocol positions and risk, with simulated metrics clearly badged and observed series labelled `since first load`.

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -22,7 +22,8 @@
     "bignumber.js": "^9.1.2",
     "blessed": "^0.1.81",
     "blessed-contrib": "^4.11.0",
-    "buffer": "^6.0.3"
+    "buffer": "^6.0.3",
+    "socket.io-client": "^4.8.3"
   },
   "devDependencies": {
     "@types/blessed": "^0.1.25",

--- a/packages/frontend/src/app.ts
+++ b/packages/frontend/src/app.ts
@@ -27,7 +27,7 @@ import { SecurityLimitsClient } from './services/security-limits.client';
 import { TeamManagementPanel } from './panels/team-management';
 import { TeamManagementClient } from './services/team-management.client';
 import { AnalyticsDashboardPanel } from './panels/analytics-dashboard';
-import { SoroswapBrowserPanel } from './panels/soroswap-browser';
+import { SoroswapBrowserPanel, fetchLpPositionsViaHorizon } from './panels/soroswap-browser';
 import { LiveMarketFeedPanel } from './panels/live-market-feed';
 import { getCurrentNetworkConfig, setSelectedNetwork, NetworkType, isMainnetReadOnly } from './utils/network';
 import { assertWriteOperation } from './actions';
@@ -280,8 +280,16 @@ export function renderPlayground(root: HTMLElement): PlaygroundStatus {
     }
   };
 
-  safeMount('analytics', () => new AnalyticsDashboardPanel('analytics-dashboard-panel', { tracker: txTracker }));
-  safeMount('soroswap', () => new SoroswapBrowserPanel('soroswap-browser-panel'));
+  safeMount('analytics', () => new AnalyticsDashboardPanel('analytics-dashboard-panel', {
+    tracker: txTracker,
+    network: networkStore.getNetwork(),
+  }));
+  const horizonUrl = networkStore.isMainnet()
+    ? 'https://horizon.stellar.org'
+    : 'https://horizon-testnet.stellar.org';
+  safeMount('soroswap', () => new SoroswapBrowserPanel('soroswap-browser-panel', {
+    loadLpPositions: (pk) => fetchLpPositionsViaHorizon(pk, horizonUrl),
+  }));
   safeMount('live-feed', () => new LiveMarketFeedPanel('live-market-feed-panel'));
 
   safeMount('wallet-create', () => new WalletCreatePanel('wallet-create-panel', client));

--- a/packages/frontend/src/app.ts
+++ b/packages/frontend/src/app.ts
@@ -26,6 +26,9 @@ import { SecurityLimitsPanel } from './panels/security-limits';
 import { SecurityLimitsClient } from './services/security-limits.client';
 import { TeamManagementPanel } from './panels/team-management';
 import { TeamManagementClient } from './services/team-management.client';
+import { AnalyticsDashboardPanel } from './panels/analytics-dashboard';
+import { SoroswapBrowserPanel } from './panels/soroswap-browser';
+import { LiveMarketFeedPanel } from './panels/live-market-feed';
 import { getCurrentNetworkConfig, setSelectedNetwork, NetworkType, isMainnetReadOnly } from './utils/network';
 import { assertWriteOperation } from './actions';
 
@@ -177,6 +180,15 @@ export function renderPlayground(root: HTMLElement): PlaygroundStatus {
         >
           <ul class="sidebar__nav" role="list">
             <li class="sidebar__nav-item">
+              <a href="#analytics" class="sidebar__nav-link" data-panel="analytics-dashboard-panel">Analytics</a>
+            </li>
+            <li class="sidebar__nav-item">
+              <a href="#soroswap-lp" class="sidebar__nav-link" data-panel="soroswap-browser-panel">Soroswap LP</a>
+            </li>
+            <li class="sidebar__nav-item">
+              <a href="#live-feed" class="sidebar__nav-link" data-panel="live-market-feed-panel">Live Feed</a>
+            </li>
+            <li class="sidebar__nav-item">
               <a href="#wallet-create" class="sidebar__nav-link" data-panel="wallet-create-panel" aria-current="page">Create Wallet</a>
             </li>
             <li class="sidebar__nav-item">
@@ -217,6 +229,9 @@ export function renderPlayground(root: HTMLElement): PlaygroundStatus {
         </nav>
 
         <main id="main-content" class="main-content workspace" role="main" tabindex="-1" aria-label="Playground panels">
+          <div id="analytics-dashboard-panel" class="panel" hidden></div>
+          <div id="soroswap-browser-panel" class="panel" hidden></div>
+          <div id="live-market-feed-panel" class="panel" hidden></div>
           <div id="wallet-create-panel" class="panel"></div>
           <div id="wallet-signers-panel" class="panel"></div>
           <div id="wallet-session-panel" class="panel" hidden></div>
@@ -254,23 +269,34 @@ export function renderPlayground(root: HTMLElement): PlaygroundStatus {
   // ── Mount panels ─────────────────────────────────────────────────────────
 //   const client = new SmartWalletClient();
   const txTracker = new TxTrackerService();
-  new WalletCreatePanel('wallet-create-panel', client);
-  new WalletSignersPanel('wallet-signers-panel', client);
 
-  mountSessionPanel(document.getElementById('wallet-session-panel')!);
-  mountLiquidityPanel(document.getElementById('liquidity-panel')!);
-  mountTxPanel(document.getElementById('wallet-tx-panel')!, client, txTracker);
-  mountTxHistoryPanel(
-    document.getElementById('wallet-tx-history-panel')!,
-    txTracker,
-  );
-  new BlendPanel('blend-panel', new BlendClient());
-  new SecurityLimitsPanel('security-limits-panel', new SecurityLimitsClient());
-  new TeamManagementPanel('team-management-panel', new TeamManagementClient());
-  new SmartSwapPanel('smart-swap-panel', new SmartSwapClient({
+  // Isolate each mount so one panel throwing cannot abort renderPlayground and
+  // leave the navigation handlers below unbound.
+  const safeMount = (label: string, mount: () => void): void => {
+    try {
+      mount();
+    } catch (error) {
+      logger.error(`Panel "${label}" failed to mount`, { scope: 'app', data: { error: String(error) } });
+    }
+  };
+
+  safeMount('analytics', () => new AnalyticsDashboardPanel('analytics-dashboard-panel', { tracker: txTracker }));
+  safeMount('soroswap', () => new SoroswapBrowserPanel('soroswap-browser-panel'));
+  safeMount('live-feed', () => new LiveMarketFeedPanel('live-market-feed-panel'));
+
+  safeMount('wallet-create', () => new WalletCreatePanel('wallet-create-panel', client));
+  safeMount('wallet-signers', () => new WalletSignersPanel('wallet-signers-panel', client));
+  safeMount('session', () => mountSessionPanel(document.getElementById('wallet-session-panel')!));
+  safeMount('liquidity', () => mountLiquidityPanel(document.getElementById('liquidity-panel')!));
+  safeMount('tx', () => mountTxPanel(document.getElementById('wallet-tx-panel')!, client, txTracker));
+  safeMount('tx-history', () => mountTxHistoryPanel(document.getElementById('wallet-tx-history-panel')!, txTracker));
+  safeMount('blend', () => new BlendPanel('blend-panel', new BlendClient()));
+  safeMount('security-limits', () => new SecurityLimitsPanel('security-limits-panel', new SecurityLimitsClient()));
+  safeMount('team-management', () => new TeamManagementPanel('team-management-panel', new TeamManagementClient()));
+  safeMount('smart-swap', () => new SmartSwapPanel('smart-swap-panel', new SmartSwapClient({
     rpcUrl: getRpcUrl(),
     networkPassphrase: networkConfig.networkPassphrase,
-  }));
+  })));
 
   const logHost = document.getElementById('activity-log-panel');
   if (logHost) logger.attach(logHost as HTMLElement);

--- a/packages/frontend/src/charts/line-chart.ts
+++ b/packages/frontend/src/charts/line-chart.ts
@@ -1,0 +1,101 @@
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+export interface LinePoint {
+  ts: number;
+  value: number;
+}
+
+export interface LineChartOptions {
+  ariaLabel: string;
+  emptyLabel?: string;
+  width?: number;
+  height?: number;
+}
+
+export interface LineTableOptions {
+  valueLabel?: string;
+}
+
+function svgEl(tag: string): SVGElement {
+  return document.createElementNS(SVG_NS, tag);
+}
+
+function baseSvg(width: number, height: number, ariaLabel: string): SVGSVGElement {
+  const svg = svgEl('svg') as SVGSVGElement;
+  svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+  svg.setAttribute('role', 'img');
+  svg.setAttribute('aria-label', ariaLabel);
+  svg.setAttribute('preserveAspectRatio', 'none');
+  return svg;
+}
+
+export function buildLineChart(points: LinePoint[], options: LineChartOptions): SVGSVGElement {
+  const width = options.width ?? 500;
+  const height = options.height ?? 200;
+  const empty = points.length === 0;
+  const emptyLabel = options.emptyLabel ?? 'No data yet';
+  const label = empty ? `${options.ariaLabel} — ${emptyLabel}` : options.ariaLabel;
+
+  const svg = baseSvg(width, height, label);
+  svg.setAttribute('data-empty', String(empty));
+
+  if (empty) {
+    const text = svgEl('text');
+    text.setAttribute('x', String(width / 2));
+    text.setAttribute('y', String(height / 2));
+    text.setAttribute('text-anchor', 'middle');
+    text.setAttribute('class', 'chart-empty');
+    text.textContent = emptyLabel;
+    svg.appendChild(text);
+    return svg;
+  }
+
+  const padding = 20;
+  const innerWidth = width - padding * 2;
+  const innerHeight = height - padding * 2;
+  const values = points.map((p) => p.value);
+  const min = Math.min(...values);
+  const range = Math.max(...values) - min || 1;
+  const xStep = innerWidth / (points.length - 1 || 1);
+
+  const d = points
+    .map((point, i) => {
+      const x = padding + i * xStep;
+      const y = padding + innerHeight - ((point.value - min) / range) * innerHeight;
+      return `${i === 0 ? 'M' : 'L'} ${x.toFixed(2)} ${y.toFixed(2)}`;
+    })
+    .join(' ');
+
+  const path = svgEl('path');
+  path.setAttribute('d', d);
+  path.setAttribute('fill', 'none');
+  path.setAttribute('class', 'chart-line');
+  path.setAttribute('data-testid', 'line');
+  svg.appendChild(path);
+
+  return svg;
+}
+
+export function buildLineChartTable(points: LinePoint[], options: LineTableOptions = {}): HTMLTableElement {
+  const table = document.createElement('table');
+  table.className = 'chart-table';
+
+  const thead = document.createElement('thead');
+  thead.innerHTML = `<tr><th scope="col">Time</th><th scope="col">${options.valueLabel ?? 'Value'}</th></tr>`;
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  points.forEach((point) => {
+    const row = document.createElement('tr');
+    const time = document.createElement('td');
+    time.textContent = new Date(point.ts).toISOString();
+    const value = document.createElement('td');
+    value.className = 'chart-table__value';
+    value.textContent = point.value.toLocaleString();
+    row.append(time, value);
+    tbody.appendChild(row);
+  });
+  table.appendChild(tbody);
+
+  return table;
+}

--- a/packages/frontend/src/charts/line-chart.ts
+++ b/packages/frontend/src/charts/line-chart.ts
@@ -76,12 +76,21 @@ export function buildLineChart(points: LinePoint[], options: LineChartOptions): 
   return svg;
 }
 
+function headerCell(text: string): HTMLTableCellElement {
+  const th = document.createElement('th');
+  th.scope = 'col';
+  th.textContent = text;
+  return th;
+}
+
 export function buildLineChartTable(points: LinePoint[], options: LineTableOptions = {}): HTMLTableElement {
   const table = document.createElement('table');
   table.className = 'chart-table';
 
   const thead = document.createElement('thead');
-  thead.innerHTML = `<tr><th scope="col">Time</th><th scope="col">${options.valueLabel ?? 'Value'}</th></tr>`;
+  const headRow = document.createElement('tr');
+  headRow.append(headerCell('Time'), headerCell(options.valueLabel ?? 'Value'));
+  thead.appendChild(headRow);
   table.appendChild(thead);
 
   const tbody = document.createElement('tbody');

--- a/packages/frontend/src/charts/pie-chart.ts
+++ b/packages/frontend/src/charts/pie-chart.ts
@@ -1,0 +1,117 @@
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+export interface PieSlice {
+  label: string;
+  value: number;
+}
+
+export interface PieChartOptions {
+  ariaLabel: string;
+  emptyLabel?: string;
+  size?: number;
+}
+
+function svgEl(tag: string): SVGElement {
+  return document.createElementNS(SVG_NS, tag);
+}
+
+function pointOnCircle(cx: number, cy: number, r: number, angle: number): [number, number] {
+  return [cx + r * Math.cos(angle), cy + r * Math.sin(angle)];
+}
+
+export function buildPieChart(slices: PieSlice[], options: PieChartOptions): SVGSVGElement {
+  const size = options.size ?? 200;
+  const positive = slices.filter((slice) => slice.value > 0);
+  const empty = positive.length === 0;
+  const emptyLabel = options.emptyLabel ?? 'No data yet';
+  const label = empty ? `${options.ariaLabel} — ${emptyLabel}` : options.ariaLabel;
+
+  const svg = svgEl('svg') as SVGSVGElement;
+  svg.setAttribute('viewBox', `0 0 ${size} ${size}`);
+  svg.setAttribute('role', 'img');
+  svg.setAttribute('aria-label', label);
+  svg.setAttribute('data-empty', String(empty));
+
+  if (empty) {
+    const text = svgEl('text');
+    text.setAttribute('x', String(size / 2));
+    text.setAttribute('y', String(size / 2));
+    text.setAttribute('text-anchor', 'middle');
+    text.setAttribute('class', 'chart-empty');
+    text.textContent = emptyLabel;
+    svg.appendChild(text);
+    return svg;
+  }
+
+  const cx = size / 2;
+  const cy = size / 2;
+  const r = size / 2 - 4;
+  const total = positive.reduce((sum, slice) => sum + slice.value, 0);
+
+  if (positive.length === 1) {
+    appendSlice(svg, positive[0], `M ${cx} ${cy - r} A ${r} ${r} 0 1 1 ${cx} ${cy + r} A ${r} ${r} 0 1 1 ${cx} ${cy - r} Z`, cx, cy - r * 0.6);
+    return svg;
+  }
+
+  let angle = -Math.PI / 2;
+  positive.forEach((slice, index) => {
+    const sweep = (slice.value / total) * Math.PI * 2;
+    const [x0, y0] = pointOnCircle(cx, cy, r, angle);
+    const [x1, y1] = pointOnCircle(cx, cy, r, angle + sweep);
+    const largeArc = sweep > Math.PI ? 1 : 0;
+    const d = `M ${cx} ${cy} L ${x0.toFixed(2)} ${y0.toFixed(2)} A ${r} ${r} 0 ${largeArc} 1 ${x1.toFixed(2)} ${y1.toFixed(2)} Z`;
+    const [lx, ly] = pointOnCircle(cx, cy, r * 0.6, angle + sweep / 2);
+    appendSlice(svg, slice, d, lx, ly, index);
+    angle += sweep;
+  });
+
+  return svg;
+}
+
+function appendSlice(
+  svg: SVGSVGElement,
+  slice: PieSlice,
+  d: string,
+  labelX: number,
+  labelY: number,
+  index = 0
+): void {
+  const path = svgEl('path');
+  path.setAttribute('d', d);
+  path.setAttribute('class', `chart-slice chart-slice--${index % 6}`);
+  path.setAttribute('data-testid', 'slice');
+  svg.appendChild(path);
+
+  const text = svgEl('text');
+  text.setAttribute('x', labelX.toFixed(2));
+  text.setAttribute('y', labelY.toFixed(2));
+  text.setAttribute('text-anchor', 'middle');
+  text.setAttribute('class', 'chart-slice-label');
+  text.setAttribute('data-testid', 'slice-label');
+  text.textContent = slice.label;
+  svg.appendChild(text);
+}
+
+export function buildPieChartTable(slices: PieSlice[]): HTMLTableElement {
+  const table = document.createElement('table');
+  table.className = 'chart-table';
+
+  const thead = document.createElement('thead');
+  thead.innerHTML = '<tr><th scope="col">Asset</th><th scope="col">Value</th></tr>';
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  slices.forEach((slice) => {
+    const row = document.createElement('tr');
+    const label = document.createElement('td');
+    label.textContent = slice.label;
+    const value = document.createElement('td');
+    value.className = 'chart-table__value';
+    value.textContent = slice.value.toLocaleString();
+    row.append(label, value);
+    tbody.appendChild(row);
+  });
+  table.appendChild(tbody);
+
+  return table;
+}

--- a/packages/frontend/src/panels/analytics-dashboard.ts
+++ b/packages/frontend/src/panels/analytics-dashboard.ts
@@ -1,0 +1,298 @@
+import { buildLineChart, buildLineChartTable } from '../charts/line-chart';
+import { buildPieChart, buildPieChartTable } from '../charts/pie-chart';
+import { PortfolioSnapshotStore } from '../services/portfolio-snapshots';
+import {
+  buildBlendRow,
+  buildSoroswapRow,
+  totalValue,
+  allocation,
+  simulatedCostBasisPnl,
+  type PositionRow,
+} from '../services/analytics.client';
+import {
+  calculateRiskProfile,
+  buildRiskAlerts,
+  type RiskTone,
+} from './risk-dashboard';
+import type { BlendPositionResponse } from '../services/blend.client';
+import { BlendClient } from '../services/blend.client';
+import { TxTrackerService, type TrackedTransaction } from '../services/tx-tracker';
+
+type BlendPosition = BlendPositionResponse & { supplyAPY?: string; borrowAPY?: string };
+
+export interface DashboardDeps {
+  loadPosition: (publicKey: string) => Promise<BlendPosition>;
+  loadSoroswapRows: (publicKey: string) => Promise<PositionRow[]>;
+  store: PortfolioSnapshotStore;
+  tracker: TxTrackerService;
+  now: () => number;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function defaultDeps(): DashboardDeps {
+  const client = new BlendClient();
+  return {
+    loadPosition: (publicKey) => client.getPosition(publicKey) as Promise<BlendPosition>,
+    loadSoroswapRows: async () => [],
+    store: new PortfolioSnapshotStore(),
+    tracker: new TxTrackerService(),
+    now: () => Date.now(),
+  };
+}
+
+function formatUsd(value: number): string {
+  return `$${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function signed(value: number): string {
+  const prefix = value > 0 ? '+' : value < 0 ? '−' : '';
+  return `${prefix}${formatUsd(Math.abs(value))}`;
+}
+
+function toneOf(value: number): RiskTone {
+  if (value > 0) return 'green';
+  if (value < 0) return 'red';
+  return 'yellow';
+}
+
+export class AnalyticsDashboardPanel {
+  private readonly container: HTMLElement;
+  private readonly deps: DashboardDeps;
+
+  constructor(container: string | HTMLElement, deps: Partial<DashboardDeps> = {}) {
+    this.container = typeof container === 'string'
+      ? (document.getElementById(container) as HTMLElement)
+      : container;
+
+    if (!this.container) {
+      throw new Error('AnalyticsDashboardPanel container is required');
+    }
+
+    this.deps = { ...defaultDeps(), ...deps };
+    this.render();
+  }
+
+  private render(): void {
+    this.container.innerHTML = `
+      <section class="analytics-panel" aria-label="Portfolio analytics dashboard">
+        <h2>Analytics</h2>
+        <p class="analytics-subtitle">Portfolio value, DeFi positions and risk across protocols. Metrics marked <span class="sim-badge">simulated</span> use mock data where no on-chain source exists.</p>
+
+        <div class="form-field">
+          <label for="ad-wallet">Wallet Public Key (G...)</label>
+          <input id="ad-wallet" type="text" placeholder="G..." autocomplete="off" />
+        </div>
+
+        <div class="actions">
+          <button id="ad-load" type="button">Load Portfolio</button>
+          <button id="ad-refresh" type="button">Refresh</button>
+        </div>
+
+        <p id="ad-status" class="status status-info" role="status" aria-live="polite">Enter a wallet and load its portfolio.</p>
+
+        <div id="ad-body" hidden>
+          <div id="ad-kpis" class="analytics-kpis"></div>
+          <div class="analytics-charts">
+            <figure id="ad-allocation" class="analytics-figure"></figure>
+            <figure id="ad-history" class="analytics-figure"></figure>
+          </div>
+          <div id="ad-positions" class="analytics-section"></div>
+          <div id="ad-risk" class="analytics-section"></div>
+          <div id="ad-activity" class="analytics-section"></div>
+        </div>
+      </section>
+    `;
+
+    this.byId<HTMLButtonElement>('ad-load').addEventListener('click', () => void this.refresh());
+    this.byId<HTMLButtonElement>('ad-refresh').addEventListener('click', () => void this.refresh());
+  }
+
+  async refresh(): Promise<void> {
+    const publicKey = this.byId<HTMLInputElement>('ad-wallet').value.trim();
+    if (!publicKey) {
+      this.setStatus('Enter a wallet public key first.', 'error');
+      return;
+    }
+
+    this.setStatus('Loading portfolio…', 'info');
+    try {
+      const [position, soroswapRows] = await Promise.all([
+        this.deps.loadPosition(publicKey),
+        this.deps.loadSoroswapRows(publicKey).catch(() => [] as PositionRow[]),
+      ]);
+
+      const rows = [buildBlendRow(position), ...soroswapRows];
+      const total = totalValue(rows);
+      this.deps.store.append('portfolio', total, this.deps.now());
+
+      this.renderKpis(total, position);
+      this.renderCharts(rows);
+      this.renderPositions(rows);
+      this.renderRisk(position);
+      this.renderActivity();
+
+      this.byId('ad-body').hidden = false;
+      this.setStatus('Portfolio loaded.', 'success');
+    } catch (error) {
+      this.setStatus(error instanceof Error ? error.message : 'Failed to load portfolio.', 'error');
+    }
+  }
+
+  private renderKpis(total: number, position: BlendPosition): void {
+    const observed = this.deps.store.delta('portfolio');
+    // Only a genuine 24h window counts; until the observed series spans a full
+    // day the tile stays blank rather than claiming a 24h move it cannot back.
+    const series = this.deps.store.series('portfolio');
+    const spans24h = series.length >= 2 && series[series.length - 1].ts - series[0].ts >= DAY_MS;
+    const change24h = spans24h ? this.deps.store.deltaSince('portfolio', DAY_MS, this.deps.now()) : null;
+    const simulated = simulatedCostBasisPnl(total);
+    const apy = position.supplyAPY ?? null;
+
+    const host = this.byId('ad-kpis');
+    host.innerHTML = '';
+    host.append(
+      kpi('Total value', formatUsd(total)),
+      kpi('24h change', change24h ? signed(change24h.absolute) : '—', change24h ? toneOf(change24h.absolute) : undefined),
+      kpi('PnL (since first load)', observed ? signed(observed.absolute) : '—', observed ? toneOf(observed.absolute) : undefined, 'observed'),
+      kpi('PnL (simulated)', signed(simulated.pnl), toneOf(simulated.pnl), 'simulated'),
+      kpi('Current APY', apy ? `${apy}%` : 'Unavailable'),
+    );
+  }
+
+  private renderCharts(rows: PositionRow[]): void {
+    const allocationFigure = this.byId('ad-allocation');
+    const slices = allocation(rows).map((entry) => ({ label: entry.label, value: entry.value }));
+    allocationFigure.innerHTML = '<figcaption>Allocation</figcaption>';
+    allocationFigure.append(
+      buildPieChart(slices, { ariaLabel: 'Asset allocation by protocol', emptyLabel: 'No positions yet' }),
+      hiddenTable(buildPieChartTable(slices)),
+    );
+
+    const historyFigure = this.byId('ad-history');
+    // A single observation cannot draw a trend line, so hold the empty state
+    // until at least two snapshots exist.
+    const series = this.deps.store.series('portfolio');
+    const points = series.length >= 2 ? series.map((s) => ({ ts: s.ts, value: s.value })) : [];
+    historyFigure.innerHTML = '<figcaption>Portfolio value <span class="sim-badge sim-badge--observed">observed since first load</span></figcaption>';
+    historyFigure.append(
+      buildLineChart(points, { ariaLabel: 'Portfolio value over time', emptyLabel: 'observed since first load' }),
+      hiddenTable(buildLineChartTable(points, { valueLabel: 'Value (USD)' })),
+    );
+  }
+
+  private renderPositions(rows: PositionRow[]): void {
+    const host = this.byId('ad-positions');
+    const body = rows
+      .map(
+        (row) => `
+          <tr>
+            <td>${row.protocol}</td>
+            <td>${row.type}</td>
+            <td class="analytics-num">${formatUsd(row.value)}</td>
+            <td>${row.healthFactor !== null ? row.healthFactor.toFixed(2) : '—'}</td>
+            <td>${row.apy ?? '<span class="analytics-muted">unavailable</span>'}</td>
+          </tr>`
+      )
+      .join('');
+
+    host.innerHTML = `
+      <h3>Positions</h3>
+      <div class="analytics-table-scroll">
+        <table class="analytics-table">
+          <thead>
+            <tr><th scope="col">Protocol</th><th scope="col">Type</th><th scope="col">Value</th><th scope="col">Health (reported)</th><th scope="col">APY</th></tr>
+          </thead>
+          <tbody>${body || '<tr><td colspan="5">No positions found.</td></tr>'}</tbody>
+        </table>
+      </div>`;
+  }
+
+  private renderRisk(position: BlendPosition): void {
+    const profile = calculateRiskProfile(position);
+    const alerts = buildRiskAlerts(profile);
+    const host = this.byId('ad-risk');
+
+    host.innerHTML = `
+      <h3>Risk indicators</h3>
+      <div class="analytics-risk-grid">
+        <div class="analytics-risk analytics-risk--${profile.tone}">
+          <strong>Risk score</strong>
+          <span class="analytics-num">${profile.riskScore}/100</span>
+        </div>
+        <div class="analytics-risk analytics-risk--${profile.tone}">
+          <strong>Health factor (leverage)</strong>
+          <span class="analytics-num">${Number.isFinite(profile.healthFactor) ? profile.healthFactor.toFixed(2) : '∞'}</span>
+        </div>
+        <div class="analytics-risk">
+          <strong>IL exposure</strong>
+          <span class="analytics-num">${(profile.leverageIndex * 12).toFixed(1)}% <span class="sim-badge">simulated</span></span>
+        </div>
+      </div>
+      <ul class="analytics-alerts">
+        ${alerts.map((alert) => `<li class="analytics-alert analytics-alert--${alert.tone}">${alert.message}</li>`).join('')}
+      </ul>`;
+  }
+
+  private renderActivity(): void {
+    const host = this.byId('ad-activity');
+    const real = this.deps.tracker.list().slice(0, 5);
+    const realItems = real.map((tx) => activityItem(describeTx(tx), tx.createdAt, false)).join('');
+    const simItems = simulatedEvents(this.deps.now())
+      .map((event) => activityItem(event.label, event.ts, true))
+      .join('');
+
+    host.innerHTML = `
+      <h3>Activity feed</h3>
+      <ul class="analytics-activity">
+        ${realItems}${simItems || ''}
+        ${!realItems && !simItems ? '<li class="analytics-activity-empty">No recent activity.</li>' : ''}
+      </ul>`;
+  }
+
+  private setStatus(message: string, tone: 'info' | 'success' | 'error'): void {
+    const status = this.byId('ad-status');
+    status.textContent = message;
+    status.className = `status status-${tone}`;
+  }
+
+  private byId<T extends HTMLElement>(id: string): T {
+    return this.container.querySelector(`#${id}`) as T;
+  }
+}
+
+function kpi(label: string, value: string, tone?: RiskTone, badge?: string): HTMLElement {
+  const article = document.createElement('article');
+  article.className = 'analytics-kpi';
+  const badgeClass = badge === 'observed' ? 'sim-badge sim-badge--observed' : 'sim-badge';
+  article.innerHTML = `
+    <span class="analytics-kpi-label">${label}${badge ? ` <span class="${badgeClass}">${badge}</span>` : ''}</span>
+    <strong class="analytics-num${tone ? ` analytics-tone--${tone}` : ''}">${value}</strong>`;
+  return article;
+}
+
+function hiddenTable(table: HTMLTableElement): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'visually-hidden';
+  wrap.appendChild(table);
+  return wrap;
+}
+
+function activityItem(label: string, ts: number, simulated: boolean): string {
+  return `
+    <li class="analytics-activity-item">
+      <span>${label}${simulated ? ' <span class="sim-badge">simulated</span>' : ''}</span>
+      <time datetime="${new Date(ts).toISOString()}">${new Date(ts).toLocaleString()}</time>
+    </li>`;
+}
+
+function describeTx(tx: TrackedTransaction): string {
+  return `Sent ${tx.amount} to ${tx.destination.slice(0, 6)}… (${tx.status})`;
+}
+
+function simulatedEvents(now: number): { label: string; ts: number }[] {
+  return [
+    { label: 'Supplied 250 USDC to Blend', ts: now - 45 * 60 * 1000 },
+    { label: 'Swapped 100 XLM → USDC on Soroswap', ts: now - 3 * 60 * 60 * 1000 },
+  ];
+}

--- a/packages/frontend/src/panels/analytics-dashboard.ts
+++ b/packages/frontend/src/panels/analytics-dashboard.ts
@@ -26,9 +26,11 @@ export interface DashboardDeps {
   store: PortfolioSnapshotStore;
   tracker: TxTrackerService;
   now: () => number;
+  network: string;
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const REFRESH_INTERVAL_MS = 30_000;
 
 function defaultDeps(): DashboardDeps {
   const client = new BlendClient();
@@ -38,6 +40,7 @@ function defaultDeps(): DashboardDeps {
     store: new PortfolioSnapshotStore(),
     tracker: new TxTrackerService(),
     now: () => Date.now(),
+    network: 'testnet',
   };
 }
 
@@ -59,6 +62,9 @@ function toneOf(value: number): RiskTone {
 export class AnalyticsDashboardPanel {
   private readonly container: HTMLElement;
   private readonly deps: DashboardDeps;
+  private requestId = 0;
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  private seriesKey = 'portfolio';
 
   constructor(container: string | HTMLElement, deps: Partial<DashboardDeps> = {}) {
     this.container = typeof container === 'string'
@@ -115,6 +121,10 @@ export class AnalyticsDashboardPanel {
       return;
     }
 
+    // Snapshot history is keyed by wallet and network so switching either never
+    // mixes one wallet's observed values into another's.
+    this.seriesKey = `portfolio:${this.deps.network}:${publicKey}`;
+    const requestId = ++this.requestId;
     this.setStatus('Loading portfolio…', 'info');
     try {
       const [position, soroswapRows] = await Promise.all([
@@ -122,9 +132,12 @@ export class AnalyticsDashboardPanel {
         this.deps.loadSoroswapRows(publicKey).catch(() => [] as PositionRow[]),
       ]);
 
+      // Ignore a result that a newer refresh (or wallet change) has superseded.
+      if (requestId !== this.requestId) return;
+
       const rows = [buildBlendRow(position), ...soroswapRows];
       const total = totalValue(rows);
-      this.deps.store.append('portfolio', total, this.deps.now());
+      this.deps.store.append(this.seriesKey, total, this.deps.now());
 
       this.renderKpis(total, position);
       this.renderCharts(rows);
@@ -134,18 +147,32 @@ export class AnalyticsDashboardPanel {
 
       this.byId('ad-body').hidden = false;
       this.setStatus('Portfolio loaded.', 'success');
+      this.startAutoRefresh();
     } catch (error) {
+      if (requestId !== this.requestId) return;
       this.setStatus(error instanceof Error ? error.message : 'Failed to load portfolio.', 'error');
     }
   }
 
+  private startAutoRefresh(): void {
+    if (this.refreshTimer !== null) return;
+    this.refreshTimer = setInterval(() => void this.refresh(), REFRESH_INTERVAL_MS);
+  }
+
+  destroy(): void {
+    if (this.refreshTimer !== null) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
   private renderKpis(total: number, position: BlendPosition): void {
-    const observed = this.deps.store.delta('portfolio');
+    const observed = this.deps.store.delta(this.seriesKey);
     // Only a genuine 24h window counts; until the observed series spans a full
     // day the tile stays blank rather than claiming a 24h move it cannot back.
-    const series = this.deps.store.series('portfolio');
+    const series = this.deps.store.series(this.seriesKey);
     const spans24h = series.length >= 2 && series[series.length - 1].ts - series[0].ts >= DAY_MS;
-    const change24h = spans24h ? this.deps.store.deltaSince('portfolio', DAY_MS, this.deps.now()) : null;
+    const change24h = spans24h ? this.deps.store.deltaSince(this.seriesKey, DAY_MS, this.deps.now()) : null;
     const simulated = simulatedCostBasisPnl(total);
     const apy = position.supplyAPY ?? null;
 
@@ -172,7 +199,7 @@ export class AnalyticsDashboardPanel {
     const historyFigure = this.byId('ad-history');
     // A single observation cannot draw a trend line, so hold the empty state
     // until at least two snapshots exist.
-    const series = this.deps.store.series('portfolio');
+    const series = this.deps.store.series(this.seriesKey);
     const points = series.length >= 2 ? series.map((s) => ({ ts: s.ts, value: s.value })) : [];
     historyFigure.innerHTML = '<figcaption>Portfolio value <span class="sim-badge sim-badge--observed">observed since first load</span></figcaption>';
     historyFigure.append(
@@ -183,19 +210,7 @@ export class AnalyticsDashboardPanel {
 
   private renderPositions(rows: PositionRow[]): void {
     const host = this.byId('ad-positions');
-    const body = rows
-      .map(
-        (row) => `
-          <tr>
-            <td>${row.protocol}</td>
-            <td>${row.type}</td>
-            <td class="analytics-num">${formatUsd(row.value)}</td>
-            <td>${row.healthFactor !== null ? row.healthFactor.toFixed(2) : '—'}</td>
-            <td>${row.apy ?? '<span class="analytics-muted">unavailable</span>'}</td>
-          </tr>`
-      )
-      .join('');
-
+    // Static scaffolding only; dynamic values are assigned via textContent below.
     host.innerHTML = `
       <h3>Positions</h3>
       <div class="analytics-table-scroll">
@@ -203,9 +218,31 @@ export class AnalyticsDashboardPanel {
           <thead>
             <tr><th scope="col">Protocol</th><th scope="col">Type</th><th scope="col">Value</th><th scope="col">Health (reported)</th><th scope="col">APY</th></tr>
           </thead>
-          <tbody>${body || '<tr><td colspan="5">No positions found.</td></tr>'}</tbody>
+          <tbody></tbody>
         </table>
       </div>`;
+
+    const tbody = host.querySelector('tbody') as HTMLTableSectionElement;
+    if (rows.length === 0) {
+      const row = document.createElement('tr');
+      const empty = td('No positions found.');
+      empty.colSpan = 5;
+      row.appendChild(empty);
+      tbody.appendChild(row);
+      return;
+    }
+
+    rows.forEach((row) => {
+      const tr = document.createElement('tr');
+      tr.append(
+        td(row.protocol),
+        td(row.type),
+        td(formatUsd(row.value), 'analytics-num'),
+        td(row.healthFactor !== null ? row.healthFactor.toFixed(2) : '—'),
+        row.apy !== null ? td(row.apy) : td('unavailable', 'analytics-muted'),
+      );
+      tbody.appendChild(tr);
+    });
   }
 
   private renderRisk(position: BlendPosition): void {
@@ -237,17 +274,20 @@ export class AnalyticsDashboardPanel {
   private renderActivity(): void {
     const host = this.byId('ad-activity');
     const real = this.deps.tracker.list().slice(0, 5);
-    const realItems = real.map((tx) => activityItem(describeTx(tx), tx.createdAt, false)).join('');
-    const simItems = simulatedEvents(this.deps.now())
-      .map((event) => activityItem(event.label, event.ts, true))
-      .join('');
+    host.innerHTML = '<h3>Activity feed</h3><ul class="analytics-activity"></ul>';
+    const list = host.querySelector('.analytics-activity') as HTMLElement;
 
-    host.innerHTML = `
-      <h3>Activity feed</h3>
-      <ul class="analytics-activity">
-        ${realItems}${simItems || ''}
-        ${!realItems && !simItems ? '<li class="analytics-activity-empty">No recent activity.</li>' : ''}
-      </ul>`;
+    real.forEach((tx) => list.appendChild(activityItem(describeTx(tx), tx.createdAt, false)));
+    simulatedEvents(this.deps.now()).forEach((event) =>
+      list.appendChild(activityItem(event.label, event.ts, true))
+    );
+
+    if (list.children.length === 0) {
+      const empty = document.createElement('li');
+      empty.className = 'analytics-activity-empty';
+      empty.textContent = 'No recent activity.';
+      list.appendChild(empty);
+    }
   }
 
   private setStatus(message: string, tone: 'info' | 'success' | 'error'): void {
@@ -264,11 +304,32 @@ export class AnalyticsDashboardPanel {
 function kpi(label: string, value: string, tone?: RiskTone, badge?: string): HTMLElement {
   const article = document.createElement('article');
   article.className = 'analytics-kpi';
-  const badgeClass = badge === 'observed' ? 'sim-badge sim-badge--observed' : 'sim-badge';
-  article.innerHTML = `
-    <span class="analytics-kpi-label">${label}${badge ? ` <span class="${badgeClass}">${badge}</span>` : ''}</span>
-    <strong class="analytics-num${tone ? ` analytics-tone--${tone}` : ''}">${value}</strong>`;
+
+  const labelEl = document.createElement('span');
+  labelEl.className = 'analytics-kpi-label';
+  labelEl.textContent = label;
+  if (badge) labelEl.append(' ', simBadge(badge));
+
+  const valueEl = document.createElement('strong');
+  valueEl.className = `analytics-num${tone ? ` analytics-tone--${tone}` : ''}`;
+  valueEl.textContent = value;
+
+  article.append(labelEl, valueEl);
   return article;
+}
+
+function simBadge(text: string): HTMLSpanElement {
+  const span = document.createElement('span');
+  span.className = text === 'observed' ? 'sim-badge sim-badge--observed' : 'sim-badge';
+  span.textContent = text;
+  return span;
+}
+
+function td(text: string, className?: string): HTMLTableCellElement {
+  const cell = document.createElement('td');
+  if (className) cell.className = className;
+  cell.textContent = text;
+  return cell;
 }
 
 function hiddenTable(table: HTMLTableElement): HTMLElement {
@@ -278,12 +339,20 @@ function hiddenTable(table: HTMLTableElement): HTMLElement {
   return wrap;
 }
 
-function activityItem(label: string, ts: number, simulated: boolean): string {
-  return `
-    <li class="analytics-activity-item">
-      <span>${label}${simulated ? ' <span class="sim-badge">simulated</span>' : ''}</span>
-      <time datetime="${new Date(ts).toISOString()}">${new Date(ts).toLocaleString()}</time>
-    </li>`;
+function activityItem(label: string, ts: number, simulated: boolean): HTMLLIElement {
+  const li = document.createElement('li');
+  li.className = 'analytics-activity-item';
+
+  const labelSpan = document.createElement('span');
+  labelSpan.textContent = label;
+  if (simulated) labelSpan.append(' ', simBadge('simulated'));
+
+  const time = document.createElement('time');
+  time.dateTime = new Date(ts).toISOString();
+  time.textContent = new Date(ts).toLocaleString();
+
+  li.append(labelSpan, time);
+  return li;
 }
 
 function describeTx(tx: TrackedTransaction): string {

--- a/packages/frontend/src/panels/live-market-feed.ts
+++ b/packages/frontend/src/panels/live-market-feed.ts
@@ -4,10 +4,18 @@ export const DEFAULT_WS_URL = 'http://localhost:3001';
 
 export interface LiveMarketFeedDeps {
   client: MarketSocketClient;
+  url: string;
 }
 
 function rowId(pair: string): string {
-  return `lmf-${pair.replace('/', '-')}`;
+  return `lmf-${pair.replace(/\//g, '-')}`;
+}
+
+function cell(text: string, className?: string): HTMLTableCellElement {
+  const td = document.createElement('td');
+  if (className) td.className = className;
+  td.textContent = text;
+  return td;
 }
 
 export class LiveMarketFeedPanel {
@@ -24,7 +32,7 @@ export class LiveMarketFeedPanel {
       throw new Error('LiveMarketFeedPanel container is required');
     }
 
-    this.client = deps.client ?? new MarketSocketClient({ url: DEFAULT_WS_URL });
+    this.client = deps.client ?? new MarketSocketClient({ url: deps.url ?? DEFAULT_WS_URL });
     this.render();
     this.unsubscribe = this.client.subscribe((update) => this.renderRow(update));
     this.client.connect();
@@ -67,10 +75,11 @@ export class LiveMarketFeedPanel {
       row.id = rowId(update.pair);
       body.appendChild(row);
     }
-    row.innerHTML = `
-      <td>${update.pair}</td>
-      <td class="analytics-num">${price}</td>
-      <td class="analytics-num analytics-tone--${tone}">${changeText}</td>`;
+    row.replaceChildren(
+      cell(update.pair),
+      cell(price, 'analytics-num'),
+      cell(changeText, `analytics-num analytics-tone--${tone}`),
+    );
   }
 
   destroy(): void {

--- a/packages/frontend/src/panels/live-market-feed.ts
+++ b/packages/frontend/src/panels/live-market-feed.ts
@@ -1,0 +1,80 @@
+import { MarketSocketClient, type PriceUpdate } from '../services/market-socket.client';
+
+export const DEFAULT_WS_URL = 'http://localhost:3001';
+
+export interface LiveMarketFeedDeps {
+  client: MarketSocketClient;
+}
+
+function rowId(pair: string): string {
+  return `lmf-${pair.replace('/', '-')}`;
+}
+
+export class LiveMarketFeedPanel {
+  private readonly container: HTMLElement;
+  private readonly client: MarketSocketClient;
+  private readonly unsubscribe: () => void;
+
+  constructor(container: string | HTMLElement, deps: Partial<LiveMarketFeedDeps> = {}) {
+    this.container = typeof container === 'string'
+      ? (document.getElementById(container) as HTMLElement)
+      : container;
+
+    if (!this.container) {
+      throw new Error('LiveMarketFeedPanel container is required');
+    }
+
+    this.client = deps.client ?? new MarketSocketClient({ url: DEFAULT_WS_URL });
+    this.render();
+    this.unsubscribe = this.client.subscribe((update) => this.renderRow(update));
+    this.client.connect();
+  }
+
+  private render(): void {
+    this.container.innerHTML = `
+      <section class="feed-panel" aria-label="Live market feed">
+        <div class="feed-header">
+          <h2>Live Market Feed</h2>
+          <span class="sim-badge">simulated</span>
+        </div>
+        <p class="analytics-subtitle">Streaming prices over WebSocket. The backend generates these ticks, so every value here is simulated.</p>
+        <div class="analytics-table-scroll">
+          <table class="analytics-table">
+            <thead>
+              <tr><th scope="col">Pair</th><th scope="col">Price</th><th scope="col">24h</th></tr>
+            </thead>
+            <tbody id="lmf-body">
+              <tr id="lmf-empty"><td colspan="3">Waiting for live prices…</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    `;
+  }
+
+  private renderRow(update: PriceUpdate): void {
+    const body = this.container.querySelector('#lmf-body') as HTMLElement;
+    this.container.querySelector('#lmf-empty')?.remove();
+
+    const change = update.change24h ?? 0;
+    const tone = change > 0 ? 'green' : change < 0 ? 'red' : 'yellow';
+    const changeText = `${change > 0 ? '+' : change < 0 ? '−' : ''}${Math.abs(change).toFixed(2)}%`;
+    const price = Number.isFinite(update.price) ? update.price.toLocaleString(undefined, { maximumFractionDigits: 6 }) : '—';
+
+    let row = this.container.querySelector(`#${rowId(update.pair)}`) as HTMLElement | null;
+    if (!row) {
+      row = document.createElement('tr');
+      row.id = rowId(update.pair);
+      body.appendChild(row);
+    }
+    row.innerHTML = `
+      <td>${update.pair}</td>
+      <td class="analytics-num">${price}</td>
+      <td class="analytics-num analytics-tone--${tone}">${changeText}</td>`;
+  }
+
+  destroy(): void {
+    this.unsubscribe();
+    this.client.disconnect();
+  }
+}

--- a/packages/frontend/src/panels/soroswap-browser.ts
+++ b/packages/frontend/src/panels/soroswap-browser.ts
@@ -7,11 +7,14 @@ export interface SoroswapBrowserDeps {
   loadLpPositions: (publicKey: string) => Promise<LpPosition[]>;
 }
 
-const HORIZON_URL = 'https://horizon-testnet.stellar.org';
+export const DEFAULT_HORIZON_URL = 'https://horizon-testnet.stellar.org';
 
-async function fetchLpPositionsViaHorizon(publicKey: string): Promise<LpPosition[]> {
+export async function fetchLpPositionsViaHorizon(
+  publicKey: string,
+  horizonUrl: string = DEFAULT_HORIZON_URL
+): Promise<LpPosition[]> {
   const { Horizon } = await import('@galaxy-kj/core-stellar-sdk');
-  const server = new Horizon.Server(HORIZON_URL);
+  const server = new Horizon.Server(horizonUrl);
   const account = await server.loadAccount(publicKey);
   return account.balances
     .filter((balance): balance is typeof balance & { liquidity_pool_id: string } =>

--- a/packages/frontend/src/panels/soroswap-browser.ts
+++ b/packages/frontend/src/panels/soroswap-browser.ts
@@ -1,0 +1,122 @@
+export interface LpPosition {
+  poolId: string;
+  shares: string;
+}
+
+export interface SoroswapBrowserDeps {
+  loadLpPositions: (publicKey: string) => Promise<LpPosition[]>;
+}
+
+const HORIZON_URL = 'https://horizon-testnet.stellar.org';
+
+async function fetchLpPositionsViaHorizon(publicKey: string): Promise<LpPosition[]> {
+  const { Horizon } = await import('@galaxy-kj/core-stellar-sdk');
+  const server = new Horizon.Server(HORIZON_URL);
+  const account = await server.loadAccount(publicKey);
+  return account.balances
+    .filter((balance): balance is typeof balance & { liquidity_pool_id: string } =>
+      balance.asset_type === 'liquidity_pool_shares'
+    )
+    .map((balance) => ({ poolId: balance.liquidity_pool_id, shares: balance.balance }));
+}
+
+export class SoroswapBrowserPanel {
+  private readonly container: HTMLElement;
+  private readonly deps: SoroswapBrowserDeps;
+
+  constructor(container: string | HTMLElement, deps: Partial<SoroswapBrowserDeps> = {}) {
+    this.container = typeof container === 'string'
+      ? (document.getElementById(container) as HTMLElement)
+      : container;
+
+    if (!this.container) {
+      throw new Error('SoroswapBrowserPanel container is required');
+    }
+
+    this.deps = { loadLpPositions: fetchLpPositionsViaHorizon, ...deps };
+    this.render();
+  }
+
+  private render(): void {
+    this.container.innerHTML = `
+      <section class="soroswap-panel" aria-label="Soroswap liquidity positions">
+        <h2>Soroswap Liquidity</h2>
+        <p class="analytics-subtitle">Liquidity pool shares held by a wallet, read directly from Horizon.</p>
+
+        <div class="form-field">
+          <label for="sb-wallet">Wallet Public Key (G...)</label>
+          <input id="sb-wallet" type="text" placeholder="G..." autocomplete="off" />
+        </div>
+
+        <div class="actions">
+          <button id="sb-load" type="button">Load Positions</button>
+        </div>
+
+        <p id="sb-status" class="status status-info" role="status" aria-live="polite">Enter a wallet to load its pool shares.</p>
+        <div id="sb-positions" class="analytics-section"></div>
+      </section>
+    `;
+
+    this.byId<HTMLButtonElement>('sb-load').addEventListener('click', () => void this.load());
+  }
+
+  async load(): Promise<void> {
+    const publicKey = this.byId<HTMLInputElement>('sb-wallet').value.trim();
+    if (!publicKey) {
+      this.setStatus('Enter a wallet public key first.', 'error');
+      return;
+    }
+
+    this.setStatus('Loading pool shares…', 'info');
+    try {
+      const positions = await this.deps.loadLpPositions(publicKey);
+      this.renderPositions(positions);
+      this.setStatus(
+        positions.length ? `${positions.length} pool position(s) found.` : 'No liquidity positions for this wallet.',
+        'success'
+      );
+    } catch (error) {
+      this.setStatus(error instanceof Error ? error.message : 'Failed to load pool shares.', 'error');
+    }
+  }
+
+  private renderPositions(positions: LpPosition[]): void {
+    const host = this.byId('sb-positions');
+    if (positions.length === 0) {
+      host.innerHTML = '<p class="analytics-activity-empty">No active liquidity pool positions.</p>';
+      return;
+    }
+
+    const rows = positions
+      .map(
+        (position) => `
+          <tr>
+            <td><code>${position.poolId.slice(0, 12)}…</code></td>
+            <td class="analytics-num">${position.shares}</td>
+            <td><span class="analytics-muted">unavailable</span></td>
+          </tr>`
+      )
+      .join('');
+
+    host.innerHTML = `
+      <h3>Pool positions</h3>
+      <div class="analytics-table-scroll">
+        <table class="analytics-table">
+          <thead>
+            <tr><th scope="col">Pool</th><th scope="col">Shares</th><th scope="col">Value (USD)</th></tr>
+          </thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>`;
+  }
+
+  private setStatus(message: string, tone: 'info' | 'success' | 'error'): void {
+    const status = this.byId('sb-status');
+    status.textContent = message;
+    status.className = `status status-${tone}`;
+  }
+
+  private byId<T extends HTMLElement>(id: string): T {
+    return this.container.querySelector(`#${id}`) as T;
+  }
+}

--- a/packages/frontend/src/services/analytics.client.ts
+++ b/packages/frontend/src/services/analytics.client.ts
@@ -1,0 +1,86 @@
+export interface BlendPositionLike {
+  collateralValue?: string;
+  debtValue?: string;
+  healthFactor?: string;
+  supplyAPY?: string;
+  borrowAPY?: string;
+  supplied?: { amount: string; valueUSD?: string }[];
+}
+
+export interface SoroswapLpLike {
+  poolLabel: string;
+  valueUSD: number;
+  feeApr?: number;
+}
+
+export interface PositionRow {
+  protocol: string;
+  type: string;
+  value: number;
+  healthFactor: number | null;
+  apy: string | null;
+}
+
+export interface AllocationEntry {
+  label: string;
+  value: number;
+}
+
+export interface SimulatedPnl {
+  costBasis: number;
+  pnl: number;
+  percent: number;
+}
+
+function num(value?: string): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function buildBlendRow(position: BlendPositionLike): PositionRow {
+  const hasCollateral = position.collateralValue !== undefined || position.debtValue !== undefined;
+  const value = hasCollateral
+    ? num(position.collateralValue) - num(position.debtValue)
+    : (position.supplied ?? []).reduce((sum, item) => sum + num(item.valueUSD), 0);
+
+  return {
+    protocol: 'Blend',
+    type: 'Lending',
+    value,
+    healthFactor: position.healthFactor !== undefined ? num(position.healthFactor) : null,
+    apy: position.supplyAPY ?? null,
+  };
+}
+
+export function buildSoroswapRow(lp: SoroswapLpLike): PositionRow {
+  return {
+    protocol: 'Soroswap',
+    type: 'Liquidity Pool',
+    value: lp.valueUSD,
+    healthFactor: null,
+    apy: lp.feeApr !== undefined ? `${lp.feeApr.toFixed(2)}%` : null,
+  };
+}
+
+export function totalValue(rows: PositionRow[]): number {
+  return rows.reduce((sum, row) => sum + row.value, 0);
+}
+
+export function allocation(rows: PositionRow[]): AllocationEntry[] {
+  const byProtocol = new Map<string, number>();
+  rows.forEach((row) => {
+    if (row.value <= 0) return;
+    byProtocol.set(row.protocol, (byProtocol.get(row.protocol) ?? 0) + row.value);
+  });
+  return [...byProtocol.entries()].map(([label, value]) => ({ label, value }));
+}
+
+export function simulatedCostBasisPnl(currentValue: number, factor = 0.9): SimulatedPnl {
+  const costBasis = currentValue * factor;
+  const pnl = currentValue - costBasis;
+  return {
+    costBasis,
+    pnl,
+    percent: costBasis !== 0 ? (pnl / costBasis) * 100 : 0,
+  };
+}

--- a/packages/frontend/src/services/market-socket.client.ts
+++ b/packages/frontend/src/services/market-socket.client.ts
@@ -1,0 +1,74 @@
+import { io } from 'socket.io-client';
+
+export interface PriceUpdate {
+  pair: string;
+  price: number;
+  volume?: number;
+  change24h?: number;
+}
+
+export interface MarketSocketLike {
+  on(event: string, handler: (payload: unknown) => void): void;
+  emit(event: string, payload?: unknown): void;
+  disconnect(): void;
+}
+
+export interface MarketSocketOptions {
+  url?: string;
+  pairs?: string[];
+  factory?: (url: string) => MarketSocketLike;
+}
+
+export const DEFAULT_MARKET_PAIRS = ['BTC/USDC', 'ETH/USDC', 'XLM/USDC'];
+
+type Listener = (update: PriceUpdate) => void;
+
+function toUpdate(payload: unknown): PriceUpdate | null {
+  const data = (payload as { data?: unknown })?.data ?? payload;
+  const record = data as Partial<PriceUpdate> | null | undefined;
+  if (!record || typeof record.pair !== 'string') return null;
+  return {
+    pair: record.pair,
+    price: Number(record.price),
+    volume: record.volume,
+    change24h: record.change24h,
+  };
+}
+
+export class MarketSocketClient {
+  private socket: MarketSocketLike | null = null;
+  private readonly listeners = new Set<Listener>();
+  private readonly url: string;
+  private readonly pairs: string[];
+  private readonly factory: (url: string) => MarketSocketLike;
+
+  constructor(options: MarketSocketOptions = {}) {
+    this.url = options.url ?? '/';
+    this.pairs = options.pairs ?? DEFAULT_MARKET_PAIRS;
+    this.factory = options.factory ?? ((url) => io(url) as unknown as MarketSocketLike);
+  }
+
+  connect(): void {
+    if (this.socket) return;
+    const socket = this.factory(this.url);
+    this.socket = socket;
+    socket.on('connect', () => socket.emit('market:subscribe', { pairs: this.pairs }));
+    socket.on('market:price_update', (payload) => this.dispatch(payload));
+  }
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  disconnect(): void {
+    this.socket?.disconnect();
+    this.socket = null;
+  }
+
+  private dispatch(payload: unknown): void {
+    const update = toUpdate(payload);
+    if (!update) return;
+    this.listeners.forEach((listener) => listener(update));
+  }
+}

--- a/packages/frontend/src/services/market-socket.client.ts
+++ b/packages/frontend/src/services/market-socket.client.ts
@@ -23,15 +23,24 @@ export const DEFAULT_MARKET_PAIRS = ['BTC/USDC', 'ETH/USDC', 'XLM/USDC'];
 
 type Listener = (update: PriceUpdate) => void;
 
+function finiteOrUndefined(value: unknown): number | undefined {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
 function toUpdate(payload: unknown): PriceUpdate | null {
   const data = (payload as { data?: unknown })?.data ?? payload;
   const record = data as Partial<PriceUpdate> | null | undefined;
   if (!record || typeof record.pair !== 'string') return null;
+
+  const price = finiteOrUndefined(record.price);
+  if (price === undefined) return null;
+
   return {
     pair: record.pair,
-    price: Number(record.price),
-    volume: record.volume,
-    change24h: record.change24h,
+    price,
+    volume: finiteOrUndefined(record.volume),
+    change24h: finiteOrUndefined(record.change24h),
   };
 }
 

--- a/packages/frontend/src/services/portfolio-snapshots.ts
+++ b/packages/frontend/src/services/portfolio-snapshots.ts
@@ -1,0 +1,111 @@
+export type SnapshotSeries = 'portfolio' | 'price';
+
+export interface Snapshot {
+  ts: number;
+  series: SnapshotSeries;
+  value: number;
+}
+
+export interface SeriesDelta {
+  base: number;
+  latest: number;
+  absolute: number;
+  percent: number;
+}
+
+type Listener = (snapshots: Snapshot[]) => void;
+
+export const SNAPSHOT_STORAGE_KEY = 'galaxy_portfolio_snapshots_v1';
+export const MAX_SNAPSHOTS = 500;
+
+function hasStorage(): boolean {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+}
+
+function readSnapshots(): Snapshot[] {
+  if (!hasStorage()) return [];
+  try {
+    const raw = window.localStorage.getItem(SNAPSHOT_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as Snapshot[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeSnapshots(snapshots: Snapshot[]): void {
+  if (!hasStorage()) return;
+  try {
+    window.localStorage.setItem(SNAPSHOT_STORAGE_KEY, JSON.stringify(snapshots));
+  } catch {
+    // Persistence is best-effort; a full quota must not break in-memory tracking.
+  }
+}
+
+function toDelta(base: number, latest: number): SeriesDelta {
+  const absolute = latest - base;
+  return {
+    base,
+    latest,
+    absolute,
+    percent: base !== 0 ? (absolute / base) * 100 : 0,
+  };
+}
+
+export class PortfolioSnapshotStore {
+  private snapshots: Snapshot[];
+  private listeners: Set<Listener>;
+
+  constructor() {
+    this.snapshots = readSnapshots();
+    this.listeners = new Set();
+  }
+
+  append(series: SnapshotSeries, value: number, ts: number = Date.now()): Snapshot {
+    const snapshot: Snapshot = { ts, series, value };
+    const next = [...this.snapshots, snapshot];
+    this.snapshots = next.slice(Math.max(0, next.length - MAX_SNAPSHOTS));
+    this.persistAndNotify();
+    return snapshot;
+  }
+
+  series(series: SnapshotSeries): Snapshot[] {
+    return this.snapshots
+      .filter((snapshot) => snapshot.series === series)
+      .sort((a, b) => a.ts - b.ts);
+  }
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    listener([...this.snapshots]);
+    return () => this.listeners.delete(listener);
+  }
+
+  delta(series: SnapshotSeries): SeriesDelta | null {
+    const points = this.series(series);
+    if (points.length === 0) return null;
+    return toDelta(points[0].value, points[points.length - 1].value);
+  }
+
+  deltaSince(series: SnapshotSeries, windowMs: number, now: number = Date.now()): SeriesDelta | null {
+    const points = this.series(series);
+    if (points.length === 0) return null;
+
+    const cutoff = now - windowMs;
+    const withinWindow = [...points].reverse().find((point) => point.ts <= cutoff);
+    const base = withinWindow ?? points[0];
+    return toDelta(base.value, points[points.length - 1].value);
+  }
+
+  clear(): void {
+    this.snapshots = [];
+    this.persistAndNotify();
+  }
+
+  private persistAndNotify(): void {
+    writeSnapshots(this.snapshots);
+    const snapshot = [...this.snapshots];
+    this.listeners.forEach((listener) => listener(snapshot));
+  }
+}

--- a/packages/frontend/src/services/portfolio-snapshots.ts
+++ b/packages/frontend/src/services/portfolio-snapshots.ts
@@ -1,4 +1,6 @@
-export type SnapshotSeries = 'portfolio' | 'price';
+// A series key namespaces snapshots (e.g. `portfolio:<network>:<wallet>`), so
+// distinct wallets/networks never share a history.
+export type SnapshotSeries = string;
 
 export interface Snapshot {
   ts: number;

--- a/packages/frontend/src/styles.css
+++ b/packages/frontend/src/styles.css
@@ -788,7 +788,7 @@ h1 {
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
 }

--- a/packages/frontend/src/styles.css
+++ b/packages/frontend/src/styles.css
@@ -2,6 +2,18 @@
   color: #16211f;
   background: #edf3ec;
   font-family: Avenir, "Avenir Next", "Segoe UI", sans-serif;
+
+  --ana-ink: #16211f;
+  --ana-ink-soft: #52615d;
+  --ana-surface: rgba(255, 255, 255, 0.86);
+  --ana-border: rgba(22, 33, 31, 0.16);
+  --ana-radius: 8px;
+  --ana-green-bg: #d8efe3;
+  --ana-green-fg: #185b39;
+  --ana-yellow-bg: #f4e5c6;
+  --ana-yellow-fg: #5f4303;
+  --ana-red-bg: #f7d9d1;
+  --ana-red-fg: #8b2c19;
 }
 
 * {
@@ -527,4 +539,269 @@ h1 {
   font-size: 0.78rem;
   overflow-x: auto;
   max-height: 160px;
+}
+
+/* ── Analytics dashboard, Soroswap and live feed panels ────────────────────── */
+
+.analytics-subtitle {
+  margin: 0 0 1rem;
+  color: var(--ana-ink-soft);
+  font-size: 0.92rem;
+}
+
+.analytics-num {
+  font-variant-numeric: tabular-nums;
+}
+
+.analytics-muted {
+  color: var(--ana-ink-soft);
+  font-style: italic;
+}
+
+.sim-badge {
+  display: inline-block;
+  border-radius: 999px;
+  background: #ece3cf;
+  color: #6b5117;
+  border: 1px dashed #b89a4e;
+  font-size: 0.64rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.05rem 0.45rem;
+  vertical-align: middle;
+}
+
+.sim-badge--observed {
+  background: #dce9f3;
+  color: #1c4a74;
+  border-color: #7ea6cc;
+}
+
+/* Keep the badge small even inside larger typographic contexts (risk values). */
+.analytics-risk .sim-badge {
+  font-size: 0.62rem;
+  font-weight: 800;
+}
+
+.analytics-kpis {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.analytics-kpi {
+  border: 1px solid var(--ana-border);
+  border-radius: var(--ana-radius);
+  background: var(--ana-surface);
+  padding: 0.8rem 0.9rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.analytics-kpi-label {
+  color: var(--ana-ink-soft);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.analytics-kpi strong {
+  font-size: 1.3rem;
+}
+
+.analytics-tone--green { color: var(--ana-green-fg); }
+.analytics-tone--red { color: var(--ana-red-fg); }
+.analytics-tone--yellow { color: var(--ana-yellow-fg); }
+
+.analytics-charts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.analytics-figure {
+  margin: 0;
+  border: 1px solid var(--ana-border);
+  border-radius: var(--ana-radius);
+  background: var(--ana-surface);
+  padding: 0.9rem;
+}
+
+.analytics-figure figcaption {
+  font-weight: 700;
+  font-size: 0.86rem;
+  margin-bottom: 0.6rem;
+}
+
+.analytics-section {
+  margin-bottom: 1.25rem;
+}
+
+.analytics-section h3 {
+  margin: 0 0 0.75rem;
+}
+
+.analytics-table-scroll {
+  overflow-x: auto;
+}
+
+.analytics-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.analytics-table th,
+.analytics-table td {
+  text-align: left;
+  padding: 0.55rem 0.65rem;
+  border-bottom: 1px solid var(--ana-border);
+  white-space: nowrap;
+}
+
+.analytics-table th {
+  color: var(--ana-ink-soft);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.analytics-risk-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.analytics-risk {
+  border: 1px solid var(--ana-border);
+  border-radius: var(--ana-radius);
+  padding: 0.8rem 0.9rem;
+  display: grid;
+  gap: 0.35rem;
+  background: var(--ana-surface);
+}
+
+.analytics-risk strong {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.analytics-risk span {
+  font-size: 1.4rem;
+  font-weight: 800;
+}
+
+.analytics-risk--green { background: var(--ana-green-bg); color: var(--ana-green-fg); }
+.analytics-risk--yellow { background: var(--ana-yellow-bg); color: var(--ana-yellow-fg); }
+.analytics-risk--red { background: var(--ana-red-bg); color: var(--ana-red-fg); }
+
+.analytics-alerts {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.analytics-alert {
+  border-radius: 6px;
+  padding: 0.55rem 0.7rem;
+  font-size: 0.88rem;
+}
+
+.analytics-alert--green { background: var(--ana-green-bg); color: var(--ana-green-fg); }
+.analytics-alert--yellow { background: var(--ana-yellow-bg); color: var(--ana-yellow-fg); }
+.analytics-alert--red { background: var(--ana-red-bg); color: var(--ana-red-fg); }
+
+.analytics-activity {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.analytics-activity-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border: 1px solid var(--ana-border);
+  border-radius: 6px;
+  background: var(--ana-surface);
+  padding: 0.55rem 0.7rem;
+  font-size: 0.9rem;
+}
+
+.analytics-activity-item time {
+  color: var(--ana-ink-soft);
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.analytics-activity-empty {
+  color: var(--ana-ink-soft);
+}
+
+.feed-header {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.25rem;
+}
+
+.feed-header h2 {
+  margin: 0;
+}
+
+.chart-line {
+  stroke: #173f36;
+  stroke-width: 2;
+}
+
+.chart-slice--0 { fill: #2f7d6c; }
+.chart-slice--1 { fill: #de5d45; }
+.chart-slice--2 { fill: #d18b1f; }
+.chart-slice--3 { fill: #124b95; }
+.chart-slice--4 { fill: #6e7c79; }
+.chart-slice--5 { fill: #8b2c19; }
+
+.chart-slice-label {
+  fill: #ffffff;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.chart-empty {
+  fill: var(--ana-ink-soft);
+  font-size: 12px;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 760px) {
+  .analytics-charts {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chart-line,
+  .chart-slice {
+    transition: none;
+  }
 }

--- a/packages/frontend/src/tests/analytics-dashboard.panel.test.ts
+++ b/packages/frontend/src/tests/analytics-dashboard.panel.test.ts
@@ -6,6 +6,8 @@ import { AnalyticsDashboardPanel, type DashboardDeps } from '../panels/analytics
 import { PortfolioSnapshotStore } from '../services/portfolio-snapshots';
 import { TxTrackerService } from '../services/tx-tracker';
 
+const mountedPanels: AnalyticsDashboardPanel[] = [];
+
 function mountPanel(overrides: Partial<DashboardDeps> = {}) {
   const container = document.createElement('div');
   document.body.appendChild(container);
@@ -20,16 +22,25 @@ function mountPanel(overrides: Partial<DashboardDeps> = {}) {
     store: new PortfolioSnapshotStore(),
     tracker: new TxTrackerService(),
     now: () => 1_000_000,
+    network: 'testnet',
     ...overrides,
   };
   const panel = new AnalyticsDashboardPanel(container, deps);
+  mountedPanels.push(panel);
   return { container, panel };
 }
+
+const SERIES_KEY = 'portfolio:testnet:GABC';
 
 describe('AnalyticsDashboardPanel', () => {
   beforeEach(() => {
     localStorage.clear();
     document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    // Stop the auto-refresh timers so no interval outlives the test.
+    while (mountedPanels.length) mountedPanels.pop()!.destroy();
   });
 
   it('renders the controls and stays hidden until a portfolio loads', () => {
@@ -80,7 +91,7 @@ describe('AnalyticsDashboardPanel', () => {
     await panel.refresh();
     await panel.refresh();
 
-    expect(store.series('portfolio')).toHaveLength(2);
+    expect(store.series(SERIES_KEY)).toHaveLength(2);
   });
 
   it('leaves 24h change blank until the observed series spans a day', async () => {
@@ -96,7 +107,7 @@ describe('AnalyticsDashboardPanel', () => {
 
   it('shows a real 24h change once the series spans a day', async () => {
     const store = new PortfolioSnapshotStore();
-    store.append('portfolio', 900, 1_000_000 - 25 * 60 * 60 * 1000);
+    store.append(SERIES_KEY, 900, 1_000_000 - 25 * 60 * 60 * 1000);
     const { container, panel } = mountPanel({ store });
     container.querySelector<HTMLInputElement>('#ad-wallet')!.value = 'GABC';
     await panel.refresh();

--- a/packages/frontend/src/tests/analytics-dashboard.panel.test.ts
+++ b/packages/frontend/src/tests/analytics-dashboard.panel.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment jest-environment-jsdom
+ */
+
+import { AnalyticsDashboardPanel, type DashboardDeps } from '../panels/analytics-dashboard';
+import { PortfolioSnapshotStore } from '../services/portfolio-snapshots';
+import { TxTrackerService } from '../services/tx-tracker';
+
+function mountPanel(overrides: Partial<DashboardDeps> = {}) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const deps: Partial<DashboardDeps> = {
+    loadPosition: async () => ({
+      collateralValue: '150',
+      debtValue: '50',
+      healthFactor: '1.8',
+      supplyAPY: '4.20',
+    }),
+    loadSoroswapRows: async () => [],
+    store: new PortfolioSnapshotStore(),
+    tracker: new TxTrackerService(),
+    now: () => 1_000_000,
+    ...overrides,
+  };
+  const panel = new AnalyticsDashboardPanel(container, deps);
+  return { container, panel };
+}
+
+describe('AnalyticsDashboardPanel', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = '';
+  });
+
+  it('renders the controls and stays hidden until a portfolio loads', () => {
+    const { container } = mountPanel();
+    expect(container.querySelector('#ad-load')).not.toBeNull();
+    expect(container.querySelector<HTMLElement>('#ad-body')!.hidden).toBe(true);
+  });
+
+  it('warns when refreshing without a wallet', async () => {
+    const { container, panel } = mountPanel();
+    await panel.refresh();
+    expect(container.querySelector('#ad-status')!.textContent).toContain('Enter a wallet');
+    expect(container.querySelector('#ad-status')!.className).toContain('status-error');
+  });
+
+  it('renders positions, charts and risk once loaded', async () => {
+    const { container, panel } = mountPanel();
+    container.querySelector<HTMLInputElement>('#ad-wallet')!.value = 'GABC';
+    await panel.refresh();
+
+    expect(container.querySelector<HTMLElement>('#ad-body')!.hidden).toBe(false);
+    expect(container.querySelector('.analytics-table tbody tr')!.textContent).toContain('Blend');
+    expect(container.querySelectorAll('svg[role="img"]').length).toBe(2);
+    expect(container.querySelector('#ad-risk')!.textContent).toContain('Risk score');
+  });
+
+  it('labels every simulated metric and never labels a real one', async () => {
+    const { container, panel } = mountPanel();
+    container.querySelector<HTMLInputElement>('#ad-wallet')!.value = 'GABC';
+    await panel.refresh();
+
+    const simPnl = [...container.querySelectorAll('.analytics-kpi')].find((el) =>
+      el.textContent?.includes('PnL (simulated)')
+    );
+    expect(simPnl!.querySelector('.sim-badge')).not.toBeNull();
+
+    const totalValue = [...container.querySelectorAll('.analytics-kpi')].find((el) =>
+      el.textContent?.includes('Total value')
+    );
+    expect(totalValue!.querySelector('.sim-badge')).toBeNull();
+  });
+
+  it('records a snapshot per refresh so the observed series grows', async () => {
+    const store = new PortfolioSnapshotStore();
+    const { container, panel } = mountPanel({ store });
+    container.querySelector<HTMLInputElement>('#ad-wallet')!.value = 'GABC';
+
+    await panel.refresh();
+    await panel.refresh();
+
+    expect(store.series('portfolio')).toHaveLength(2);
+  });
+
+  it('leaves 24h change blank until the observed series spans a day', async () => {
+    const { container, panel } = mountPanel();
+    container.querySelector<HTMLInputElement>('#ad-wallet')!.value = 'GABC';
+    await panel.refresh();
+
+    const tile = [...container.querySelectorAll('.analytics-kpi')].find((el) =>
+      el.textContent?.includes('24h change')
+    );
+    expect(tile!.querySelector('strong')!.textContent).toBe('—');
+  });
+
+  it('shows a real 24h change once the series spans a day', async () => {
+    const store = new PortfolioSnapshotStore();
+    store.append('portfolio', 900, 1_000_000 - 25 * 60 * 60 * 1000);
+    const { container, panel } = mountPanel({ store });
+    container.querySelector<HTMLInputElement>('#ad-wallet')!.value = 'GABC';
+    await panel.refresh();
+
+    const tile = [...container.querySelectorAll('.analytics-kpi')].find((el) =>
+      el.textContent?.includes('24h change')
+    );
+    expect(tile!.querySelector('strong')!.textContent).not.toBe('—');
+  });
+
+  it('surfaces load failures in the status line', async () => {
+    const { container, panel } = mountPanel({
+      loadPosition: async () => {
+        throw new Error('network down');
+      },
+    });
+    container.querySelector<HTMLInputElement>('#ad-wallet')!.value = 'GABC';
+    await panel.refresh();
+
+    expect(container.querySelector('#ad-status')!.textContent).toContain('network down');
+  });
+});

--- a/packages/frontend/src/tests/analytics.client.test.ts
+++ b/packages/frontend/src/tests/analytics.client.test.ts
@@ -1,0 +1,86 @@
+import {
+  buildBlendRow,
+  buildSoroswapRow,
+  totalValue,
+  allocation,
+  simulatedCostBasisPnl,
+} from '../services/analytics.client';
+
+describe('buildBlendRow', () => {
+  it('derives net value, health factor and apy when present', () => {
+    const row = buildBlendRow({
+      collateralValue: '150',
+      debtValue: '50',
+      healthFactor: '1.8',
+      supplyAPY: '4.20',
+    });
+
+    expect(row).toEqual({
+      protocol: 'Blend',
+      type: 'Lending',
+      value: 100,
+      healthFactor: 1.8,
+      apy: '4.20',
+    });
+  });
+
+  it('marks apy unavailable when the backend omits it', () => {
+    const row = buildBlendRow({ collateralValue: '150', debtValue: '50', healthFactor: '1.8' });
+    expect(row.apy).toBeNull();
+  });
+
+  it('falls back to supplied values when collateral is absent', () => {
+    const row = buildBlendRow({ supplied: [{ amount: '10', valueUSD: '30' }, { amount: '5', valueUSD: '20' }] });
+    expect(row.value).toBe(50);
+    expect(row.healthFactor).toBeNull();
+  });
+});
+
+describe('buildSoroswapRow', () => {
+  it('maps a liquidity position with fee apr', () => {
+    const row = buildSoroswapRow({ poolLabel: 'XLM/USDC', valueUSD: 42, feeApr: 3.5 });
+    expect(row).toEqual({
+      protocol: 'Soroswap',
+      type: 'Liquidity Pool',
+      value: 42,
+      healthFactor: null,
+      apy: '3.50%',
+    });
+  });
+
+  it('marks apy unavailable without a fee apr', () => {
+    const row = buildSoroswapRow({ poolLabel: 'XLM/USDC', valueUSD: 42 });
+    expect(row.apy).toBeNull();
+  });
+});
+
+describe('aggregation', () => {
+  const rows = [
+    buildBlendRow({ collateralValue: '100', debtValue: '0' }),
+    buildSoroswapRow({ poolLabel: 'XLM/USDC', valueUSD: 50 }),
+  ];
+
+  it('sums the total value across protocols', () => {
+    expect(totalValue(rows)).toBe(150);
+  });
+
+  it('breaks allocation down by protocol', () => {
+    expect(allocation(rows)).toEqual([
+      { label: 'Blend', value: 100 },
+      { label: 'Soroswap', value: 50 },
+    ]);
+  });
+});
+
+describe('simulatedCostBasisPnl', () => {
+  it('derives a simulated cost basis and pnl from the current value', () => {
+    const result = simulatedCostBasisPnl(110, 0.9);
+    expect(result.costBasis).toBeCloseTo(99);
+    expect(result.pnl).toBeCloseTo(11);
+    expect(result.percent).toBeCloseTo(11.11, 1);
+  });
+
+  it('avoids dividing by zero when the current value is zero', () => {
+    expect(simulatedCostBasisPnl(0).percent).toBe(0);
+  });
+});

--- a/packages/frontend/src/tests/line-chart.test.ts
+++ b/packages/frontend/src/tests/line-chart.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment jest-environment-jsdom
+ */
+
+import { buildLineChart, buildLineChartTable } from '../charts/line-chart';
+
+describe('buildLineChart', () => {
+  it('renders an accessible svg with one vertex per point', () => {
+    const svg = buildLineChart(
+      [
+        { ts: 1, value: 10 },
+        { ts: 2, value: 20 },
+        { ts: 3, value: 15 },
+      ],
+      { ariaLabel: 'Portfolio value over time' }
+    );
+
+    expect(svg.tagName.toLowerCase()).toBe('svg');
+    expect(svg.getAttribute('role')).toBe('img');
+    expect(svg.getAttribute('aria-label')).toBe('Portfolio value over time');
+    expect(svg.getAttribute('data-empty')).toBe('false');
+
+    const path = svg.querySelector('path[data-testid="line"]');
+    expect(path).not.toBeNull();
+    const commands = path!.getAttribute('d')!.match(/[ML]/g) ?? [];
+    expect(commands).toHaveLength(3);
+  });
+
+  it('renders an explicit empty state when there is no data', () => {
+    const svg = buildLineChart([], { ariaLabel: 'Portfolio value', emptyLabel: 'observed since first load' });
+
+    expect(svg.getAttribute('data-empty')).toBe('true');
+    expect(svg.getAttribute('aria-label')).toContain('observed since first load');
+    expect(svg.querySelector('path[data-testid="line"]')).toBeNull();
+    expect(svg.textContent).toContain('observed since first load');
+  });
+
+  it('handles a single point without collapsing the path', () => {
+    const svg = buildLineChart([{ ts: 1, value: 5 }], { ariaLabel: 'One point' });
+    const path = svg.querySelector('path[data-testid="line"]');
+    expect(path).not.toBeNull();
+    expect(svg.getAttribute('data-empty')).toBe('false');
+  });
+
+  it('builds a data-table alternative with a row per point', () => {
+    const table = buildLineChartTable(
+      [
+        { ts: 1000, value: 10 },
+        { ts: 2000, value: 20 },
+      ],
+      { valueLabel: 'Value (USD)' }
+    );
+
+    expect(table.tagName.toLowerCase()).toBe('table');
+    expect(table.querySelectorAll('tbody tr')).toHaveLength(2);
+    expect(table.querySelectorAll('.chart-table__value')).toHaveLength(2);
+  });
+});

--- a/packages/frontend/src/tests/live-market-feed.panel.test.ts
+++ b/packages/frontend/src/tests/live-market-feed.panel.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jest-environment-jsdom
+ */
+
+import { LiveMarketFeedPanel } from '../panels/live-market-feed';
+import { MarketSocketClient } from '../services/market-socket.client';
+
+class FakeSocket {
+  handlers = new Map<string, (payload: unknown) => void>();
+  disconnected = false;
+  on(event: string, handler: (payload: unknown) => void): void {
+    this.handlers.set(event, handler);
+  }
+  emit(): void {}
+  disconnect(): void {
+    this.disconnected = true;
+  }
+  fire(event: string, payload?: unknown): void {
+    this.handlers.get(event)?.(payload);
+  }
+}
+
+function priceEvent(pair: string, price: number, change24h: number) {
+  return { type: 'market:price_update', data: { pair, price, change24h } };
+}
+
+function mount() {
+  const socket = new FakeSocket();
+  const client = new MarketSocketClient({ factory: () => socket });
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const panel = new LiveMarketFeedPanel(container, { client });
+  return { container, panel, socket };
+}
+
+describe('LiveMarketFeedPanel', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('carries a simulated badge in its header', () => {
+    const { container } = mount();
+    const header = container.querySelector('.feed-header');
+    expect(header!.querySelector('.sim-badge')).not.toBeNull();
+  });
+
+  it('shows a waiting state until the first tick arrives', () => {
+    const { container } = mount();
+    expect(container.querySelector('#lmf-empty')).not.toBeNull();
+  });
+
+  it('renders a row when a price update arrives', () => {
+    const { container, socket } = mount();
+    socket.fire('market:price_update', priceEvent('BTC/USDC', 45000, 1.2));
+
+    expect(container.querySelector('#lmf-empty')).toBeNull();
+    const row = container.querySelector('#lmf-BTC-USDC');
+    expect(row).not.toBeNull();
+    expect(row!.textContent).toContain('45,000');
+    expect(row!.textContent).toContain('+1.20%');
+  });
+
+  it('updates the existing row in place on the next tick', () => {
+    const { container, socket } = mount();
+    socket.fire('market:price_update', priceEvent('XLM/USDC', 0.1, 0));
+    socket.fire('market:price_update', priceEvent('XLM/USDC', 0.12, -2));
+
+    expect(container.querySelectorAll('#lmf-body tr')).toHaveLength(1);
+    expect(container.querySelector('#lmf-XLM-USDC')!.textContent).toContain('−2.00%');
+  });
+
+  it('disconnects the socket on destroy', () => {
+    const { panel, socket } = mount();
+    panel.destroy();
+    expect(socket.disconnected).toBe(true);
+  });
+});

--- a/packages/frontend/src/tests/market-socket.client.test.ts
+++ b/packages/frontend/src/tests/market-socket.client.test.ts
@@ -1,0 +1,115 @@
+import { MarketSocketClient, DEFAULT_MARKET_PAIRS } from '../services/market-socket.client';
+
+class FakeSocket {
+  handlers = new Map<string, (payload: unknown) => void>();
+  emitted: { event: string; payload: unknown }[] = [];
+  disconnected = false;
+
+  on(event: string, handler: (payload: unknown) => void): void {
+    this.handlers.set(event, handler);
+  }
+
+  emit(event: string, payload?: unknown): void {
+    this.emitted.push({ event, payload });
+  }
+
+  disconnect(): void {
+    this.disconnected = true;
+  }
+
+  fire(event: string, payload?: unknown): void {
+    this.handlers.get(event)?.(payload);
+  }
+}
+
+function priceEvent(pair: string, price: number) {
+  return { type: 'market:price_update', data: { pair, price, volume: 1000, change24h: 2 } };
+}
+
+describe('MarketSocketClient', () => {
+  it('subscribes to the configured pairs once connected', () => {
+    const socket = new FakeSocket();
+    const client = new MarketSocketClient({ pairs: ['BTC/USDC'], factory: () => socket });
+    client.connect();
+    socket.fire('connect');
+
+    expect(socket.emitted).toContainEqual({ event: 'market:subscribe', payload: { pairs: ['BTC/USDC'] } });
+  });
+
+  it('normalizes price updates and forwards them to subscribers', () => {
+    const socket = new FakeSocket();
+    const client = new MarketSocketClient({ factory: () => socket });
+    const received: unknown[] = [];
+    client.subscribe((update) => received.push(update));
+    client.connect();
+
+    socket.fire('market:price_update', priceEvent('XLM/USDC', 0.12));
+
+    expect(received).toEqual([{ pair: 'XLM/USDC', price: 0.12, volume: 1000, change24h: 2 }]);
+  });
+
+  it('defaults to the three known market pairs', () => {
+    const socket = new FakeSocket();
+    const client = new MarketSocketClient({ factory: () => socket });
+    client.connect();
+    socket.fire('connect');
+
+    expect(socket.emitted[0]).toEqual({ event: 'market:subscribe', payload: { pairs: DEFAULT_MARKET_PAIRS } });
+  });
+
+  it('ignores malformed payloads', () => {
+    const socket = new FakeSocket();
+    const client = new MarketSocketClient({ factory: () => socket });
+    const received: unknown[] = [];
+    client.subscribe((update) => received.push(update));
+    client.connect();
+
+    socket.fire('market:price_update', { data: { price: 1 } });
+    socket.fire('market:price_update', null);
+
+    expect(received).toHaveLength(0);
+  });
+
+  it('stops forwarding after unsubscribe', () => {
+    const socket = new FakeSocket();
+    const client = new MarketSocketClient({ factory: () => socket });
+    const received: unknown[] = [];
+    const unsubscribe = client.subscribe((update) => received.push(update));
+    client.connect();
+    unsubscribe();
+
+    socket.fire('market:price_update', priceEvent('XLM/USDC', 0.12));
+    expect(received).toHaveLength(0);
+  });
+
+  it('connects only once even if called repeatedly', () => {
+    let created = 0;
+    const socket = new FakeSocket();
+    const client = new MarketSocketClient({
+      factory: () => {
+        created += 1;
+        return socket;
+      },
+    });
+    client.connect();
+    client.connect();
+    expect(created).toBe(1);
+  });
+
+  it('disconnects the underlying socket and allows reconnecting', () => {
+    const sockets: FakeSocket[] = [];
+    const client = new MarketSocketClient({
+      factory: () => {
+        const socket = new FakeSocket();
+        sockets.push(socket);
+        return socket;
+      },
+    });
+    client.connect();
+    client.disconnect();
+    client.connect();
+
+    expect(sockets).toHaveLength(2);
+    expect(sockets[0].disconnected).toBe(true);
+  });
+});

--- a/packages/frontend/src/tests/pie-chart.test.ts
+++ b/packages/frontend/src/tests/pie-chart.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jest-environment-jsdom
+ */
+
+import { buildPieChart, buildPieChartTable } from '../charts/pie-chart';
+
+describe('buildPieChart', () => {
+  it('renders an accessible svg with one labelled slice per entry', () => {
+    const svg = buildPieChart(
+      [
+        { label: 'XLM', value: 60 },
+        { label: 'USDC', value: 40 },
+      ],
+      { ariaLabel: 'Asset allocation' }
+    );
+
+    expect(svg.getAttribute('role')).toBe('img');
+    expect(svg.getAttribute('aria-label')).toBe('Asset allocation');
+    expect(svg.getAttribute('data-empty')).toBe('false');
+    expect(svg.querySelectorAll('path[data-testid="slice"]')).toHaveLength(2);
+    // Meaning is never carried by colour alone: every slice is also labelled.
+    expect(svg.querySelectorAll('text[data-testid="slice-label"]')).toHaveLength(2);
+  });
+
+  it('renders a single full-circle slice when one entry dominates', () => {
+    const svg = buildPieChart([{ label: 'XLM', value: 100 }], { ariaLabel: 'Allocation' });
+    expect(svg.querySelectorAll('path[data-testid="slice"]')).toHaveLength(1);
+    expect(svg.getAttribute('data-empty')).toBe('false');
+  });
+
+  it('renders an empty state when there is no data', () => {
+    const svg = buildPieChart([], { ariaLabel: 'Allocation', emptyLabel: 'No positions yet' });
+    expect(svg.getAttribute('data-empty')).toBe('true');
+    expect(svg.querySelectorAll('path[data-testid="slice"]')).toHaveLength(0);
+    expect(svg.textContent).toContain('No positions yet');
+  });
+
+  it('ignores non-positive slices so the geometry stays valid', () => {
+    const svg = buildPieChart(
+      [
+        { label: 'XLM', value: 50 },
+        { label: 'ZERO', value: 0 },
+      ],
+      { ariaLabel: 'Allocation' }
+    );
+    expect(svg.querySelectorAll('path[data-testid="slice"]')).toHaveLength(1);
+  });
+
+  it('builds a data-table alternative with a row per slice', () => {
+    const table = buildPieChartTable([
+      { label: 'XLM', value: 60 },
+      { label: 'USDC', value: 40 },
+    ]);
+    expect(table.querySelectorAll('tbody tr')).toHaveLength(2);
+    expect(table.querySelectorAll('.chart-table__value')).toHaveLength(2);
+  });
+});

--- a/packages/frontend/src/tests/portfolio-snapshots.test.ts
+++ b/packages/frontend/src/tests/portfolio-snapshots.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @jest-environment jest-environment-jsdom
+ */
+
+import {
+  PortfolioSnapshotStore,
+  SNAPSHOT_STORAGE_KEY,
+  MAX_SNAPSHOTS,
+} from '../services/portfolio-snapshots';
+
+describe('PortfolioSnapshotStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it('appends snapshots and returns each series in chronological order', () => {
+    const store = new PortfolioSnapshotStore();
+    store.append('portfolio', 100, 3);
+    store.append('portfolio', 90, 1);
+    store.append('price', 0.5, 2);
+
+    expect(store.series('portfolio').map((s) => s.value)).toEqual([90, 100]);
+    expect(store.series('price').map((s) => s.value)).toEqual([0.5]);
+  });
+
+  it('persists under a versioned key and reloads in a new instance', () => {
+    const store = new PortfolioSnapshotStore();
+    store.append('portfolio', 100, 1);
+
+    expect(localStorage.getItem(SNAPSHOT_STORAGE_KEY)).not.toBeNull();
+    expect(new PortfolioSnapshotStore().series('portfolio')).toHaveLength(1);
+  });
+
+  it('caps total entries and drops the oldest', () => {
+    const store = new PortfolioSnapshotStore();
+    for (let i = 0; i < MAX_SNAPSHOTS + 5; i++) {
+      store.append('portfolio', i, i);
+    }
+
+    const values = store.series('portfolio');
+    expect(values).toHaveLength(MAX_SNAPSHOTS);
+    expect(values[0].value).toBe(5);
+  });
+
+  it('does not throw when the write fails', () => {
+    const store = new PortfolioSnapshotStore();
+    jest
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('quota exceeded');
+      });
+
+    expect(() => store.append('portfolio', 100, 1)).not.toThrow();
+    expect(store.series('portfolio')).toHaveLength(1);
+  });
+
+  it('notifies subscribers immediately and on append', () => {
+    const store = new PortfolioSnapshotStore();
+    const listener = jest.fn();
+    store.subscribe(listener);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    store.append('portfolio', 100, 1);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops notifying after unsubscribe', () => {
+    const store = new PortfolioSnapshotStore();
+    const listener = jest.fn();
+    const unsubscribe = store.subscribe(listener);
+    unsubscribe();
+
+    store.append('portfolio', 100, 1);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('derives the delta against the first snapshot of a series', () => {
+    const store = new PortfolioSnapshotStore();
+    store.append('portfolio', 200, 1);
+    store.append('portfolio', 260, 2);
+
+    expect(store.delta('portfolio')).toEqual({
+      base: 200,
+      latest: 260,
+      absolute: 60,
+      percent: 30,
+    });
+  });
+
+  it('returns a zero percent when the first snapshot value is zero', () => {
+    const store = new PortfolioSnapshotStore();
+    store.append('portfolio', 0, 1);
+    store.append('portfolio', 50, 2);
+
+    expect(store.delta('portfolio')?.percent).toBe(0);
+  });
+
+  it('returns null delta when a series has no snapshots', () => {
+    const store = new PortfolioSnapshotStore();
+    expect(store.delta('price')).toBeNull();
+  });
+
+  it('measures the windowed delta against the snapshot before the cutoff', () => {
+    const store = new PortfolioSnapshotStore();
+    const hour = 60 * 60 * 1000;
+    const now = 100 * hour;
+    store.append('portfolio', 100, now - 30 * hour);
+    store.append('portfolio', 150, now - 10 * hour);
+    store.append('portfolio', 180, now);
+
+    const delta = store.deltaSince('portfolio', 24 * hour, now);
+    expect(delta).toEqual({ base: 100, latest: 180, absolute: 80, percent: 80 });
+  });
+
+  it('falls back to the first snapshot when history is younger than the window', () => {
+    const store = new PortfolioSnapshotStore();
+    const hour = 60 * 60 * 1000;
+    const now = 100 * hour;
+    store.append('portfolio', 120, now - 2 * hour);
+    store.append('portfolio', 132, now);
+
+    const delta = store.deltaSince('portfolio', 24 * hour, now);
+    expect(delta).toEqual({ base: 120, latest: 132, absolute: 12, percent: 10 });
+  });
+
+  it('recovers from a corrupted payload', () => {
+    localStorage.setItem(SNAPSHOT_STORAGE_KEY, '{not-json');
+    expect(new PortfolioSnapshotStore().series('portfolio')).toEqual([]);
+  });
+
+  it('ignores a non-array payload', () => {
+    localStorage.setItem(SNAPSHOT_STORAGE_KEY, JSON.stringify({ bad: true }));
+    expect(new PortfolioSnapshotStore().series('portfolio')).toEqual([]);
+  });
+
+  it('clears all snapshots', () => {
+    const store = new PortfolioSnapshotStore();
+    store.append('portfolio', 100, 1);
+    store.clear();
+    expect(store.series('portfolio')).toEqual([]);
+  });
+});

--- a/packages/frontend/src/tests/soroswap-browser.panel.test.ts
+++ b/packages/frontend/src/tests/soroswap-browser.panel.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jest-environment-jsdom
+ */
+
+import { SoroswapBrowserPanel } from '../panels/soroswap-browser';
+
+function mount(loadLpPositions: (publicKey: string) => Promise<{ poolId: string; shares: string }[]>) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const panel = new SoroswapBrowserPanel(container, { loadLpPositions });
+  return { container, panel };
+}
+
+describe('SoroswapBrowserPanel', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders the controls on mount', () => {
+    const { container } = mount(async () => []);
+    expect(container.querySelector('#sb-load')).not.toBeNull();
+    expect(container.querySelector('#sb-status')!.textContent).toContain('Enter a wallet');
+  });
+
+  it('warns when no wallet is provided', async () => {
+    const { container, panel } = mount(async () => []);
+    await panel.load();
+    expect(container.querySelector('#sb-status')!.className).toContain('status-error');
+  });
+
+  it('renders a row per liquidity position', async () => {
+    const { container, panel } = mount(async () => [
+      { poolId: 'abcdef0123456789', shares: '12.5' },
+    ]);
+    container.querySelector<HTMLInputElement>('#sb-wallet')!.value = 'GABC';
+    await panel.load();
+
+    expect(container.querySelectorAll('.analytics-table tbody tr')).toHaveLength(1);
+    expect(container.querySelector('.analytics-table tbody tr')!.textContent).toContain('12.5');
+  });
+
+  it('shows an empty state when there are no positions', async () => {
+    const { container, panel } = mount(async () => []);
+    container.querySelector<HTMLInputElement>('#sb-wallet')!.value = 'GABC';
+    await panel.load();
+
+    expect(container.querySelector('#sb-positions')!.textContent).toContain('No active liquidity');
+    expect(container.querySelector('#sb-status')!.textContent).toContain('No liquidity positions');
+  });
+
+  it('surfaces horizon errors in the status line', async () => {
+    const { container, panel } = mount(async () => {
+      throw new Error('horizon unreachable');
+    });
+    container.querySelector<HTMLInputElement>('#sb-wallet')!.value = 'GABC';
+    await panel.load();
+
+    expect(container.querySelector('#sb-status')!.textContent).toContain('horizon unreachable');
+  });
+});

--- a/packages/frontend/src/utils/network.ts
+++ b/packages/frontend/src/utils/network.ts
@@ -295,11 +295,11 @@ export function renderNetworkSwitcher(container: HTMLElement): void {
         </option>
       </select>
     </div>
-    \${
+    ${
       networkStore.isMainnet()
-        ? \`<p class="network-switcher__warning" role="alert">
+        ? `<p class="network-switcher__warning" role="alert">
              ⚠️ Mainnet is <strong>read-only</strong>. Transaction buttons are disabled.
-           </p>\`
+           </p>`
         : ''
     }
   `;


### PR DESCRIPTION
## 📋 Description

Adds a comprehensive analytics dashboard to the frontend playground: a new **Analytics**
panel that aggregates a wallet's Blend position into a portfolio summary (KPIs, allocation
pie, historical value line chart), a cross-protocol positions table, risk indicators and an
activity feed; a browser-native **Soroswap LP** panel that reads pool shares directly from
Horizon; and a **Live Market Feed** panel streaming prices over WebSocket.

Business logic lives in pure, fully-tested modules (store, chart builders, analytics client,
socket client); the panels are thin render layers. Where no on-chain source exists, values
are simulated and carry a visible **`simulated`** badge; client-observed series are labelled
**`since first load`**; real values (Blend position, APY, local tx history) carry no badge.

Two incidental fixes were surfaced while building and are included:
- Panel mounts are isolated with a `safeMount` guard so one failing panel (the pre-existing
  liquidity panel, whose `LiquidityPoolManager` is not browser-safe) can no longer abort
  `renderPlayground` and leave navigation unbound. This also revives the Blend and Smart Swap
  panels.
- The network-switcher template literal had an escaped interpolation that leaked raw code
  into the header and inflated the mobile viewport; unescaping it cleans the header and cuts
  ~300px of mobile overflow.

## 🔗 Related Issues

Closes #339 (implements roadmap item #71).

## 🧪 Testing

- [x] Unit tests added/updated — 57 new tests across 8 suites, written TDD-first
- [ ] Integration tests added/updated — N/A (jsdom unit + panel tests)
- [x] Manual testing completed — verified in a real browser (rendering, navigation, the real-vs-simulated labeling map, responsive at 375px)
- [ ] All tests passing locally — **275/276**. The single failure (`app.test › reports that the Stellar SDK workspace import is usable`) pre-exists on the branch and is unrelated to this PR (`LiquidityPoolManager` is not browser-safe; needs a separate `core-stellar-sdk` fix). This branch incidentally fixed the other two pre-existing failures.

## 📚 Documentation Updates

- [x] Updated `docs/AI.md` with new patterns/examples (added "Adding a new frontend playground panel")
- [x] Updated API reference in relevant package README (`packages/frontend/README.md`)
- [x] Added/updated code examples (frontend README examples)
- [ ] Updated ARCHITECTURE.md — N/A, this composes existing pieces and does not change architecture
- [ ] Added/updated inline JSDoc/TSDoc — intentionally minimal per project style (comments only where non-obvious)
- [x] Updated ROADMAP.md progress (marked #71 complete)

### Documentation Checklist by Component

Not applicable — this PR does not modify `core/stellar-sdk`, `core/invisible-wallet`, `core/automation`, `core/defi-protocols`, `core/oracles`, `contracts/`, or `tools/cli`. It touches `packages/frontend/` and one endpoint in `packages/api/rest/`.

## 🤖 AI-Friendly Documentation

### New Files Created

```
packages/frontend/src/services/portfolio-snapshots.ts  - localStorage two-series store (portfolio value + observed price), delta / deltaSince helpers
packages/frontend/src/services/analytics.client.ts     - pure aggregation fns (Blend/Soroswap rows, allocation, simulated PnL)
packages/frontend/src/services/market-socket.client.ts - socket.io-client wrapper for market:price_update ticks
packages/frontend/src/charts/line-chart.ts             - pure SVG line chart builder (+ data-table alternative)
packages/frontend/src/charts/pie-chart.ts              - pure SVG pie chart builder (+ data-table alternative)
packages/frontend/src/panels/analytics-dashboard.ts    - analytics dashboard panel (thin render layer)
packages/frontend/src/panels/soroswap-browser.ts       - browser-native Soroswap LP panel (Horizon-backed)
packages/frontend/src/panels/live-market-feed.ts       - WebSocket live market feed panel
packages/frontend/src/tests/*.test.ts                  - one test suite per module above (8 suites)
```

### Key Functions/Classes Added

```typescript
class PortfolioSnapshotStore {
  append(series: 'portfolio' | 'price', value: number, ts?: number): Snapshot;
  series(series: SnapshotSeries): Snapshot[];
  subscribe(listener: (s: Snapshot[]) => void): () => void;
  delta(series: SnapshotSeries): SeriesDelta | null;           // vs first snapshot
  deltaSince(series, windowMs, now?): SeriesDelta | null;      // vs pre-cutoff snapshot, else first
}

function buildBlendRow(position: BlendPositionLike): PositionRow;   // apy?: string -> null when absent
function buildSoroswapRow(lp: SoroswapLpLike): PositionRow;
function simulatedCostBasisPnl(currentValue: number, factor?: number): SimulatedPnl;

function buildLineChart(points: LinePoint[], options: LineChartOptions): SVGSVGElement; // role="img" + empty state
function buildPieChart(slices: PieSlice[], options: PieChartOptions): SVGSVGElement;     // labelled slices, never colour-alone

class MarketSocketClient { connect(): void; subscribe(cb): () => void; disconnect(): void; }

class AnalyticsDashboardPanel { constructor(container, deps?); refresh(): Promise<void>; }
class SoroswapBrowserPanel     { constructor(container, deps?); load(): Promise<void>; }
class LiveMarketFeedPanel      { constructor(container, deps?); destroy(): void; }
```

### Patterns Used

- **Pure logic + thin panels** — testable logic lives in pure modules covered by TDD; panels only wire the DOM. This keeps the global jest coverage gate satisfiable.
- **Dependency injection** — panels/clients accept injectable deps (fetchers, stores, socket factory) with production defaults, so everything is testable in jsdom.
- **localStorage time-series** — mirrors `tx-tracker.ts` (versioned key, subscribe pattern, entry cap, try/catch on write).
- **Honest labeling** — an authoritative real-vs-simulated map: simulated values are badged, observed series are labelled `since first load`, real values are unbadged.
- **Resilient mounting** — `safeMount(label, fn)` isolates each panel mount.

See `docs/AI.md → Common Tasks → Adding a new frontend playground panel`.

## 📸 Screenshots
<img width="1532" height="902" alt="image" src="https://github.com/user-attachments/assets/51591561-bbec-4e05-ab21-e103f4b153f6" />
<img width="834" height="941" alt="image" src="https://github.com/user-attachments/assets/ee63c7e0-d81a-4dee-9484-8804899689c9" />
<img width="1501" height="992" alt="image" src="https://github.com/user-attachments/assets/91a431f0-834b-43af-9f7a-34bc87fdd239" />
<img width="1597" height="970" alt="image" src="https://github.com/user-attachments/assets/b68f34c9-3258-44d2-8796-a57c9a7644e1" />

<img width="1918" height="898" alt="image" src="https://github.com/user-attachments/assets/949f2e49-867e-47ec-b921-5c92281fc3bc" />

## ⚠️ Breaking Changes

- [x] No breaking changes

The backend addition (`supplyAPY`/`borrowAPY` on the Blend position endpoint) is additive and best-effort — it never alters or removes existing fields and omits APY on failure.

## 🔄 Deployment Notes

- New dependency: `socket.io-client` (^4, matching the server's `socket.io` major).
- The Live Feed connects to the WebSocket server (`packages/api/websocket`, default `:3001`); without it the feed shows a "Waiting for live prices…" state.

## ✅ Final Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console.log or debug code left (verified across the diff)
- [x] Error handling implemented (load failures surface in each panel's status line; best-effort backend APY)
- [x] Performance considered (pure builders, entry-capped store, no chart library)
- [ ] Security reviewed — table/feed values are interpolated into `innerHTML` without escaping; sources are our own API / Horizon / the user's own `localStorage` on a testnet playground, so risk is ~nil, but flagged for awareness
- [x] Documentation updated
- [x] ROADMAP.md updated with progress

---

### Verification notes for reviewers

- **Verified by running:** 275/276 tests, `tsc --noEmit` clean, `vite build` succeeds; browser rendering, navigation and the labeling map confirmed manually.
- **Written but not run locally (please exercise on CI):** the best-effort APY route — its test file (`defi.routes.test.ts`) is excluded from the package `testMatch` and currently fails to load via `jest.requireActual` pulling `blend-sdk` CJS (both pre-existing); and the global coverage gate, which does not run on Windows due to a pre-existing `test-exclude`/minimatch issue but runs on CI/Linux.
- **Known low-risk notes:** `LiveMarketFeedPanel` opens its socket in the constructor and closes it in `destroy()`, which `app.ts` never calls (harmless for a page-lifetime panel); the mobile shell still overflows ~159px at 375px due to a pre-existing topbar/workspace layout issue (the pre-existing log/status panels overflow identically) — the dashboard panel itself is responsive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Analytics, Soroswap LP, and Live Market Feed panels to the Smart Wallet playground.
  * Analytics now displays portfolio KPIs, allocations, charts, positions, risk indicators, and activity.
  * Added portfolio history tracking and accessible chart/table views.
  * Live market updates show prices and 24-hour changes with simulated-data labels.
* **Bug Fixes**
  * Blend position responses now include APY data when available without failing when APY lookup is unavailable.
  * Improved panel isolation so one panel error does not disrupt the rest of the playground.
* **Documentation**
  * Added guidance for developing frontend playground panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->