### PR TITLE
Feat/api real time performance monitoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5286,6 +5286,15 @@
         "@octokit/openapi-types": "^24.2.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -8722,6 +8731,12 @@
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/bip32-path": {
       "version": "0.4.2",
@@ -19646,6 +19661,19 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/promise-all-reject-late": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
@@ -22000,6 +22028,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
+    },
     "node_modules/term-canvas": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/term-canvas/-/term-canvas-0.0.5.tgz",
@@ -23678,7 +23715,8 @@
         "helmet": "^7.1.0",
         "joi": "^17.11.0",
         "jsonwebtoken": "^9.0.2",
-        "morgan": "^1.10.0"
+        "morgan": "^1.10.0",
+        "prom-client": "^15.1.3"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",

--- a/packages/api/rest/package.json
+++ b/packages/api/rest/package.json
@@ -32,7 +32,8 @@
     "helmet": "^7.1.0",
     "joi": "^17.11.0",
     "jsonwebtoken": "^9.0.2",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/packages/api/rest/src/config/monitoring-config.ts
+++ b/packages/api/rest/src/config/monitoring-config.ts
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview Configuration for health checks and metrics collection.
+ * @description Reads env vars once at import time. Defaults chosen for
+ *              container platforms where probes fire every 5-10s.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-19
+ */
+
+function readInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function readString(name: string, fallback: string): string {
+  const raw = process.env[name];
+  return raw && raw.length > 0 ? raw : fallback;
+}
+
+export const monitoringConfig = {
+  healthCheckTimeoutMs: readInt('HEALTH_CHECK_TIMEOUT_MS', 3000),
+
+  horizon: {
+    url: readString('STELLAR_HORIZON_URL', 'https://horizon-testnet.stellar.org'),
+  },
+
+  oracle: {
+    stalenessThresholdMs: readInt('ORACLE_STALENESS_THRESHOLD_MS', 60_000),
+  },
+
+  defi: {
+    blendUrl: readString('BLEND_HEALTH_URL', 'https://api.blend.capital/health'),
+    soroswapUrl: readString('SOROSWAP_HEALTH_URL', 'https://api.soroswap.finance/health'),
+  },
+
+  system: {
+    memoryHighWatermarkBytes: readInt(
+      'SYSTEM_MEMORY_HIGH_WATERMARK_BYTES',
+      1024 * 1024 * 1024
+    ),
+    eventLoopLagHighWatermarkMs: readInt('SYSTEM_EVENT_LOOP_LAG_HIGH_MS', 200),
+  },
+
+  metrics: {
+    prefix: readString('METRICS_PREFIX', 'galaxy_'),
+  },
+} as const;

--- a/packages/api/rest/src/index.ts
+++ b/packages/api/rest/src/index.ts
@@ -39,6 +39,17 @@ import { setupApprovalsRoutes } from './routes/approvals';
 import { setupTeamRoutes } from './routes/teams';
 import { setupComplianceRoutes } from './routes/compliance';
 import { kycRoutes } from './routes/kyc-routes';
+import { setupHealthRoutes } from './routes/health';
+import { setupMetricsRoutes } from './routes/metrics';
+import { httpMetricsMiddleware } from './middleware/metrics';
+import {
+  HealthOrchestrator,
+  DatabaseHealthChecker,
+  HorizonHealthChecker,
+  OracleHealthChecker,
+  DefiProtocolHealthChecker,
+  SystemHealthChecker,
+} from './services/monitoring/health';
 import { globalCache } from '@galaxy-kj/core-stellar-sdk';
 
 /**
@@ -89,6 +100,21 @@ class RestApiServer {
       this.app.use(morgan('combined'));
     }
 
+    // Health & metrics endpoints. Mounted BEFORE rate-limiter so probes and
+    // Prometheus scrapers are never throttled.
+    const orchestrator = new HealthOrchestrator([
+      new DatabaseHealthChecker(),
+      new HorizonHealthChecker(),
+      new OracleHealthChecker(),
+      new DefiProtocolHealthChecker(),
+      new SystemHealthChecker(),
+    ]);
+    this.app.use(setupHealthRoutes({ orchestrator }));
+    this.app.use(setupMetricsRoutes());
+
+    // HTTP request metrics tracker (excludes health/metrics paths internally).
+    this.app.use(httpMetricsMiddleware());
+
     // Rate limiting middleware (applied to all routes)
     this.app.use(rateLimiterMiddleware());
 
@@ -104,16 +130,6 @@ class RestApiServer {
    * Setup routes
    */
   private setupRoutes(): void {
-    // Health check endpoint
-    this.app.get('/health', (req, res) => {
-      res.json({
-        status: 'healthy',
-        timestamp: new Date().toISOString(),
-        uptime: process.uptime(),
-        version: process.env.npm_package_version || '1.0.0',
-      });
-    });
-
     // API info endpoint
     this.app.get('/', (req, res) => {
       res.json({
@@ -122,6 +138,9 @@ class RestApiServer {
         description: 'REST API for Galaxy DevKit',
         endpoints: {
           health: '/health',
+          liveness: '/health/live',
+          readiness: '/health/ready',
+          metrics: '/metrics',
           api: '/api/v1',
         },
       });

--- a/packages/api/rest/src/middleware/__tests__/metrics.middleware.test.ts
+++ b/packages/api/rest/src/middleware/__tests__/metrics.middleware.test.ts
@@ -1,0 +1,57 @@
+import express from 'express';
+import request from 'supertest';
+import { Registry } from 'prom-client';
+import { httpMetricsMiddleware } from '../metrics';
+import { getHttpMetrics, __resetHttpMetricsForTests } from '../../services/monitoring/metrics/http-metrics';
+
+describe('httpMetricsMiddleware', () => {
+  beforeEach(() => {
+    __resetHttpMetricsForTests();
+  });
+
+  it('records requests using the route pattern, not the full URL', async () => {
+    const registry = new Registry();
+    const metrics = getHttpMetrics(registry);
+
+    const app = express();
+    app.use(httpMetricsMiddleware({ metrics }));
+    app.get('/users/:id', (_req, res) => res.status(200).json({}));
+
+    await request(app).get('/users/123');
+    await request(app).get('/users/456');
+
+    const output = await registry.metrics();
+    expect(output).toMatch(/route="\/users\/:id"/);
+    expect(output).not.toMatch(/route="\/users\/123"/);
+  });
+
+  it('skips the excluded health and metrics paths', async () => {
+    const registry = new Registry();
+    const metrics = getHttpMetrics(registry);
+
+    const app = express();
+    app.use(httpMetricsMiddleware({ metrics }));
+    app.get('/health', (_req, res) => res.status(200).json({}));
+    app.get('/metrics', (_req, res) => res.status(200).json({}));
+
+    await request(app).get('/health');
+    await request(app).get('/metrics');
+
+    const output = await registry.metrics();
+    expect(output).not.toMatch(/route="\/health"/);
+    expect(output).not.toMatch(/route="\/metrics"/);
+  });
+
+  it('captures the response status code', async () => {
+    const registry = new Registry();
+    const metrics = getHttpMetrics(registry);
+
+    const app = express();
+    app.use(httpMetricsMiddleware({ metrics }));
+    app.get('/boom', (_req, res) => res.status(500).json({}));
+
+    await request(app).get('/boom');
+    const output = await registry.metrics();
+    expect(output).toMatch(/status_code="500"/);
+  });
+});

--- a/packages/api/rest/src/middleware/metrics.ts
+++ b/packages/api/rest/src/middleware/metrics.ts
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview Express middleware that records HTTP request count and latency
+ *               into the Prometheus registry.
+ * @description Uses `req.route?.path` (mounted route pattern) as the `route`
+ *              label to keep cardinality bounded. Unmatched routes are
+ *              labelled `unknown`. Latency is measured with `process.hrtime`
+ *              for nanosecond precision and reported in seconds (Prometheus
+ *              convention).
+ * @author Galaxy DevKit Team
+ * @since 2026-07-19
+ */
+
+import { NextFunction, Request, Response } from 'express';
+import { getHttpMetrics, HttpMetrics } from '../services/monitoring/metrics/http-metrics';
+
+const EXCLUDED_ROUTES = new Set<string>([
+  '/health',
+  '/health/live',
+  '/health/ready',
+  '/metrics',
+]);
+
+function resolveRoute(req: Request): string {
+  // `req.route` is populated once Express matches. `req.baseUrl` prefixes it
+  // when the request went through a mounted router (e.g. /api/v1).
+  const routePath = req.route?.path;
+  if (routePath) {
+    const base = req.baseUrl ?? '';
+    return `${base}${routePath}` || '/';
+  }
+  return 'unknown';
+}
+
+export interface HttpMetricsMiddlewareOptions {
+  metrics?: HttpMetrics;
+  excludedPaths?: Set<string>;
+}
+
+export function httpMetricsMiddleware(options: HttpMetricsMiddlewareOptions = {}) {
+  const metrics = options.metrics ?? getHttpMetrics();
+  const excluded = options.excludedPaths ?? EXCLUDED_ROUTES;
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (excluded.has(req.path)) {
+      next();
+      return;
+    }
+
+    const start = process.hrtime.bigint();
+
+    res.on('finish', () => {
+      const route = resolveRoute(req);
+      const durationSeconds = Number(process.hrtime.bigint() - start) / 1e9;
+      const labels = {
+        method: req.method,
+        route,
+        status_code: String(res.statusCode),
+      };
+      metrics.requestsTotal.inc(labels);
+      metrics.requestDurationSeconds.observe(labels, durationSeconds);
+    });
+
+    next();
+  };
+}

--- a/packages/api/rest/src/routes/health/__tests__/health.routes.test.ts
+++ b/packages/api/rest/src/routes/health/__tests__/health.routes.test.ts
@@ -1,0 +1,73 @@
+import express from 'express';
+import request from 'supertest';
+import { setupHealthRoutes } from '../index';
+import { HealthOrchestrator } from '../../../services/monitoring/health';
+import { HealthChecker } from '../../../types/monitoring-health-types';
+
+function orchestrator(checkers: HealthChecker[]) {
+  return new HealthOrchestrator(checkers, {
+    timeoutMs: 100,
+    version: 'test',
+    now: () => new Date('2026-07-19T00:00:00Z'),
+    startedAt: new Date('2026-07-19T00:00:00Z'),
+  });
+}
+
+function makeApp(checkers: HealthChecker[]) {
+  const app = express();
+  app.use(setupHealthRoutes({ orchestrator: orchestrator(checkers) }));
+  return app;
+}
+
+describe('health routes', () => {
+  it('GET /health/live is always 200', async () => {
+    const app = makeApp([
+      {
+        name: 'db', critical: true,
+        check: async () => { throw new Error('DB DOWN'); },
+      },
+    ]);
+    const res = await request(app).get('/health/live');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('up');
+  });
+
+  it('GET /health returns 200 with degraded aggregate when non-critical fails', async () => {
+    const app = makeApp([
+      { name: 'db', critical: true, check: async () => ({ name: 'db', status: 'up', latencyMs: 1 }) },
+      { name: 'oracle', critical: false, check: async () => ({ name: 'oracle', status: 'degraded', latencyMs: 1 }) },
+    ]);
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('degraded');
+    expect(res.body.components).toHaveLength(2);
+  });
+
+  it('GET /health returns 503 when a component is down', async () => {
+    const app = makeApp([
+      { name: 'db', critical: true, check: async () => ({ name: 'db', status: 'down', latencyMs: 1 }) },
+    ]);
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe('down');
+  });
+
+  it('GET /health/ready returns 200 when critical deps are up even if non-critical is down', async () => {
+    const app = makeApp([
+      { name: 'db', critical: true, check: async () => ({ name: 'db', status: 'up', latencyMs: 1 }) },
+      { name: 'oracle', critical: false, check: async () => ({ name: 'oracle', status: 'down', latencyMs: 1 }) },
+    ]);
+    const res = await request(app).get('/health/ready');
+    expect(res.status).toBe(200);
+    expect(res.body.components).toHaveLength(1);
+    expect(res.body.components[0].name).toBe('db');
+  });
+
+  it('GET /health/ready returns 503 when a critical dep is down', async () => {
+    const app = makeApp([
+      { name: 'db', critical: true, check: async () => ({ name: 'db', status: 'down', latencyMs: 1 }) },
+    ]);
+    const res = await request(app).get('/health/ready');
+    expect(res.status).toBe(503);
+  });
+});

--- a/packages/api/rest/src/routes/health/index.ts
+++ b/packages/api/rest/src/routes/health/index.ts
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview Health check endpoints (detailed / liveness / readiness).
+ * @description
+ *  - GET /health          Full component-level report. 200 if any component is
+ *                         up or degraded, 503 if the aggregate is down.
+ *  - GET /health/live     Liveness probe. Always 200 while the process is up.
+ *                         Kubernetes uses this to decide when to restart the
+ *                         container - it must not depend on external systems.
+ *  - GET /health/ready    Readiness probe. 200 only when every critical
+ *                         dependency is up. Kubernetes removes the pod from
+ *                         the load balancer on 503 without restarting it.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-19
+ */
+
+import express, { Request, Response } from 'express';
+import { HealthOrchestrator } from '../../services/monitoring/health';
+
+export interface HealthRoutesDeps {
+  orchestrator: HealthOrchestrator;
+}
+
+function httpStatusFor(status: 'up' | 'down' | 'degraded'): number {
+  return status === 'down' ? 503 : 200;
+}
+
+export function setupHealthRoutes({ orchestrator }: HealthRoutesDeps): express.Router {
+  const router = express.Router();
+
+  router.get('/health/live', (_req: Request, res: Response) => {
+    res.status(200).json({
+      status: 'up',
+      timestamp: new Date().toISOString(),
+      uptimeSeconds: Math.floor(process.uptime()),
+    });
+  });
+
+  router.get('/health/ready', async (_req: Request, res: Response) => {
+    const report = await orchestrator.runCritical();
+    res.status(httpStatusFor(report.status)).json(report);
+  });
+
+  router.get('/health', async (_req: Request, res: Response) => {
+    const report = await orchestrator.runAll();
+    res.status(httpStatusFor(report.status)).json(report);
+  });
+
+  return router;
+}

--- a/packages/api/rest/src/routes/metrics/__tests__/metrics.routes.test.ts
+++ b/packages/api/rest/src/routes/metrics/__tests__/metrics.routes.test.ts
@@ -1,0 +1,24 @@
+import express from 'express';
+import request from 'supertest';
+import { Counter, Registry } from 'prom-client';
+import { setupMetricsRoutes } from '../index';
+
+describe('metrics routes', () => {
+  it('GET /metrics returns Prometheus text format with content type set', async () => {
+    const registry = new Registry();
+    const counter = new Counter({
+      name: 'sample_events_total',
+      help: 'sample',
+      registers: [registry],
+    });
+    counter.inc(3);
+
+    const app = express();
+    app.use(setupMetricsRoutes({ registry }));
+
+    const res = await request(app).get('/metrics');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/plain');
+    expect(res.text).toContain('sample_events_total 3');
+  });
+});

--- a/packages/api/rest/src/routes/metrics/index.ts
+++ b/packages/api/rest/src/routes/metrics/index.ts
@@ -1,0 +1,34 @@
+/**
+ * @fileoverview Prometheus-compatible /metrics endpoint.
+ * @description Renders the shared registry in Prometheus text format.
+ *              Kept public by default so Prometheus scrapers can consume it;
+ *              lock down with network policy or a reverse-proxy allowlist in
+ *              production.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-19
+ */
+
+import express, { NextFunction, Request, Response } from 'express';
+import { Registry } from 'prom-client';
+import { getMetricsRegistry } from '../../services/monitoring/metrics';
+
+export interface MetricsRoutesDeps {
+  registry?: Registry;
+}
+
+export function setupMetricsRoutes(deps: MetricsRoutesDeps = {}): express.Router {
+  const router = express.Router();
+  const registry = deps.registry ?? getMetricsRegistry();
+
+  router.get('/metrics', async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+      const body = await registry.metrics();
+      res.setHeader('Content-Type', registry.contentType);
+      res.status(200).send(body);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/packages/api/rest/src/services/monitoring/health/__tests__/database-checker.test.ts
+++ b/packages/api/rest/src/services/monitoring/health/__tests__/database-checker.test.ts
@@ -1,0 +1,41 @@
+import { DatabaseHealthChecker } from '../database-checker';
+import { __resetSupabaseClientForTests } from '../../../../utils/supabase';
+
+describe('DatabaseHealthChecker', () => {
+  it('is marked as critical', () => {
+    const checker = new DatabaseHealthChecker(async () => undefined);
+    expect(checker.critical).toBe(true);
+    expect(checker.name).toBe('database');
+  });
+
+  it('does not throw when constructed without env vars (lazy resolution)', async () => {
+    const original = { url: process.env.SUPABASE_URL, key: process.env.SUPABASE_SERVICE_ROLE_KEY };
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    __resetSupabaseClientForTests();
+    try {
+      const checker = new DatabaseHealthChecker();
+      const result = await checker.check();
+      expect(result.status).toBe('down');
+      expect(result.message).toMatch(/SUPABASE_URL/);
+    } finally {
+      if (original.url !== undefined) process.env.SUPABASE_URL = original.url;
+      if (original.key !== undefined) process.env.SUPABASE_SERVICE_ROLE_KEY = original.key;
+      __resetSupabaseClientForTests();
+    }
+  });
+
+  it('returns up when the ping resolves', async () => {
+    const checker = new DatabaseHealthChecker(async () => undefined);
+    const result = await checker.check();
+    expect(result.status).toBe('up');
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns down and surfaces the error message when the ping throws', async () => {
+    const checker = new DatabaseHealthChecker(async () => { throw new Error('nope'); });
+    const result = await checker.check();
+    expect(result.status).toBe('down');
+    expect(result.message).toBe('nope');
+  });
+});

--- a/packages/api/rest/src/services/monitoring/health/__tests__/defi-checker.test.ts
+++ b/packages/api/rest/src/services/monitoring/health/__tests__/defi-checker.test.ts
@@ -1,0 +1,58 @@
+import { DefiProtocolHealthChecker } from '../defi-checker';
+
+function fetcherFor(responses: Record<string, { ok: boolean; status: number } | Error>) {
+  return jest.fn().mockImplementation(async (url: string) => {
+    const r = responses[url];
+    if (r instanceof Error) throw r;
+    if (!r) throw new Error(`no mock for ${url}`);
+    return { ok: r.ok, status: r.status, json: async () => ({}) };
+  });
+}
+
+describe('DefiProtocolHealthChecker', () => {
+  const targets = [
+    { name: 'blend', url: 'https://blend.test/health' },
+    { name: 'soroswap', url: 'https://soroswap.test/health' },
+  ];
+
+  it('is non-critical', () => {
+    expect(new DefiProtocolHealthChecker().critical).toBe(false);
+  });
+
+  it('returns up when all protocols respond ok', async () => {
+    const checker = new DefiProtocolHealthChecker({
+      targets,
+      fetcher: fetcherFor({
+        'https://blend.test/health': { ok: true, status: 200 },
+        'https://soroswap.test/health': { ok: true, status: 200 },
+      }),
+    });
+    const result = await checker.check();
+    expect(result.status).toBe('up');
+  });
+
+  it('returns degraded when some but not all protocols fail', async () => {
+    const checker = new DefiProtocolHealthChecker({
+      targets,
+      fetcher: fetcherFor({
+        'https://blend.test/health': { ok: true, status: 200 },
+        'https://soroswap.test/health': new Error('timeout'),
+      }),
+    });
+    const result = await checker.check();
+    expect(result.status).toBe('degraded');
+    expect(result.message).toContain('1/2');
+  });
+
+  it('returns down when every protocol fails', async () => {
+    const checker = new DefiProtocolHealthChecker({
+      targets,
+      fetcher: fetcherFor({
+        'https://blend.test/health': new Error('down'),
+        'https://soroswap.test/health': { ok: false, status: 500 },
+      }),
+    });
+    const result = await checker.check();
+    expect(result.status).toBe('down');
+  });
+});

--- a/packages/api/rest/src/services/monitoring/health/__tests__/health-checker.test.ts
+++ b/packages/api/rest/src/services/monitoring/health/__tests__/health-checker.test.ts
@@ -1,0 +1,120 @@
+import { HealthOrchestrator } from '../health-checker';
+import { ComponentHealth, HealthChecker } from '../../../../types/monitoring-health-types';
+
+function makeChecker(overrides: Partial<HealthChecker> & { result: ComponentHealth }): HealthChecker {
+  return {
+    name: overrides.name ?? overrides.result.name,
+    critical: overrides.critical ?? true,
+    check: async () => overrides.result,
+  };
+}
+
+describe('HealthOrchestrator', () => {
+  const now = new Date('2026-07-19T12:00:00Z');
+  const startedAt = new Date('2026-07-19T11:59:00Z');
+  const commonOpts = {
+    version: '1.2.3',
+    now: () => now,
+    startedAt,
+    timeoutMs: 50,
+  };
+
+  it('aggregates as up when all components are up', async () => {
+    const orchestrator = new HealthOrchestrator(
+      [
+        makeChecker({ result: { name: 'a', status: 'up', latencyMs: 1 } }),
+        makeChecker({ result: { name: 'b', status: 'up', latencyMs: 2 } }),
+      ],
+      commonOpts
+    );
+    const report = await orchestrator.runAll();
+    expect(report.status).toBe('up');
+    expect(report.version).toBe('1.2.3');
+    expect(report.uptimeSeconds).toBe(60);
+    expect(report.components).toHaveLength(2);
+  });
+
+  it('reports degraded when at least one component is degraded and none down', async () => {
+    const orchestrator = new HealthOrchestrator(
+      [
+        makeChecker({ result: { name: 'a', status: 'up', latencyMs: 1 } }),
+        makeChecker({ result: { name: 'b', status: 'degraded', latencyMs: 2 } }),
+      ],
+      commonOpts
+    );
+    const report = await orchestrator.runAll();
+    expect(report.status).toBe('degraded');
+  });
+
+  it('reports down when any component is down', async () => {
+    const orchestrator = new HealthOrchestrator(
+      [
+        makeChecker({ result: { name: 'a', status: 'degraded', latencyMs: 1 } }),
+        makeChecker({ result: { name: 'b', status: 'down', latencyMs: 2 } }),
+      ],
+      commonOpts
+    );
+    const report = await orchestrator.runAll();
+    expect(report.status).toBe('down');
+  });
+
+  it('marks a checker down when it throws and preserves the message', async () => {
+    const orchestrator = new HealthOrchestrator(
+      [
+        {
+          name: 'thrower',
+          critical: true,
+          check: async () => { throw new Error('kaboom'); },
+        },
+      ],
+      commonOpts
+    );
+    const report = await orchestrator.runAll();
+    expect(report.status).toBe('down');
+    expect(report.components[0].message).toBe('kaboom');
+    expect(report.components[0].details).toBeUndefined();
+  });
+
+  it('marks a checker down when it exceeds the timeout', async () => {
+    const orchestrator = new HealthOrchestrator(
+      [
+        {
+          name: 'slow',
+          critical: true,
+          check: () => new Promise((resolve) => setTimeout(() => resolve({
+            name: 'slow', status: 'up', latencyMs: 200,
+          }), 200)),
+        },
+      ],
+      { ...commonOpts, timeoutMs: 10 }
+    );
+    const report = await orchestrator.runAll();
+    expect(report.status).toBe('down');
+    expect(report.components[0].details).toEqual(
+      expect.objectContaining({ timeout: true, timeoutMs: 10 })
+    );
+  });
+
+  it('runCritical only evaluates critical checkers', async () => {
+    const criticalChecker = makeChecker({
+      result: { name: 'critical', status: 'up', latencyMs: 1 },
+      critical: true,
+    });
+    const nonCriticalCheck = jest.fn().mockResolvedValue({
+      name: 'noncrit',
+      status: 'down',
+      latencyMs: 5,
+    });
+    const orchestrator = new HealthOrchestrator(
+      [
+        criticalChecker,
+        { name: 'noncrit', critical: false, check: nonCriticalCheck },
+      ],
+      commonOpts
+    );
+    const report = await orchestrator.runCritical();
+    expect(report.status).toBe('up');
+    expect(report.components).toHaveLength(1);
+    expect(nonCriticalCheck).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/rest/src/services/monitoring/health/__tests__/horizon-checker.test.ts
+++ b/packages/api/rest/src/services/monitoring/health/__tests__/horizon-checker.test.ts
@@ -1,0 +1,43 @@
+import { HorizonHealthChecker } from '../horizon-checker';
+
+function mockFetcher(response: { ok: boolean; status: number; body?: unknown }) {
+  return jest.fn().mockResolvedValue({
+    ok: response.ok,
+    status: response.status,
+    json: async () => response.body ?? {},
+  });
+}
+
+describe('HorizonHealthChecker', () => {
+  it('returns up on a 2xx response', async () => {
+    const checker = new HorizonHealthChecker({
+      url: 'https://horizon.test/',
+      fetcher: mockFetcher({ ok: true, status: 200 }),
+    });
+    const result = await checker.check();
+    expect(result.status).toBe('up');
+    expect(result.details).toEqual(
+      expect.objectContaining({ httpStatus: 200, url: 'https://horizon.test/' })
+    );
+  });
+
+  it('returns down when Horizon responds with a non-2xx', async () => {
+    const checker = new HorizonHealthChecker({
+      url: 'https://horizon.test/',
+      fetcher: mockFetcher({ ok: false, status: 502 }),
+    });
+    const result = await checker.check();
+    expect(result.status).toBe('down');
+    expect(result.message).toContain('HTTP 502');
+  });
+
+  it('returns down when the fetch rejects', async () => {
+    const checker = new HorizonHealthChecker({
+      url: 'https://horizon.test/',
+      fetcher: jest.fn().mockRejectedValue(new Error('dns error')),
+    });
+    const result = await checker.check();
+    expect(result.status).toBe('down');
+    expect(result.message).toBe('dns error');
+  });
+});

--- a/packages/api/rest/src/services/monitoring/health/__tests__/oracle-checker.test.ts
+++ b/packages/api/rest/src/services/monitoring/health/__tests__/oracle-checker.test.ts
@@ -1,0 +1,59 @@
+import { OracleHealthChecker } from '../oracle-checker';
+
+describe('OracleHealthChecker', () => {
+  const now = new Date('2026-07-19T12:00:00Z');
+
+  it('is non-critical', () => {
+    const checker = new OracleHealthChecker();
+    expect(checker.critical).toBe(false);
+    expect(checker.name).toBe('oracle-feeds');
+  });
+
+  it('returns up with details when no feeds are wired', async () => {
+    const checker = new OracleHealthChecker({
+      provider: async () => [],
+      now: () => now,
+    });
+    const result = await checker.check();
+    expect(result.status).toBe('up');
+    expect(result.details).toEqual(expect.objectContaining({ feeds: 0 }));
+  });
+
+  it('returns up when every feed is fresh', async () => {
+    const checker = new OracleHealthChecker({
+      stalenessMs: 60_000,
+      provider: async () => [
+        { feed: 'XLM/USD', lastUpdatedAt: new Date(now.getTime() - 10_000) },
+      ],
+      now: () => now,
+    });
+    const result = await checker.check();
+    expect(result.status).toBe('up');
+  });
+
+  it('returns degraded when at least one feed exceeds staleness', async () => {
+    const checker = new OracleHealthChecker({
+      stalenessMs: 60_000,
+      provider: async () => [
+        { feed: 'XLM/USD', lastUpdatedAt: new Date(now.getTime() - 10_000) },
+        { feed: 'USDC/USD', lastUpdatedAt: new Date(now.getTime() - 120_000) },
+      ],
+      now: () => now,
+    });
+    const result = await checker.check();
+    expect(result.status).toBe('degraded');
+    expect(result.details).toEqual(
+      expect.objectContaining({ staleFeeds: ['USDC/USD'] })
+    );
+  });
+
+  it('returns down when the provider throws', async () => {
+    const checker = new OracleHealthChecker({
+      provider: async () => { throw new Error('feed offline'); },
+      now: () => now,
+    });
+    const result = await checker.check();
+    expect(result.status).toBe('down');
+    expect(result.message).toBe('feed offline');
+  });
+});

--- a/packages/api/rest/src/services/monitoring/health/__tests__/system-checker.test.ts
+++ b/packages/api/rest/src/services/monitoring/health/__tests__/system-checker.test.ts
@@ -1,0 +1,38 @@
+import { SystemHealthChecker } from '../system-checker';
+
+describe('SystemHealthChecker', () => {
+  it('returns up when metrics are within watermarks', async () => {
+    const checker = new SystemHealthChecker({
+      sampler: () => ({ rssBytes: 100, heapUsedBytes: 50, eventLoopLagMs: 5 }),
+      memoryHighWatermarkBytes: 1_000,
+      eventLoopLagHighMs: 50,
+    });
+    const result = await checker.check();
+    expect(result.status).toBe('up');
+    expect(result.details).toEqual(
+      expect.objectContaining({ rssBytes: 100, eventLoopLagMs: 5 })
+    );
+  });
+
+  it('reports degraded when memory crosses the watermark', async () => {
+    const checker = new SystemHealthChecker({
+      sampler: () => ({ rssBytes: 2_000, heapUsedBytes: 1_500, eventLoopLagMs: 5 }),
+      memoryHighWatermarkBytes: 1_000,
+      eventLoopLagHighMs: 50,
+    });
+    const result = await checker.check();
+    expect(result.status).toBe('degraded');
+    expect(result.message).toContain('rss above watermark');
+  });
+
+  it('reports degraded when event loop lag crosses the watermark', async () => {
+    const checker = new SystemHealthChecker({
+      sampler: () => ({ rssBytes: 100, heapUsedBytes: 50, eventLoopLagMs: 500 }),
+      memoryHighWatermarkBytes: 1_000,
+      eventLoopLagHighMs: 100,
+    });
+    const result = await checker.check();
+    expect(result.status).toBe('degraded');
+    expect(result.message).toContain('event loop lag');
+  });
+});

--- a/packages/api/rest/src/services/monitoring/health/__tests__/with-timeout.test.ts
+++ b/packages/api/rest/src/services/monitoring/health/__tests__/with-timeout.test.ts
@@ -1,0 +1,18 @@
+import { HealthCheckTimeoutError, withTimeout } from '../with-timeout';
+
+describe('withTimeout', () => {
+  it('resolves when the op finishes before the timeout', async () => {
+    const result = await withTimeout('t', 100, async () => 'ok');
+    expect(result).toBe('ok');
+  });
+
+  it('rejects with HealthCheckTimeoutError when the op exceeds the timeout', async () => {
+    const slow = () => new Promise<string>((resolve) => setTimeout(() => resolve('late'), 100));
+    await expect(withTimeout('slow', 20, slow)).rejects.toBeInstanceOf(HealthCheckTimeoutError);
+  });
+
+  it('propagates the underlying rejection unchanged', async () => {
+    const err = new Error('boom');
+    await expect(withTimeout('t', 100, async () => { throw err; })).rejects.toBe(err);
+  });
+});

--- a/packages/api/rest/src/services/monitoring/health/database-checker.ts
+++ b/packages/api/rest/src/services/monitoring/health/database-checker.ts
@@ -1,0 +1,71 @@
+/**
+ * @fileoverview Health checker for the Supabase/Postgres backing store.
+ * @description Issues a lightweight ping via the service-role client.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-19
+ */
+
+import { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseClient } from '../../../utils/supabase';
+import { ComponentHealth, HealthChecker } from '../../../types/monitoring-health-types';
+
+export type DatabasePinger = () => Promise<void>;
+
+/**
+ * Default ping: HEAD count on `api_keys` (chosen because it exists in every
+ * environment and RLS does not block the service-role client). Kept as a
+ * single, cheap round-trip. Swap via constructor for tests or alt schemas.
+ */
+function defaultPing(client: SupabaseClient): DatabasePinger {
+  return async () => {
+    const { error } = await client
+      .from('api_keys')
+      .select('id', { count: 'exact', head: true })
+      .limit(1);
+    if (error) throw new Error(error.message);
+  };
+}
+
+export class DatabaseHealthChecker implements HealthChecker {
+  readonly name = 'database';
+  readonly critical = true;
+
+  private readonly customPing?: DatabasePinger;
+  private cachedPing?: DatabasePinger;
+
+  constructor(ping?: DatabasePinger) {
+    this.customPing = ping;
+  }
+
+  async check(): Promise<ComponentHealth> {
+    const started = Date.now();
+    try {
+      const ping = this.resolvePing();
+      await ping();
+      return {
+        name: this.name,
+        status: 'up',
+        latencyMs: Date.now() - started,
+      };
+    } catch (err) {
+      return {
+        name: this.name,
+        status: 'down',
+        latencyMs: Date.now() - started,
+        message: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  /**
+   * Lazy so a missing SUPABASE_URL surfaces as a "down" component instead of
+   * crashing the process at startup when the orchestrator is constructed.
+   */
+  private resolvePing(): DatabasePinger {
+    if (this.customPing) return this.customPing;
+    if (!this.cachedPing) {
+      this.cachedPing = defaultPing(getSupabaseClient());
+    }
+    return this.cachedPing;
+  }
+}

--- a/packages/api/rest/src/services/monitoring/health/defi-checker.ts
+++ b/packages/api/rest/src/services/monitoring/health/defi-checker.ts
@@ -1,0 +1,101 @@
+/**
+ * @fileoverview Health checker for DeFi protocol reachability (Blend, Soroswap).
+ * @description Pings each protocol's health URL in parallel. Marked
+ *              non-critical: a failing protocol degrades /health but the API
+ *              can still serve other traffic.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-19
+ */
+
+import { ComponentHealth, HealthChecker, HealthStatus } from '../../../types/monitoring-health-types';
+import { monitoringConfig } from '../../../config/monitoring-config';
+import { Fetcher } from './horizon-checker';
+
+interface ProtocolTarget {
+  name: string;
+  url: string;
+}
+
+interface ProtocolProbeResult {
+  name: string;
+  status: HealthStatus;
+  latencyMs: number;
+  httpStatus?: number;
+  error?: string;
+}
+
+const defaultFetcher: Fetcher = (input, init) =>
+  fetch(input, init as RequestInit) as unknown as ReturnType<Fetcher>;
+
+export class DefiProtocolHealthChecker implements HealthChecker {
+  readonly name = 'defi-protocols';
+  readonly critical = false;
+
+  private readonly targets: ProtocolTarget[];
+  private readonly fetcher: Fetcher;
+  private readonly timeoutMs: number;
+
+  constructor(opts?: {
+    targets?: ProtocolTarget[];
+    fetcher?: Fetcher;
+    timeoutMs?: number;
+  }) {
+    this.targets = opts?.targets ?? [
+      { name: 'blend', url: monitoringConfig.defi.blendUrl },
+      { name: 'soroswap', url: monitoringConfig.defi.soroswapUrl },
+    ];
+    this.fetcher = opts?.fetcher ?? defaultFetcher;
+    this.timeoutMs = opts?.timeoutMs ?? monitoringConfig.healthCheckTimeoutMs;
+  }
+
+  async check(): Promise<ComponentHealth> {
+    const started = Date.now();
+    const results = await Promise.all(this.targets.map((t) => this.probe(t)));
+    const latencyMs = Date.now() - started;
+
+    const down = results.filter((r) => r.status === 'down');
+    let status: HealthStatus = 'up';
+    if (down.length === results.length && results.length > 0) status = 'down';
+    else if (down.length > 0) status = 'degraded';
+
+    return {
+      name: this.name,
+      status,
+      latencyMs,
+      message:
+        down.length === 0
+          ? undefined
+          : `${down.length}/${results.length} DeFi protocols unreachable`,
+      details: { protocols: results },
+    };
+  }
+
+  private async probe(target: ProtocolTarget): Promise<ProtocolProbeResult> {
+    const started = Date.now();
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    timer.unref?.();
+
+    try {
+      const res = await this.fetcher(target.url, {
+        method: 'GET',
+        signal: controller.signal,
+      });
+      return {
+        name: target.name,
+        status: res.ok ? 'up' : 'down',
+        latencyMs: Date.now() - started,
+        httpStatus: res.status,
+      };
+    } catch (err) {
+      return {
+        name: target.name,
+        status: 'down',
+        latencyMs: Date.now() - started,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/packages/api/rest/src/services/monitoring/health/health-checker.ts
+++ b/packages/api/rest/src/services/monitoring/health/health-checker.ts
@@ -1,0 +1,97 @@
+/**
+ * @fileoverview Orchestrator that runs all registered health checkers in
+ *               parallel, enforces per-check timeouts and aggregates results.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-19
+ */
+
+import {
+  ComponentHealth,
+  HealthChecker,
+  HealthReport,
+  HealthStatus,
+} from '../../../types/monitoring-health-types';
+import { monitoringConfig } from '../../../config/monitoring-config';
+import { HealthCheckTimeoutError, withTimeout } from './with-timeout';
+
+export interface HealthOrchestratorOptions {
+  timeoutMs?: number;
+  version?: string;
+  now?: () => Date;
+  startedAt?: Date;
+}
+
+/**
+ * Rank statuses so we can compute the aggregate as the "worst" one.
+ */
+const STATUS_RANK: Record<HealthStatus, number> = { up: 0, degraded: 1, down: 2 };
+
+function worst(a: HealthStatus, b: HealthStatus): HealthStatus {
+  return STATUS_RANK[a] >= STATUS_RANK[b] ? a : b;
+}
+
+export class HealthOrchestrator {
+  private readonly checkers: readonly HealthChecker[];
+  private readonly timeoutMs: number;
+  private readonly version: string;
+  private readonly now: () => Date;
+  private readonly startedAt: Date;
+
+  constructor(checkers: readonly HealthChecker[], options: HealthOrchestratorOptions = {}) {
+    this.checkers = checkers;
+    this.timeoutMs = options.timeoutMs ?? monitoringConfig.healthCheckTimeoutMs;
+    this.version = options.version ?? process.env.npm_package_version ?? '0.0.0';
+    this.now = options.now ?? (() => new Date());
+    this.startedAt = options.startedAt ?? new Date();
+  }
+
+  async runAll(): Promise<HealthReport> {
+    const components = await Promise.all(
+      this.checkers.map((c) => this.runOne(c))
+    );
+    return {
+      status: this.aggregate(components),
+      timestamp: this.now().toISOString(),
+      uptimeSeconds: Math.floor((this.now().getTime() - this.startedAt.getTime()) / 1000),
+      version: this.version,
+      components,
+    };
+  }
+
+  /**
+   * Readiness only considers `critical` components. Non-critical failures
+   * degrade /health but must not evict the pod from the load balancer.
+   */
+  async runCritical(): Promise<HealthReport> {
+    const critical = this.checkers.filter((c) => c.critical);
+    const components = await Promise.all(critical.map((c) => this.runOne(c)));
+    return {
+      status: this.aggregate(components),
+      timestamp: this.now().toISOString(),
+      uptimeSeconds: Math.floor((this.now().getTime() - this.startedAt.getTime()) / 1000),
+      version: this.version,
+      components,
+    };
+  }
+
+  private async runOne(checker: HealthChecker): Promise<ComponentHealth> {
+    const started = Date.now();
+    try {
+      return await withTimeout(checker.name, this.timeoutMs, () => checker.check());
+    } catch (err) {
+      const latencyMs = Date.now() - started;
+      const isTimeout = err instanceof HealthCheckTimeoutError;
+      return {
+        name: checker.name,
+        status: 'down',
+        latencyMs,
+        message: err instanceof Error ? err.message : String(err),
+        details: isTimeout ? { timeout: true, timeoutMs: this.timeoutMs } : undefined,
+      };
+    }
+  }
+
+  private aggregate(components: ComponentHealth[]): HealthStatus {
+    return components.reduce<HealthStatus>((acc, c) => worst(acc, c.status), 'up');
+  }
+}

--- a/packages/api/rest/src/services/monitoring/health/horizon-checker.ts
+++ b/packages/api/rest/src/services/monitoring/health/horizon-checker.ts
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview Health checker for Stellar Horizon.
+ * @description Fetches the Horizon root document. HTTP 2xx = up.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-19
+ */
+
+import { ComponentHealth, HealthChecker } from '../../../types/monitoring-health-types';
+import { monitoringConfig } from '../../../config/monitoring-config';
+
+export type Fetcher = (
+  input: string,
+  init?: { method?: string; signal?: AbortSignal }
+) => Promise<{ ok: boolean; status: number; json(): Promise<unknown> }>;
+
+const defaultFetcher: Fetcher = (input, init) =>
+  fetch(input, init as RequestInit) as unknown as ReturnType<Fetcher>;
+
+export class HorizonHealthChecker implements HealthChecker {
+  readonly name = 'stellar-horizon';
+  readonly critical = true;
+
+  private readonly url: string;
+  private readonly fetcher: Fetcher;
+  private readonly timeoutMs: number;
+
+  constructor(opts?: { url?: string; fetcher?: Fetcher; timeoutMs?: number }) {
+    this.url = opts?.url ?? monitoringConfig.horizon.url;
+    this.fetcher = opts?.fetcher ?? defaultFetcher;
+    this.timeoutMs = opts?.timeoutMs ?? monitoringConfig.healthCheckTimeoutMs;
+  }
+
+  async check(): Promise<ComponentHealth> {
+    const started = Date.now();
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    timer.unref?.();
+
+    try {
+      const res = await this.fetcher(this.url, {
+        method: 'GET',
+        signal: controller.signal,
+      });
+      const latencyMs = Date.now() - started;
+
+      if (!res.ok) {
+        return {
+          name: this.name,
+          status: 'down',
+          latencyMs,
+          message: `Horizon responded with HTTP ${res.status}`,
+          details: { url: this.url, httpStatus: res.status },
+        };
+      }
+
+      return {
+        name: this.name,
+        status: 'up',
+        latencyMs,
+        details: { url: this.url, httpStatus: res.status },
+      };
+    } catch (err) {
+      return {
+        name: this.name,
+        status: 'down',
+        latencyMs: Date.now() - started,
+        message: err instanceof Error ? err.message : String(err),
+        details: { url: this.url },
+      };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/packages/api/rest/src/services/monitoring/health/index.ts
+++ b/packages/api/rest/src/services/monitoring/health/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @fileoverview Public barrel for the health-check subsystem.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-19
+ */
+
+export { HealthOrchestrator } from './health-checker';
+export type { HealthOrchestratorOptions } from './health-checker';
+export { DatabaseHealthChecker } from './database-checker';
+export { HorizonHealthChecker } from './horizon-checker';
+export { OracleHealthChecker } from './oracle-checker';
+export type { OracleFreshnessProvider, OracleFreshnessSnapshot } from './oracle-checker';
+export { DefiProtocolHealthChecker } from './defi-checker';
+export { SystemHealthChecker } from './system-checker';
+export type { SystemSampler, SystemMetricsSnapshot } from './system-checker';
+export { withTimeout, HealthCheckTimeoutError } from './with-timeout';

--- a/packages/api/rest/src/services/monitoring/health/oracle-checker.ts
+++ b/packages/api/rest/src/services/monitoring/health/oracle-checker.ts
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview Health checker for Oracle price feeds.
+ * @description Determines freshness by comparing `now()` with the last-updated
+ *              timestamp reported by a pluggable provider. Marked non-critical:
+ *              stale prices degrade the system but do not warrant removing the
+ *              pod from the load balancer.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-19
+ */
+
+import { ComponentHealth, HealthChecker } from '../../../types/monitoring-health-types';
+import { monitoringConfig } from '../../../config/monitoring-config';
+
+export interface OracleFreshnessSnapshot {
+  feed: string;
+  lastUpdatedAt: Date;
+}
+
+export type OracleFreshnessProvider = () => Promise<OracleFreshnessSnapshot[]>;
+
+/**
+ * Placeholder provider used until the oracle service exposes a freshness API.
+ * Returns an empty snapshot so the checker reports `up` with `details.reason`.
+ * Replace by injecting a real provider when the oracle client is wired.
+ */
+const defaultProvider: OracleFreshnessProvider = async () => [];
+
+export class OracleHealthChecker implements HealthChecker {
+  readonly name = 'oracle-feeds';
+  readonly critical = false;
+
+  private readonly provider: OracleFreshnessProvider;
+  private readonly stalenessMs: number;
+  private readonly now: () => Date;
+
+  constructor(opts?: {
+    provider?: OracleFreshnessProvider;
+    stalenessMs?: number;
+    now?: () => Date;
+  }) {
+    this.provider = opts?.provider ?? defaultProvider;
+    this.stalenessMs = opts?.stalenessMs ?? monitoringConfig.oracle.stalenessThresholdMs;
+    this.now = opts?.now ?? (() => new Date());
+  }
+
+  async check(): Promise<ComponentHealth> {
+    const started = Date.now();
+    try {
+      const snapshots = await this.provider();
+      const latencyMs = Date.now() - started;
+
+      if (snapshots.length === 0) {
+        return {
+          name: this.name,
+          status: 'up',
+          latencyMs,
+          details: { reason: 'no oracle provider wired', feeds: 0 },
+        };
+      }
+
+      const nowMs = this.now().getTime();
+      const stale = snapshots.filter(
+        (s) => nowMs - s.lastUpdatedAt.getTime() > this.stalenessMs
+      );
+
+      return {
+        name: this.name,
+        status: stale.length === 0 ? 'up' : 'degraded',
+        latencyMs,
+        message:
+          stale.length === 0
+            ? undefined
+            : `${stale.length}/${snapshots.length} oracle feeds are stale`,
+        details: {
+          totalFeeds: snapshots.length,
+          staleFeeds: stale.map((s) => s.feed),
+          stalenessThresholdMs: this.stalenessMs,
+        },
+      };
+    } catch (err) {
+      return {
+        name: this.name,
+        status: 'down',
+        latencyMs: Date.now() - started,
+        message: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+}

--- a/packages/api/rest/src/services/monitoring/health/system-checker.ts
+++ b/packages/api/rest/src/services/monitoring/health/system-checker.ts
@@ -1,0 +1,92 @@
+/**
+ * @fileoverview Health checker for local process resources.
+ * @description Samples RSS memory and event-loop delay against configurable
+ *              high watermarks. Non-critical: a spike degrades /health but the
+ *              process may still be serving requests.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-19
+ */
+
+import { monitorEventLoopDelay, IntervalHistogram } from 'perf_hooks';
+import { ComponentHealth, HealthChecker, HealthStatus } from '../../../types/monitoring-health-types';
+import { monitoringConfig } from '../../../config/monitoring-config';
+
+export interface SystemMetricsSnapshot {
+  rssBytes: number;
+  heapUsedBytes: number;
+  eventLoopLagMs: number;
+}
+
+export type SystemSampler = () => SystemMetricsSnapshot;
+
+function defaultSampler(histogram: IntervalHistogram): SystemSampler {
+  return () => {
+    const mem = process.memoryUsage();
+    const lagMs = histogram.max / 1e6;
+    histogram.reset();
+    return {
+      rssBytes: mem.rss,
+      heapUsedBytes: mem.heapUsed,
+      eventLoopLagMs: Number.isFinite(lagMs) ? lagMs : 0,
+    };
+  };
+}
+
+export class SystemHealthChecker implements HealthChecker {
+  readonly name = 'system';
+  readonly critical = false;
+
+  private readonly sampler: SystemSampler;
+  private readonly memoryHighWatermarkBytes: number;
+  private readonly eventLoopLagHighMs: number;
+  private readonly histogram?: IntervalHistogram;
+
+  constructor(opts?: {
+    sampler?: SystemSampler;
+    memoryHighWatermarkBytes?: number;
+    eventLoopLagHighMs?: number;
+  }) {
+    this.memoryHighWatermarkBytes =
+      opts?.memoryHighWatermarkBytes ?? monitoringConfig.system.memoryHighWatermarkBytes;
+    this.eventLoopLagHighMs =
+      opts?.eventLoopLagHighMs ?? monitoringConfig.system.eventLoopLagHighWatermarkMs;
+
+    if (opts?.sampler) {
+      this.sampler = opts.sampler;
+    } else {
+      this.histogram = monitorEventLoopDelay({ resolution: 20 });
+      this.histogram.enable();
+      this.sampler = defaultSampler(this.histogram);
+    }
+  }
+
+  async check(): Promise<ComponentHealth> {
+    const started = Date.now();
+    const snapshot = this.sampler();
+
+    let status: HealthStatus = 'up';
+    const reasons: string[] = [];
+    if (snapshot.rssBytes > this.memoryHighWatermarkBytes) {
+      status = 'degraded';
+      reasons.push('rss above watermark');
+    }
+    if (snapshot.eventLoopLagMs > this.eventLoopLagHighMs) {
+      status = 'degraded';
+      reasons.push('event loop lag above watermark');
+    }
+
+    return {
+      name: this.name,
+      status,
+      latencyMs: Date.now() - started,
+      message: reasons.length > 0 ? reasons.join('; ') : undefined,
+      details: {
+        rssBytes: snapshot.rssBytes,
+        heapUsedBytes: snapshot.heapUsedBytes,
+        eventLoopLagMs: Number(snapshot.eventLoopLagMs.toFixed(2)),
+        memoryHighWatermarkBytes: this.memoryHighWatermarkBytes,
+        eventLoopLagHighMs: this.eventLoopLagHighMs,
+      },
+    };
+  }
+}

--- a/packages/api/rest/src/services/monitoring/health/with-timeout.ts
+++ b/packages/api/rest/src/services/monitoring/health/with-timeout.ts
@@ -1,0 +1,36 @@
+/**
+ * @fileoverview Timeout wrapper for health check promises.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-19
+ */
+
+export class HealthCheckTimeoutError extends Error {
+  constructor(name: string, timeoutMs: number) {
+    super(`Health check "${name}" timed out after ${timeoutMs}ms`);
+    this.name = 'HealthCheckTimeoutError';
+  }
+}
+
+export function withTimeout<T>(
+  name: string,
+  timeoutMs: number,
+  op: () => Promise<T>
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new HealthCheckTimeoutError(name, timeoutMs));
+    }, timeoutMs);
+    timer.unref?.();
+
+    op().then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      }
+    );
+  });
+}

--- a/packages/api/rest/src/services/monitoring/metrics/domain-metrics.ts
+++ b/packages/api/rest/src/services/monitoring/metrics/domain-metrics.ts
@@ -1,0 +1,86 @@
+/**
+ * @fileoverview Domain-level metrics exposed by the API surface.
+ * @description Provides thin, typed helpers that other services import to
+ *              record Stellar Horizon calls, Oracle freshness, DeFi protocol
+ *              calls and WebSocket activity. All series share a common prefix.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-19
+ */
+
+import { Counter, Gauge, Histogram, Registry } from 'prom-client';
+import { monitoringConfig } from '../../../config/monitoring-config';
+import { getMetricsRegistry } from './registry';
+
+export interface DomainMetrics {
+  horizonResponseSeconds: Histogram<string>;
+  horizonErrorsTotal: Counter<string>;
+  oracleFeedAgeSeconds: Gauge<string>;
+  defiCallsTotal: Counter<string>;
+  websocketConnections: Gauge<string>;
+  websocketMessagesTotal: Counter<string>;
+}
+
+let cached: DomainMetrics | null = null;
+
+export function getDomainMetrics(registry: Registry = getMetricsRegistry()): DomainMetrics {
+  if (cached) return cached;
+
+  const prefix = monitoringConfig.metrics.prefix;
+
+  const horizonResponseSeconds = new Histogram({
+    name: `${prefix}horizon_response_seconds`,
+    help: 'Stellar Horizon response times in seconds by endpoint.',
+    labelNames: ['endpoint'] as const,
+    buckets: [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+    registers: [registry],
+  });
+
+  const horizonErrorsTotal = new Counter({
+    name: `${prefix}horizon_errors_total`,
+    help: 'Stellar Horizon errors by endpoint and reason.',
+    labelNames: ['endpoint', 'reason'] as const,
+    registers: [registry],
+  });
+
+  const oracleFeedAgeSeconds = new Gauge({
+    name: `${prefix}oracle_feed_age_seconds`,
+    help: 'Seconds since the oracle feed was last updated (freshness).',
+    labelNames: ['feed'] as const,
+    registers: [registry],
+  });
+
+  const defiCallsTotal = new Counter({
+    name: `${prefix}defi_calls_total`,
+    help: 'DeFi protocol calls by protocol, operation and outcome.',
+    labelNames: ['protocol', 'operation', 'outcome'] as const,
+    registers: [registry],
+  });
+
+  const websocketConnections = new Gauge({
+    name: `${prefix}websocket_connections`,
+    help: 'Currently open WebSocket connections by namespace.',
+    labelNames: ['namespace'] as const,
+    registers: [registry],
+  });
+
+  const websocketMessagesTotal = new Counter({
+    name: `${prefix}websocket_messages_total`,
+    help: 'WebSocket messages by namespace and direction.',
+    labelNames: ['namespace', 'direction'] as const,
+    registers: [registry],
+  });
+
+  cached = {
+    horizonResponseSeconds,
+    horizonErrorsTotal,
+    oracleFeedAgeSeconds,
+    defiCallsTotal,
+    websocketConnections,
+    websocketMessagesTotal,
+  };
+  return cached;
+}
+
+export function __resetDomainMetricsForTests(): void {
+  cached = null;
+}

--- a/packages/api/rest/src/services/monitoring/metrics/http-metrics.ts
+++ b/packages/api/rest/src/services/monitoring/metrics/http-metrics.ts
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview HTTP request metrics (counter + latency histogram).
+ * @description Buckets tuned for API workloads: sub-ms to 10s. Labels are
+ *              kept low-cardinality (method, route pattern, status). Route
+ *              pattern comes from Express's `req.route.path`; unmatched
+ *              requests are grouped as "unknown".
+ * @author Galaxy DevKit Team
+ * @since 2026-07-19
+ */
+
+import { Counter, Histogram, Registry } from 'prom-client';
+import { monitoringConfig } from '../../../config/monitoring-config';
+import { getMetricsRegistry } from './registry';
+
+export interface HttpMetrics {
+  requestsTotal: Counter<string>;
+  requestDurationSeconds: Histogram<string>;
+}
+
+let cached: HttpMetrics | null = null;
+
+export function getHttpMetrics(registry: Registry = getMetricsRegistry()): HttpMetrics {
+  if (cached) return cached;
+
+  const prefix = monitoringConfig.metrics.prefix;
+
+  const requestsTotal = new Counter({
+    name: `${prefix}http_requests_total`,
+    help: 'Total number of HTTP requests handled by the REST API.',
+    labelNames: ['method', 'route', 'status_code'] as const,
+    registers: [registry],
+  });
+
+  const requestDurationSeconds = new Histogram({
+    name: `${prefix}http_request_duration_seconds`,
+    help: 'HTTP request latency in seconds, labelled by method, route and status.',
+    labelNames: ['method', 'route', 'status_code'] as const,
+    buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+    registers: [registry],
+  });
+
+  cached = { requestsTotal, requestDurationSeconds };
+  return cached;
+}
+
+export function __resetHttpMetricsForTests(): void {
+  cached = null;
+}

--- a/packages/api/rest/src/services/monitoring/metrics/index.ts
+++ b/packages/api/rest/src/services/monitoring/metrics/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @fileoverview Public barrel for the metrics subsystem.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-19
+ */
+
+export { getMetricsRegistry, __resetMetricsRegistryForTests } from './registry';
+export { getHttpMetrics, __resetHttpMetricsForTests } from './http-metrics';
+export type { HttpMetrics } from './http-metrics';
+export { getDomainMetrics, __resetDomainMetricsForTests } from './domain-metrics';
+export type { DomainMetrics } from './domain-metrics';

--- a/packages/api/rest/src/services/monitoring/metrics/registry.ts
+++ b/packages/api/rest/src/services/monitoring/metrics/registry.ts
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Prometheus registry singleton and default metrics setup.
+ * @description Uses an isolated `Registry` (not prom-client's global one) so
+ *              tests can reset state without leaking metrics between suites.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-19
+ */
+
+import { Registry, collectDefaultMetrics } from 'prom-client';
+import { monitoringConfig } from '../../../config/monitoring-config';
+
+let registry: Registry | null = null;
+
+export function getMetricsRegistry(): Registry {
+  if (registry) return registry;
+
+  registry = new Registry();
+  collectDefaultMetrics({
+    register: registry,
+    prefix: monitoringConfig.metrics.prefix,
+  });
+  return registry;
+}
+
+/**
+ * Test-only: wipe the registry so each suite starts from scratch.
+ */
+export function __resetMetricsRegistryForTests(): void {
+  registry?.clear();
+  registry = null;
+}

--- a/packages/api/rest/src/types/monitoring-health-types.ts
+++ b/packages/api/rest/src/types/monitoring-health-types.ts
@@ -1,0 +1,45 @@
+/**
+ * @fileoverview Types for real-time performance monitoring and health checks.
+ * @description Public contract shared by health checkers, orchestrator and
+ *              HTTP routes. Kept framework-agnostic so checkers stay portable.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-19
+ */
+
+export type HealthStatus = 'up' | 'down' | 'degraded';
+
+/**
+ * Aggregate health of a single dependency (DB, Horizon, Oracle, DeFi, System).
+ */
+export interface ComponentHealth {
+  name: string;
+  status: HealthStatus;
+  latencyMs: number;
+  message?: string;
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Full snapshot returned by GET /health.
+ * `status` is the worst of the component statuses (weighted by `critical`).
+ */
+export interface HealthReport {
+  status: HealthStatus;
+  timestamp: string;
+  uptimeSeconds: number;
+  version: string;
+  components: ComponentHealth[];
+}
+
+/**
+ * Contract for anything that can be health-checked.
+ *
+ * `critical=true` means the checker's status feeds into readiness. A critical
+ * component being `down` causes GET /health/ready to return 503, which tells
+ * Kubernetes to remove the pod from the load balancer without killing it.
+ */
+export interface HealthChecker {
+  readonly name: string;
+  readonly critical: boolean;
+  check(): Promise<ComponentHealth>;
+}


### PR DESCRIPTION
# Pull Request Feat/api real time performance monitoring

## 📋 Description

 Introduce real-time performance monitoring and health check endpoints to
  `@galaxy-kj/api-rest` for operational visibility and Kubernetes-ready lifecycle
  management.

  Adds four public endpoints, five pluggable health checkers behind a common
  interface, a Prometheus-compatible metrics registry (with cardinality-safe HTTP
  tracking), and wires everything into the existing Express server **before** the
  rate limiter so probes and scrapers are never throttled.

  The design follows dependency injection throughout — every checker accepts its
  external collaborator (fetcher / pinger / provider / sampler) via constructor —
  so integration tests exercise real code paths against fakes with zero
  monkey-patching.

## 🔗 Related Issues

Closes #340 

## 🧪 Testing

- [x] Unit tests added/updated — **37 new tests across 10 suites**
 - [ ] Integration tests added/updated (out of scope; probes will be exercised end-to-end via K8s manifests in a follow-up)
 - [x] Manual testing completed — booted a standalone demo server, hit every endpoint with curl, verified cardinality control (3 `/api/v1/echo/:id`requests → 1 series), confirmed 503 on critical failure and 200 on liveness under a downed dependency
 - [x] All tests passing locally

## 📚 Documentation Updates (Required)

 > **Not included in this PR.** The feature ships with exhaustive inline JSDoc on
  > every new file. Longer-form documentation (README section for `/monitoring`,
  > AI.md patterns, ROADMAP entry) will be a separate docs PR once the endpoints
  > are reviewed and merged, to keep this diff reviewable.

  - [ ] Updated `docs/AI.md` with new patterns/examples — **pending, follow-up PR**
  - [ ] Updated API reference in relevant package README — **pending, follow-up PR**
  - [ ] Added/updated code examples — pending
  - [ ] Updated ARCHITECTURE.md (if architecture changed) — N/A (additive, no arch change)
  - [x] Added inline JSDoc/TSDoc comments — every new file has a top-level `@fileoverview` + `@description`
  - [ ] Updated ROADMAP.md progress (mark issue as completed) — **pending, follow-up PR**

  ### Documentation Checklist by Component:

  Not applicable — this PR only touches `packages/api/rest/`. All component-specific
  sections below are **N/A**:

  - `packages/core/stellar-sdk/` — not modified
  - `packages/core/invisible-wallet/` — not modified
  - `packages/core/automation/` — not modified
  - `packages/core/defi-protocols/` — not modified (only pings its health URL over HTTP)
  - `packages/core/oracles/` — not modified (only reads freshness via a pluggable provider)
  - `packages/contracts/` — not modified
  - `tools/cli/` — not modified
  
## 🤖 AI-Friendly Documentation

### New Files Created
 ```
  packages/api/rest/src/
  ├── config/
  │   └── monitoring-config.ts                — env-driven timeouts, URLs, watermarks, metrics prefix
  ├── types/
  │   └── monitoring-health-types.ts          — HealthChecker interface + ComponentHealth / HealthReport
  ├── middleware/
  │   ├── metrics.ts                          — HTTP tracker; labels by req.route.path for cardinality control
  │   └── __tests__/
  │       └── metrics.middleware.test.ts      — cardinality, exclusions, status capture
  ├── routes/
  │   ├── health/
  │   │   ├── index.ts                        — /health, /health/live, /health/ready
  │   │   └── __tests__/
  │   │       └── health.routes.test.ts       — 200/503 flows via supertest
  │   └── metrics/
  │       ├── index.ts                        — /metrics in Prometheus text format
  │       └── __tests__/
  │           └── metrics.routes.test.ts      — content-type + body assertions
  └── services/monitoring/
      ├── health/
      │   ├── with-timeout.ts                 — promise wrapper w/ HealthCheckTimeoutError
      │   ├── health-checker.ts               — HealthOrchestrator (runAll + runCritical)
      │   ├── database-checker.ts             — Supabase ping (critical); lazy client resolution
      │   ├── horizon-checker.ts              — Stellar Horizon root fetch (critical)
      │   ├── oracle-checker.ts               — freshness vs staleness threshold
      │   ├── defi-checker.ts                 — Blend + Soroswap health, parallel
      │   ├── system-checker.ts               — RSS + event loop lag watermarks
      │   ├── index.ts                        — barrel
      │   └── __tests__/                      — 7 suites covering all checkers
      └── metrics/
          ├── registry.ts                     — isolated prom-client Registry + default metrics
          ├── http-metrics.ts                 — Counter + Histogram (p50/p95/p99 buckets)
          ├── domain-metrics.ts               — Horizon / Oracle / DeFi / WebSocket collectors
          └── index.ts                        — barrel
  ```

### Key Functions/Classes Added

```typescript
// The public contract every checker implements
  export interface HealthChecker {
    readonly name: string;
    readonly critical: boolean;   // affects /health/ready aggregation
    check(): Promise<ComponentHealth>;
  }

  // Coordinator that runs checkers in parallel with timeouts
  export class HealthOrchestrator {
    constructor(checkers: readonly HealthChecker[], options?: HealthOrchestratorOptions);
    runAll(): Promise<HealthReport>;         // /health
    runCritical(): Promise<HealthReport>;    // /health/ready
  }

  // Prom-client isolation for testability
  export function getMetricsRegistry(): Registry;
  export function getHttpMetrics(registry?: Registry): HttpMetrics;
  export function getDomainMetrics(registry?: Registry): DomainMetrics;

  // Middleware
  export function httpMetricsMiddleware(opts?: HttpMetricsMiddlewareOptions): RequestHandler;

  // Routes
  export function setupHealthRoutes(deps: { orchestrator: HealthOrchestrator }): Router;
  export function setupMetricsRoutes(deps?: { registry?: Registry }): Router;
```

### Patterns Used

- Interface + DI for pluggable checkers: every checker accepts its
  external collaborator via constructor (fetcher, ping, provider,
  sampler), so tests never mock modules — they pass fakes. Follow the same
  shape when adding a new checker (e.g. Redis, Kafka).
  - Isolated Prometheus Registry (not the global one): prevents series
  leaking between test suites and makes it trivial to inject a fresh registry.
  Any new metric family should be registered via getDomainMetrics (or a
  similar factory), never via the global default.
  - Cardinality-safe HTTP labels: route label is derived from
  req.route?.path (mounted pattern) — never from req.originalUrl. When
  adding new middleware that emits metrics per-request, do the same or expect
  Prometheus to blow up under path-param traffic.
  - Kubernetes probe distinction: /health/live never touches deps
  (restart signal); /health/ready only touches critical deps (LB gating).
  Keep this invariant when extending — a non-critical failure must never
  cause a restart loop.
  - Lazy resource resolution in checkers: a checker that reaches for an
  external client should do it inside check(), not the constructor, so a
  missing env var surfaces as down instead of crashing the process at
  startup.

## 📸 Screenshots (if applicable)

  N/A — backend-only feature.

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented in CHANGELOG.md

## 🔄 Deployment Notes

<!-- Any special deployment considerations -->

## ✅ Final Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console.log or debug code left
- [x] Error handling implemented
- [x] Performance considered
- [x] Security reviewed
- [ ] Documentation updated (required)
- [ ] ROADMAP.md updated with progress

 Security notes:
  - /metrics is unauthenticated by design (Prometheus scraper convention). Should be gated at network layer in production.
  - /health returns internal component names and error messages. If exposed externally, wrap behind an auth layer or reverse proxy — currently it is at
  the edge, same posture as most K8s-native services.
  - No new attack surface on write paths (all endpoints are read-only GETs).
  - No new secrets required. Blend/Soroswap URLs default to public endpoints.
---

**By submitting this PR, I confirm that**:
- ✅ I have updated all relevant documentation
- ✅ AI.md includes new patterns from my changes
- ✅ Examples are provided for new features
- ✅ The documentation is accurate and helpful for AI assistants and developers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live, readiness, and comprehensive health endpoints with database, Horizon, oracle, DeFi, and system checks.
  * Added a Prometheus-compatible `/metrics` endpoint.
  * Added HTTP performance metrics, domain monitoring metrics, configurable thresholds, and timeout handling.
  * Expanded API information to include the new monitoring endpoints.

* **Bug Fixes**
  * Health checks now report degraded or unavailable components without crashing the service.

* **Tests**
  * Added coverage for health checks, metrics collection, endpoint responses, failures, and timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->