### PR TITLE
Add audit trail export with cryptographic integrity verification

### DIFF
--- a/packages/api/rest/src/index.ts
+++ b/packages/api/rest/src/index.ts
@@ -38,6 +38,7 @@ import { setupTransactionMonitoringRoutes } from './routes/monitoring/transactio
 import { setupApprovalsRoutes } from './routes/approvals';
 import { setupTeamRoutes } from './routes/teams';
 import { setupComplianceRoutes } from './routes/compliance';
+import { setupAuditExportRoutes } from './routes/audit-exports';
 import { kycRoutes } from './routes/kyc-routes';
 import { setupHealthRoutes } from './routes/health';
 import { setupMetricsRoutes } from './routes/metrics';
@@ -181,6 +182,9 @@ class RestApiServer {
 
     // Compliance reporting tools (Issue #335 / Roadmap #67)
     router.use('/compliance', setupComplianceRoutes());
+
+    // Audit trail export with cryptographic integrity (Issue #338 / Roadmap #70)
+    router.use('/audit-exports', setupAuditExportRoutes());
 
     // KYC/AML Integration (Issue #337)
     router.use('/kyc', authenticate(), auditRequest(), kycRoutes);

--- a/packages/api/rest/src/repositories/audit-export.repository.ts
+++ b/packages/api/rest/src/repositories/audit-export.repository.ts
@@ -1,0 +1,206 @@
+/**
+ * @fileoverview Persistence for audit_exports and the per-user last-export cursor.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-21
+ */
+
+import { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseClient } from '../utils/supabase';
+import {
+  AuditExportError,
+  AuditExportRecord,
+  ExportFormat,
+  ExportStatus,
+} from '../types/audit-export-types';
+
+interface ExportRow {
+  id: string;
+  user_id: string;
+  format: ExportFormat;
+  status: ExportStatus;
+  period_start: string;
+  period_end: string;
+  filter_action: string | null;
+  filter_resource: string | null;
+  incremental: boolean;
+  record_count: number;
+  chain_root_hash: string | null;
+  content: string | null;
+  content_type: string | null;
+  error_message: string | null;
+  created_at: string;
+  completed_at: string | null;
+}
+
+const EXPORTS_TABLE = 'audit_exports';
+const CURSORS_TABLE = 'audit_export_cursors';
+
+function rowToExport(row: ExportRow): AuditExportRecord {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    format: row.format,
+    status: row.status,
+    periodStart: new Date(row.period_start),
+    periodEnd: new Date(row.period_end),
+    filterAction: row.filter_action,
+    filterResource: row.filter_resource,
+    incremental: row.incremental,
+    recordCount: row.record_count,
+    chainRootHash: row.chain_root_hash,
+    content: row.content,
+    contentType: row.content_type,
+    errorMessage: row.error_message,
+    createdAt: new Date(row.created_at),
+    completedAt: row.completed_at ? new Date(row.completed_at) : null,
+  };
+}
+
+export class AuditExportRepository {
+  private client: SupabaseClient;
+
+  constructor(client?: SupabaseClient) {
+    this.client = client ?? getSupabaseClient();
+  }
+
+  async createPending(input: {
+    userId: string;
+    format: ExportFormat;
+    periodStart: Date;
+    periodEnd: Date;
+    filterAction?: string | null;
+    filterResource?: string | null;
+    incremental: boolean;
+  }): Promise<AuditExportRecord> {
+    const { data, error } = await this.client
+      .from(EXPORTS_TABLE)
+      .insert({
+        user_id: input.userId,
+        format: input.format,
+        status: 'pending',
+        period_start: input.periodStart.toISOString(),
+        period_end: input.periodEnd.toISOString(),
+        filter_action: input.filterAction ?? null,
+        filter_resource: input.filterResource ?? null,
+        incremental: input.incremental,
+        record_count: 0,
+      })
+      .select('*')
+      .single();
+
+    if (error) {
+      throw new AuditExportError('REPOSITORY_ERROR', error.message, 500);
+    }
+    return rowToExport(data as ExportRow);
+  }
+
+  async markProcessing(id: string): Promise<void> {
+    const { error } = await this.client
+      .from(EXPORTS_TABLE)
+      .update({ status: 'processing' })
+      .eq('id', id);
+
+    if (error) {
+      throw new AuditExportError('REPOSITORY_ERROR', error.message, 500);
+    }
+  }
+
+  async markCompleted(
+    id: string,
+    update: { content: string; contentType: string; recordCount: number; chainRootHash: string }
+  ): Promise<void> {
+    const { error } = await this.client
+      .from(EXPORTS_TABLE)
+      .update({
+        status: 'completed',
+        content: update.content,
+        content_type: update.contentType,
+        record_count: update.recordCount,
+        chain_root_hash: update.chainRootHash,
+        completed_at: new Date().toISOString(),
+        error_message: null,
+      })
+      .eq('id', id);
+
+    if (error) {
+      throw new AuditExportError('REPOSITORY_ERROR', error.message, 500);
+    }
+  }
+
+  async markFailed(id: string, message: string): Promise<void> {
+    const { error } = await this.client
+      .from(EXPORTS_TABLE)
+      .update({
+        status: 'failed',
+        error_message: message,
+        completed_at: new Date().toISOString(),
+      })
+      .eq('id', id);
+
+    if (error) {
+      throw new AuditExportError('REPOSITORY_ERROR', error.message, 500);
+    }
+  }
+
+  async getForUser(id: string, userId: string): Promise<AuditExportRecord> {
+    const { data, error } = await this.client
+      .from(EXPORTS_TABLE)
+      .select('*')
+      .eq('id', id)
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (error) {
+      throw new AuditExportError('REPOSITORY_ERROR', error.message, 500);
+    }
+    if (!data) {
+      throw new AuditExportError('NOT_FOUND', 'Export not found', 404);
+    }
+    return rowToExport(data as ExportRow);
+  }
+
+  async listForUser(
+    userId: string,
+    opts: { limit: number; offset: number }
+  ): Promise<AuditExportRecord[]> {
+    const { data, error } = await this.client
+      .from(EXPORTS_TABLE)
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .range(opts.offset, opts.offset + opts.limit - 1);
+
+    if (error) {
+      throw new AuditExportError('REPOSITORY_ERROR', error.message, 500);
+    }
+    return (data || []).map((row) => rowToExport(row as ExportRow));
+  }
+
+  async getLastExportedAt(userId: string): Promise<Date | null> {
+    const { data, error } = await this.client
+      .from(CURSORS_TABLE)
+      .select('last_exported_at')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (error) {
+      throw new AuditExportError('REPOSITORY_ERROR', error.message, 500);
+    }
+    return data ? new Date((data as { last_exported_at: string }).last_exported_at) : null;
+  }
+
+  async setLastExportedAt(userId: string, at: Date): Promise<void> {
+    const { error } = await this.client.from(CURSORS_TABLE).upsert(
+      {
+        user_id: userId,
+        last_exported_at: at.toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id' }
+    );
+
+    if (error) {
+      throw new AuditExportError('REPOSITORY_ERROR', error.message, 500);
+    }
+  }
+}

--- a/packages/api/rest/src/routes/audit-exports/__tests__/audit-exports.routes.test.ts
+++ b/packages/api/rest/src/routes/audit-exports/__tests__/audit-exports.routes.test.ts
@@ -1,0 +1,124 @@
+import express from 'express';
+import request from 'supertest';
+import { setupAuditExportRoutes } from '../index';
+import { AuditExportError } from '../../../types/audit-export-types';
+
+jest.mock('../../../middleware/auth', () => ({
+  authenticate: () => (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.user = {
+      userId: 'user-1',
+      email: 'user@example.com',
+    } as never;
+    next();
+  },
+}));
+
+jest.mock('../../../middleware/audit', () => ({
+  auditRequest: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+    next(),
+}));
+
+function buildApp(engine: unknown) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/audit-exports', setupAuditExportRoutes(engine as never));
+  app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(500).json({ error: { code: 'INTERNAL', message: err.message, details: {} } });
+  });
+  return app;
+}
+
+describe('audit export routes', () => {
+  const sampleExport = {
+    id: 'exp-1',
+    userId: 'user-1',
+    format: 'json' as const,
+    status: 'completed' as const,
+    periodStart: new Date('2026-07-01T00:00:00.000Z'),
+    periodEnd: new Date('2026-07-20T00:00:00.000Z'),
+    filterAction: null,
+    filterResource: null,
+    incremental: false,
+    recordCount: 1,
+    chainRootHash: 'root-hash',
+    content: '{"entries":[]}',
+    contentType: 'application/json',
+    errorMessage: null,
+    createdAt: new Date('2026-07-21T00:00:00.000Z'),
+    completedAt: new Date('2026-07-21T00:00:01.000Z'),
+  };
+
+  it('starts a background export and returns 202 with a pending/queued record', async () => {
+    const engine = { startExport: jest.fn().mockResolvedValue({ ...sampleExport, status: 'pending' }) };
+    const res = await request(buildApp(engine)).post('/api/v1/audit-exports').send({
+      format: 'json',
+      from: '2026-07-01T00:00:00.000Z',
+      to: '2026-07-20T00:00:00.000Z',
+    });
+
+    expect(res.status).toBe(202);
+    expect(res.body.export.id).toBe('exp-1');
+    expect(engine.startExport).toHaveBeenCalled();
+  });
+
+  it('rejects invalid create body', async () => {
+    const engine = { startExport: jest.fn() };
+    const res = await request(buildApp(engine)).post('/api/v1/audit-exports').send({ format: 'nope' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('lists exports', async () => {
+    const engine = { listExports: jest.fn().mockResolvedValue([sampleExport]) };
+    const res = await request(buildApp(engine)).get('/api/v1/audit-exports');
+    expect(res.status).toBe(200);
+    expect(res.body.exports).toHaveLength(1);
+  });
+
+  it('gets export status/metadata for polling', async () => {
+    const engine = { getExport: jest.fn().mockResolvedValue(sampleExport) };
+    const res = await request(buildApp(engine)).get('/api/v1/audit-exports/exp-1');
+    expect(res.status).toBe(200);
+    expect(res.body.export.status).toBe('completed');
+    expect(res.body.export.chainRootHash).toBe('root-hash');
+  });
+
+  it('downloads completed export content', async () => {
+    const engine = { getExport: jest.fn().mockResolvedValue(sampleExport) };
+    const res = await request(buildApp(engine)).get('/api/v1/audit-exports/exp-1/download');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    expect(res.text).toContain('entries');
+  });
+
+  it('returns 409 when downloading a non-completed export', async () => {
+    const engine = {
+      getExport: jest.fn().mockResolvedValue({ ...sampleExport, status: 'processing', content: null }),
+    };
+    const res = await request(buildApp(engine)).get('/api/v1/audit-exports/exp-1/download');
+    expect(res.status).toBe(409);
+  });
+
+  it('verifies an export chain and returns the result', async () => {
+    const engine = {
+      verifyExport: jest.fn().mockResolvedValue({
+        valid: true,
+        tamperedIndex: null,
+        expectedRootHash: 'root-hash',
+        actualRootHash: 'root-hash',
+      }),
+    };
+    const res = await request(buildApp(engine)).post('/api/v1/audit-exports/exp-1/verify');
+    expect(res.status).toBe(200);
+    expect(res.body.verification.valid).toBe(true);
+  });
+
+  it('maps AuditExportError to the corresponding http status', async () => {
+    const engine = {
+      getExport: jest.fn().mockRejectedValue(new AuditExportError('NOT_FOUND', 'Export not found', 404)),
+    };
+    const res = await request(buildApp(engine)).get('/api/v1/audit-exports/missing');
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+  });
+});

--- a/packages/api/rest/src/routes/audit-exports/index.ts
+++ b/packages/api/rest/src/routes/audit-exports/index.ts
@@ -1,0 +1,175 @@
+/**
+ * @fileoverview REST routes for audit trail export with cryptographic integrity (Issue #338 / Roadmap #70).
+ * @author Galaxy DevKit Team
+ * @since 2026-07-21
+ */
+
+import express, { NextFunction, Request, Response } from 'express';
+import { authenticate } from '../../middleware/auth';
+import { auditRequest } from '../../middleware/audit';
+import { validate } from '../../middleware/validate';
+import { AuditExportEngine } from '../../services/audit-export/export-engine';
+import { AuditExportError, AuditExportRecord, CreateExportInput } from '../../types/audit-export-types';
+import {
+  createExportSchema,
+  exportIdParamSchema,
+  listExportsQuerySchema,
+} from '../../validators/audit-export-validators';
+
+function requireUser(req: Request, res: Response): string | null {
+  if (!req.user) {
+    res.status(401).json({
+      error: { code: 'AUTH_ERROR', message: 'Authentication required', details: {} },
+    });
+    return null;
+  }
+  return req.user.userId;
+}
+
+function handleExportError(err: unknown, res: Response, next: NextFunction): void {
+  if (err instanceof AuditExportError) {
+    res.status(err.statusCode).json({
+      error: { code: err.code, message: err.message, details: err.details },
+    });
+    return;
+  }
+  next(err);
+}
+
+function serializeExport(record: AuditExportRecord) {
+  return {
+    id: record.id,
+    format: record.format,
+    status: record.status,
+    periodStart: record.periodStart.toISOString(),
+    periodEnd: record.periodEnd.toISOString(),
+    filters: {
+      action: record.filterAction,
+      resource: record.filterResource,
+    },
+    incremental: record.incremental,
+    recordCount: record.recordCount,
+    chainRootHash: record.chainRootHash,
+    errorMessage: record.errorMessage,
+    createdAt: record.createdAt.toISOString(),
+    completedAt: record.completedAt ? record.completedAt.toISOString() : null,
+  };
+}
+
+const FILE_EXTENSIONS: Record<string, string> = {
+  json: 'json',
+  csv: 'csv',
+  archive: 'zip',
+};
+
+export function setupAuditExportRoutes(
+  engine: AuditExportEngine = new AuditExportEngine()
+): express.Router {
+  const router = express.Router();
+
+  router.use(authenticate(), auditRequest());
+
+  // POST /exports — start a background export job (non-blocking)
+  router.post('/', validate(createExportSchema, 'body'), async (req, res, next) => {
+    const userId = requireUser(req, res);
+    if (!userId) return;
+    try {
+      const body = req.body as CreateExportInput;
+      const record = await engine.startExport(userId, {
+        format: body.format,
+        from: new Date(body.from),
+        to: new Date(body.to),
+        filters: body.filters,
+        incremental: body.incremental,
+      });
+      res.status(202).json({ export: serializeExport(record) });
+    } catch (err) {
+      handleExportError(err, res, next);
+    }
+  });
+
+  // GET /exports — list user exports
+  router.get('/', validate(listExportsQuerySchema, 'query'), async (req, res, next) => {
+    const userId = requireUser(req, res);
+    if (!userId) return;
+    try {
+      const query = req.query as unknown as { limit: number; offset: number };
+      const exports = await engine.listExports(userId, {
+        limit: Number(query.limit),
+        offset: Number(query.offset),
+      });
+      res.json({ exports: exports.map(serializeExport) });
+    } catch (err) {
+      handleExportError(err, res, next);
+    }
+  });
+
+  // GET /exports/:id — status + metadata (poll target)
+  router.get('/:id', validate(exportIdParamSchema, 'params'), async (req, res, next) => {
+    const userId = requireUser(req, res);
+    if (!userId) return;
+    try {
+      const record = await engine.getExport(userId, req.params.id);
+      res.json({ export: serializeExport(record) });
+    } catch (err) {
+      handleExportError(err, res, next);
+    }
+  });
+
+  // GET /exports/:id/download — raw export body
+  router.get(
+    '/:id/download',
+    validate(exportIdParamSchema, 'params'),
+    async (req, res, next) => {
+      const userId = requireUser(req, res);
+      if (!userId) return;
+      try {
+        const record = await engine.getExport(userId, req.params.id);
+        if (record.status !== 'completed' || !record.content || !record.contentType) {
+          res.status(409).json({
+            error: {
+              code: 'EXPORT_NOT_READY',
+              message: 'Export is not ready for download',
+              details: { status: record.status },
+            },
+          });
+          return;
+        }
+
+        const extension = FILE_EXTENSIONS[record.format];
+        res.setHeader(
+          'Content-Disposition',
+          `attachment; filename="audit-export-${record.id}.${extension}"`
+        );
+
+        if (record.format === 'archive') {
+          res.setHeader('Content-Type', record.contentType);
+          res.status(200).send(Buffer.from(record.content, 'base64'));
+        } else {
+          res.setHeader('Content-Type', record.contentType);
+          res.status(200).send(record.content);
+        }
+      } catch (err) {
+        handleExportError(err, res, next);
+      }
+    }
+  );
+
+  // POST /exports/:id/verify — validate hash chain integrity
+  router.post(
+    '/:id/verify',
+    validate(exportIdParamSchema, 'params'),
+    async (req, res, next) => {
+      const userId = requireUser(req, res);
+      if (!userId) return;
+      try {
+        const result = await engine.verifyExport(userId, req.params.id);
+        res.json({ verification: result });
+      } catch (err) {
+        handleExportError(err, res, next);
+      }
+    }
+  );
+
+  return router;
+}

--- a/packages/api/rest/src/services/audit-export/__tests__/export-engine.test.ts
+++ b/packages/api/rest/src/services/audit-export/__tests__/export-engine.test.ts
@@ -1,0 +1,173 @@
+import { AuditExportEngine } from '../export-engine';
+import { AuditExportRecord } from '../../../types/audit-export-types';
+import { buildHashChain } from '../hash-chain';
+
+function flushAsync(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('AuditExportEngine', () => {
+  const pending: AuditExportRecord = {
+    id: 'exp-1',
+    userId: 'user-1',
+    format: 'json',
+    status: 'pending',
+    periodStart: new Date('2026-07-01T00:00:00.000Z'),
+    periodEnd: new Date('2026-07-20T00:00:00.000Z'),
+    filterAction: null,
+    filterResource: null,
+    incremental: false,
+    recordCount: 0,
+    chainRootHash: null,
+    content: null,
+    contentType: null,
+    errorMessage: null,
+    createdAt: new Date('2026-07-21T00:00:00.000Z'),
+    completedAt: null,
+  };
+
+  it('returns a pending record immediately and processes in the background', async () => {
+    const auditLogger = {
+      query: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
+    };
+    const repository = {
+      getLastExportedAt: jest.fn().mockResolvedValue(null),
+      createPending: jest.fn().mockResolvedValue(pending),
+      markProcessing: jest.fn().mockResolvedValue(undefined),
+      markCompleted: jest.fn().mockResolvedValue(undefined),
+      markFailed: jest.fn().mockResolvedValue(undefined),
+      setLastExportedAt: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const engine = new AuditExportEngine(auditLogger as never, repository as never);
+    const result = await engine.startExport('user-1', {
+      format: 'json',
+      from: new Date('2026-07-01T00:00:00.000Z'),
+      to: new Date('2026-07-20T00:00:00.000Z'),
+    });
+
+    expect(result.status).toBe('pending');
+    expect(repository.createPending).toHaveBeenCalledTimes(1);
+
+    await flushAsync();
+
+    expect(repository.markProcessing).toHaveBeenCalledWith('exp-1');
+    expect(repository.markCompleted).toHaveBeenCalledTimes(1);
+    expect(repository.setLastExportedAt).toHaveBeenCalledWith(
+      'user-1',
+      new Date('2026-07-20T00:00:00.000Z')
+    );
+  });
+
+  it('widens `from` to the last export cursor for incremental exports', async () => {
+    const lastExportedAt = new Date('2026-07-15T00:00:00.000Z');
+    const auditLogger = { query: jest.fn().mockResolvedValue({ items: [], nextCursor: null }) };
+    const repository = {
+      getLastExportedAt: jest.fn().mockResolvedValue(lastExportedAt),
+      createPending: jest.fn().mockResolvedValue(pending),
+      markProcessing: jest.fn().mockResolvedValue(undefined),
+      markCompleted: jest.fn().mockResolvedValue(undefined),
+      markFailed: jest.fn().mockResolvedValue(undefined),
+      setLastExportedAt: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const engine = new AuditExportEngine(auditLogger as never, repository as never);
+    await engine.startExport('user-1', {
+      format: 'json',
+      from: new Date('2026-07-01T00:00:00.000Z'),
+      to: new Date('2026-07-20T00:00:00.000Z'),
+      incremental: true,
+    });
+
+    expect(repository.createPending).toHaveBeenCalledWith(
+      expect.objectContaining({ periodStart: lastExportedAt })
+    );
+  });
+
+  it('marks the export failed if audit log query throws', async () => {
+    const auditLogger = { query: jest.fn().mockRejectedValue(new Error('db down')) };
+    const repository = {
+      getLastExportedAt: jest.fn().mockResolvedValue(null),
+      createPending: jest.fn().mockResolvedValue(pending),
+      markProcessing: jest.fn().mockResolvedValue(undefined),
+      markCompleted: jest.fn().mockResolvedValue(undefined),
+      markFailed: jest.fn().mockResolvedValue(undefined),
+      setLastExportedAt: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const engine = new AuditExportEngine(auditLogger as never, repository as never);
+    await engine.startExport('user-1', {
+      format: 'json',
+      from: new Date('2026-07-01T00:00:00.000Z'),
+      to: new Date('2026-07-20T00:00:00.000Z'),
+    });
+
+    await flushAsync();
+
+    expect(repository.markFailed).toHaveBeenCalledWith('exp-1', 'db down');
+    expect(repository.markCompleted).not.toHaveBeenCalled();
+  });
+
+  it('verifies a completed export by recomputing the hash chain', async () => {
+    const events = [
+      {
+        id: '1',
+        timestamp: '2026-07-02T10:00:00.000Z',
+        user_id: 'user-1',
+        action: 'wallet.transfer',
+        resource: '/tx',
+        ip_address: '1.2.3.4',
+        success: true,
+      },
+    ];
+    const { entries, rootHash } = buildHashChain(events);
+
+    const completed: AuditExportRecord = {
+      ...pending,
+      status: 'completed',
+      chainRootHash: rootHash,
+      content: JSON.stringify({ manifest: {}, entries }),
+      contentType: 'application/json',
+      recordCount: 1,
+      completedAt: new Date(),
+    };
+
+    const repository = { getForUser: jest.fn().mockResolvedValue(completed) };
+    const engine = new AuditExportEngine({} as never, repository as never);
+
+    const result = await engine.verifyExport('user-1', 'exp-1');
+    expect(result.valid).toBe(true);
+  });
+
+  it('detects tampering during verification', async () => {
+    const events = [
+      {
+        id: '1',
+        timestamp: '2026-07-02T10:00:00.000Z',
+        user_id: 'user-1',
+        action: 'wallet.transfer',
+        resource: '/tx',
+        ip_address: '1.2.3.4',
+        success: true,
+      },
+    ];
+    const { entries, rootHash } = buildHashChain(events);
+    const tamperedEntries = [{ ...entries[0], action: 'wallet.withdraw' }];
+
+    const completed: AuditExportRecord = {
+      ...pending,
+      status: 'completed',
+      chainRootHash: rootHash,
+      content: JSON.stringify({ manifest: {}, entries: tamperedEntries }),
+      contentType: 'application/json',
+      recordCount: 1,
+      completedAt: new Date(),
+    };
+
+    const repository = { getForUser: jest.fn().mockResolvedValue(completed) };
+    const engine = new AuditExportEngine({} as never, repository as never);
+
+    const result = await engine.verifyExport('user-1', 'exp-1');
+    expect(result.valid).toBe(false);
+  });
+});

--- a/packages/api/rest/src/services/audit-export/__tests__/exporters.test.ts
+++ b/packages/api/rest/src/services/audit-export/__tests__/exporters.test.ts
@@ -1,0 +1,63 @@
+import { AuditEvent } from '../../audit-logger';
+import { buildHashChain } from '../hash-chain';
+import { exportAuditTrail } from '../exporters';
+import { readZipArchive } from '../zip-writer';
+import { ExportedManifest } from '../../../types/audit-export-types';
+
+function makeManifest(overrides: Partial<ExportedManifest> = {}): ExportedManifest {
+  return {
+    format: 'json',
+    generatedAt: '2026-07-21T00:00:00.000Z',
+    period: { from: '2026-07-01T00:00:00.000Z', to: '2026-07-20T00:00:00.000Z' },
+    filters: {},
+    recordCount: 1,
+    chainRootHash: 'abc',
+    ...overrides,
+  };
+}
+
+describe('exportAuditTrail', () => {
+  const events: AuditEvent[] = [
+    {
+      id: '1',
+      timestamp: '2026-07-02T10:00:00.000Z',
+      user_id: 'user-1',
+      action: 'wallet.transfer',
+      resource: '/tx',
+      ip_address: '1.2.3.4',
+      success: true,
+      metadata: { amount: '10' },
+    },
+  ];
+  const { entries, rootHash } = buildHashChain(events);
+  const manifest = makeManifest({ chainRootHash: rootHash, recordCount: entries.length });
+
+  it('exports JSON with manifest and hash-chained entries', () => {
+    const result = exportAuditTrail('json', manifest, entries);
+    expect(result.contentType).toBe('application/json');
+    const parsed = JSON.parse(result.content);
+    expect(parsed.manifest.chainRootHash).toBe(rootHash);
+    expect(parsed.entries[0].hash).toBe(entries[0].hash);
+  });
+
+  it('exports CSV with hash columns', () => {
+    const result = exportAuditTrail('csv', manifest, entries);
+    expect(result.contentType).toBe('text/csv');
+    expect(result.content).toContain('wallet.transfer');
+    expect(result.content).toContain(entries[0].hash);
+  });
+
+  it('exports a signed archive containing manifest.json and entries.json', () => {
+    const result = exportAuditTrail('archive', manifest, entries);
+    expect(result.contentType).toBe('application/zip');
+
+    const zip = Buffer.from(result.content, 'base64');
+    const files = readZipArchive(zip);
+    const names = files.map((f) => f.name);
+    expect(names).toEqual(['manifest.json', 'entries.json']);
+
+    const manifestFile = files.find((f) => f.name === 'manifest.json')!;
+    const parsedManifest = JSON.parse(manifestFile.content.toString('utf8'));
+    expect(parsedManifest.chainRootHash).toBe(rootHash);
+  });
+});

--- a/packages/api/rest/src/services/audit-export/__tests__/hash-chain.test.ts
+++ b/packages/api/rest/src/services/audit-export/__tests__/hash-chain.test.ts
@@ -1,0 +1,83 @@
+import { AuditEvent } from '../../audit-logger';
+import { buildHashChain, verifyHashChain, GENESIS_HASH } from '../hash-chain';
+
+function makeEvent(overrides: Partial<AuditEvent> = {}): AuditEvent {
+  return {
+    id: '1',
+    timestamp: '2026-07-20T00:00:00.000Z',
+    user_id: 'user-1',
+    action: 'wallet.transfer',
+    resource: '/tx',
+    ip_address: '1.2.3.4',
+    success: true,
+    ...overrides,
+  };
+}
+
+describe('buildHashChain', () => {
+  it('is deterministic for the same input events', () => {
+    const events = [makeEvent({ id: '1' }), makeEvent({ id: '2' })];
+    const a = buildHashChain(events);
+    const b = buildHashChain(events);
+    expect(a.rootHash).toBe(b.rootHash);
+    expect(a.entries[0].hash).toBe(b.entries[0].hash);
+  });
+
+  it('chains previousHash across entries starting from the genesis hash', () => {
+    const events = [makeEvent({ id: '1' }), makeEvent({ id: '2' }), makeEvent({ id: '3' })];
+    const { entries, rootHash } = buildHashChain(events);
+
+    expect(entries[0].previousHash).toBe(GENESIS_HASH);
+    expect(entries[1].previousHash).toBe(entries[0].hash);
+    expect(entries[2].previousHash).toBe(entries[1].hash);
+    expect(rootHash).toBe(entries[2].hash);
+  });
+
+  it('produces a different root hash when any field changes', () => {
+    const events = [makeEvent({ id: '1' })];
+    const { rootHash: rootA } = buildHashChain(events);
+    const { rootHash: rootB } = buildHashChain([makeEvent({ id: '1', success: false })]);
+    expect(rootA).not.toBe(rootB);
+  });
+});
+
+describe('verifyHashChain', () => {
+  it('validates an untampered chain', () => {
+    const events = [makeEvent({ id: '1' }), makeEvent({ id: '2' })];
+    const { entries, rootHash } = buildHashChain(events);
+    const result = verifyHashChain(entries, rootHash);
+    expect(result.valid).toBe(true);
+    expect(result.tamperedIndex).toBeNull();
+  });
+
+  it('detects a tampered field in an entry', () => {
+    const events = [makeEvent({ id: '1' }), makeEvent({ id: '2' }), makeEvent({ id: '3' })];
+    const { entries, rootHash } = buildHashChain(events);
+
+    const tampered = entries.map((e, i) => (i === 1 ? { ...e, action: 'wallet.withdraw' } : e));
+    const result = verifyHashChain(tampered, rootHash);
+
+    expect(result.valid).toBe(false);
+    expect(result.tamperedIndex).toBe(1);
+  });
+
+  it('detects a deleted entry', () => {
+    const events = [makeEvent({ id: '1' }), makeEvent({ id: '2' }), makeEvent({ id: '3' })];
+    const { entries, rootHash } = buildHashChain(events);
+
+    const withDeletion = [entries[0], entries[2]];
+    const result = verifyHashChain(withDeletion, rootHash);
+
+    expect(result.valid).toBe(false);
+  });
+
+  it('detects reordered entries', () => {
+    const events = [makeEvent({ id: '1' }), makeEvent({ id: '2' })];
+    const { entries, rootHash } = buildHashChain(events);
+
+    const reordered = [entries[1], entries[0]];
+    const result = verifyHashChain(reordered, rootHash);
+
+    expect(result.valid).toBe(false);
+  });
+});

--- a/packages/api/rest/src/services/audit-export/__tests__/zip-writer.test.ts
+++ b/packages/api/rest/src/services/audit-export/__tests__/zip-writer.test.ts
@@ -1,0 +1,23 @@
+import { buildZipArchive, readZipArchive } from '../zip-writer';
+
+describe('buildZipArchive / readZipArchive', () => {
+  it('round-trips multiple entries', () => {
+    const zip = buildZipArchive([
+      { name: 'manifest.json', content: '{"a":1}' },
+      { name: 'entries.json', content: '[1,2,3]' },
+    ]);
+
+    const entries = readZipArchive(zip);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].name).toBe('manifest.json');
+    expect(entries[0].content.toString('utf8')).toBe('{"a":1}');
+    expect(entries[1].name).toBe('entries.json');
+    expect(entries[1].content.toString('utf8')).toBe('[1,2,3]');
+  });
+
+  it('produces a valid ZIP signature and end-of-central-directory record', () => {
+    const zip = buildZipArchive([{ name: 'a.txt', content: 'hello' }]);
+    expect(zip.readUInt32LE(0)).toBe(0x04034b50);
+    expect(zip.readUInt32LE(zip.length - 22)).toBe(0x06054b50);
+  });
+});

--- a/packages/api/rest/src/services/audit-export/export-engine.ts
+++ b/packages/api/rest/src/services/audit-export/export-engine.ts
@@ -1,0 +1,147 @@
+/**
+ * @fileoverview Audit trail export engine.
+ * @description Runs as a non-blocking background job: `startExport` persists
+ *              a `pending` record and returns immediately, while the actual
+ *              audit-log paging, hash-chain computation, and formatting run
+ *              asynchronously. Callers poll `getExport` for status/content.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-21
+ */
+
+import { AuditEvent, AuditLogger } from '../audit-logger';
+import { AuditExportRepository } from '../../repositories/audit-export.repository';
+import {
+  AuditExportError,
+  AuditExportRecord,
+  CreateExportInput,
+  ExportedManifest,
+} from '../../types/audit-export-types';
+import { buildHashChain, ChainVerificationResult } from './hash-chain';
+import { exportAuditTrail } from './exporters';
+import { verifyExportRecord } from './verifier';
+
+/** Hard cap on pages fetched per export (page size 200 => 200k records) to bound worst-case memory/time. */
+const MAX_PAGES = 1000;
+
+export class AuditExportEngine {
+  constructor(
+    private readonly auditLogger: AuditLogger = new AuditLogger(),
+    private readonly repository: AuditExportRepository = new AuditExportRepository()
+  ) {}
+
+  /**
+   * Creates the pending export record and kicks off background processing.
+   * Returns immediately with the pending record so callers can poll status.
+   */
+  async startExport(userId: string, input: CreateExportInput): Promise<AuditExportRecord> {
+    if (input.from.getTime() > input.to.getTime()) {
+      throw new AuditExportError(
+        'VALIDATION_ERROR',
+        '`from` must be earlier than or equal to `to`',
+        400
+      );
+    }
+
+    let from = input.from;
+    if (input.incremental) {
+      const lastExportedAt = await this.repository.getLastExportedAt(userId);
+      if (lastExportedAt && lastExportedAt.getTime() > from.getTime()) {
+        from = lastExportedAt;
+      }
+    }
+
+    const pending = await this.repository.createPending({
+      userId,
+      format: input.format,
+      periodStart: from,
+      periodEnd: input.to,
+      filterAction: input.filters?.action ?? null,
+      filterResource: input.filters?.resource ?? null,
+      incremental: input.incremental ?? false,
+    });
+
+    void this.process(pending.id, userId, {
+      ...input,
+      from,
+    });
+
+    return pending;
+  }
+
+  private async process(exportId: string, userId: string, input: CreateExportInput): Promise<void> {
+    try {
+      await this.repository.markProcessing(exportId);
+
+      const events = await this.fetchAllEvents(userId, input);
+      events.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+
+      const { entries, rootHash } = buildHashChain(events);
+
+      const manifest: ExportedManifest = {
+        format: input.format,
+        generatedAt: new Date().toISOString(),
+        period: { from: input.from.toISOString(), to: input.to.toISOString() },
+        filters: input.filters ?? {},
+        recordCount: entries.length,
+        chainRootHash: rootHash,
+      };
+
+      const exported = exportAuditTrail(input.format, manifest, entries);
+
+      await this.repository.markCompleted(exportId, {
+        content: exported.content,
+        contentType: exported.contentType,
+        recordCount: entries.length,
+        chainRootHash: rootHash,
+      });
+
+      await this.repository.setLastExportedAt(userId, input.to);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Export generation failed';
+      await this.repository.markFailed(exportId, message);
+    }
+  }
+
+  private async fetchAllEvents(userId: string, input: CreateExportInput): Promise<AuditEvent[]> {
+    const events: AuditEvent[] = [];
+    let cursor: string | undefined;
+
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const result = await this.auditLogger.query({
+        userId,
+        action: input.filters?.action,
+        resource: input.filters?.resource,
+        from: input.from,
+        to: input.to,
+        cursor,
+        limit: 200,
+      });
+
+      events.push(...result.items);
+
+      if (!result.nextCursor) break;
+      cursor = result.nextCursor;
+    }
+
+    return events;
+  }
+
+  async getExport(userId: string, exportId: string): Promise<AuditExportRecord> {
+    return this.repository.getForUser(exportId, userId);
+  }
+
+  async listExports(
+    userId: string,
+    opts: { limit?: number; offset?: number } = {}
+  ): Promise<AuditExportRecord[]> {
+    return this.repository.listForUser(userId, {
+      limit: opts.limit ?? 50,
+      offset: opts.offset ?? 0,
+    });
+  }
+
+  async verifyExport(userId: string, exportId: string): Promise<ChainVerificationResult> {
+    const record = await this.repository.getForUser(exportId, userId);
+    return verifyExportRecord(record);
+  }
+}

--- a/packages/api/rest/src/services/audit-export/exporters.ts
+++ b/packages/api/rest/src/services/audit-export/exporters.ts
@@ -1,0 +1,97 @@
+/**
+ * @fileoverview Exporters for hash-chained audit trail exports (JSON/CSV/signed archive).
+ * @author Galaxy DevKit Team
+ * @since 2026-07-21
+ */
+
+import { ChainedAuditEvent } from './hash-chain';
+import { ExportedManifest, ExportFormat } from '../../types/audit-export-types';
+import { buildZipArchive } from './zip-writer';
+
+export interface ExportResult {
+  content: string;
+  contentType: string;
+}
+
+function escapeCsvCell(value: string | number | boolean | null): string {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (/[",\n\r]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+const CSV_COLUMNS = [
+  'id',
+  'timestamp',
+  'user_id',
+  'action',
+  'resource',
+  'ip_address',
+  'success',
+  'error_code',
+  'previousHash',
+  'hash',
+] as const;
+
+export function exportJson(manifest: ExportedManifest, entries: ChainedAuditEvent[]): ExportResult {
+  return {
+    content: JSON.stringify({ manifest, entries }, null, 2),
+    contentType: 'application/json',
+  };
+}
+
+export function exportCsv(manifest: ExportedManifest, entries: ChainedAuditEvent[]): ExportResult {
+  const header = [...CSV_COLUMNS, 'metadata'].map(escapeCsvCell).join(',');
+  const lines: string[] = [header];
+
+  for (const entry of entries) {
+    const row = CSV_COLUMNS.map((col) => escapeCsvCell(entry[col] as string | number | boolean | null));
+    row.push(escapeCsvCell(entry.metadata ? JSON.stringify(entry.metadata) : null));
+    lines.push(row.join(','));
+  }
+
+  return {
+    content: lines.join('\n') + '\n',
+    contentType: 'text/csv',
+  };
+}
+
+/**
+ * Signed archive: a ZIP containing `manifest.json` (SHA-256 chain root hash
+ * and export metadata) and `entries.json` (the full hash-chained payload).
+ * GPG signing is intentionally out of scope here — the manifest is the
+ * verifiable integrity artifact; a signature step can wrap this archive
+ * externally without changing its layout.
+ */
+export function exportArchive(manifest: ExportedManifest, entries: ChainedAuditEvent[]): ExportResult {
+  const zip = buildZipArchive([
+    { name: 'manifest.json', content: JSON.stringify(manifest, null, 2) },
+    { name: 'entries.json', content: JSON.stringify(entries, null, 2) },
+  ]);
+
+  return {
+    content: zip.toString('base64'),
+    contentType: 'application/zip',
+  };
+}
+
+export function exportAuditTrail(
+  format: ExportFormat,
+  manifest: ExportedManifest,
+  entries: ChainedAuditEvent[]
+): ExportResult {
+  switch (format) {
+    case 'json':
+      return exportJson(manifest, entries);
+    case 'csv':
+      return exportCsv(manifest, entries);
+    case 'archive':
+      return exportArchive(manifest, entries);
+    default: {
+      const _exhaustive: never = format;
+      throw new Error(`Unsupported format: ${_exhaustive}`);
+    }
+  }
+}

--- a/packages/api/rest/src/services/audit-export/hash-chain.ts
+++ b/packages/api/rest/src/services/audit-export/hash-chain.ts
@@ -1,0 +1,109 @@
+/**
+ * @fileoverview SHA-256 hash-chain utilities for tamper-evident audit exports.
+ * @description Each entry's hash is derived from the previous entry's hash
+ *              plus its own canonical fields, so altering, reordering, or
+ *              removing any entry breaks every hash from that point forward.
+ *              The last entry's hash is the "chain root hash" and is stored
+ *              alongside the export as the single value needed to prove
+ *              the whole export is unmodified.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-21
+ */
+
+import { createHash } from 'crypto';
+import { AuditEvent } from '../audit-logger';
+
+export const GENESIS_HASH = '0'.repeat(64);
+
+export interface ChainedAuditEvent extends AuditEvent {
+  previousHash: string;
+  hash: string;
+}
+
+export interface HashChainResult {
+  entries: ChainedAuditEvent[];
+  rootHash: string;
+}
+
+/** Canonical, order-stable representation of the fields covered by the hash. */
+function canonicalize(event: AuditEvent): string {
+  return JSON.stringify({
+    id: event.id,
+    timestamp: event.timestamp,
+    user_id: event.user_id,
+    action: event.action,
+    resource: event.resource,
+    ip_address: event.ip_address,
+    success: event.success,
+    error_code: event.error_code ?? null,
+    metadata: event.metadata ?? null,
+  });
+}
+
+export function computeEntryHash(previousHash: string, event: AuditEvent): string {
+  return createHash('sha256').update(previousHash).update(canonicalize(event)).digest('hex');
+}
+
+/**
+ * Builds a hash chain over `events` in the given order. Callers must pass
+ * events in a stable, deterministic order (e.g. ascending timestamp) since
+ * the chain is order-sensitive by design.
+ */
+export function buildHashChain(
+  events: AuditEvent[],
+  genesisHash: string = GENESIS_HASH
+): HashChainResult {
+  let previousHash = genesisHash;
+  const entries: ChainedAuditEvent[] = events.map((event) => {
+    const hash = computeEntryHash(previousHash, event);
+    const entry: ChainedAuditEvent = { ...event, previousHash, hash };
+    previousHash = hash;
+    return entry;
+  });
+
+  return { entries, rootHash: previousHash };
+}
+
+export interface ChainVerificationResult {
+  valid: boolean;
+  /** Index of the first entry whose stored hash no longer matches its recomputed hash, or null if none. */
+  tamperedIndex: number | null;
+  expectedRootHash: string;
+  actualRootHash: string;
+}
+
+/**
+ * Recomputes the hash chain from the raw fields of each entry and compares
+ * it against the hashes stored on the entries themselves and the expected
+ * root hash. Detects insertion, deletion, reordering, and field tampering.
+ */
+export function verifyHashChain(
+  entries: ChainedAuditEvent[],
+  expectedRootHash: string,
+  genesisHash: string = GENESIS_HASH
+): ChainVerificationResult {
+  let previousHash = genesisHash;
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    const recomputedHash = computeEntryHash(previousHash, entry);
+
+    if (entry.previousHash !== previousHash || entry.hash !== recomputedHash) {
+      return {
+        valid: false,
+        tamperedIndex: i,
+        expectedRootHash,
+        actualRootHash: recomputedHash,
+      };
+    }
+
+    previousHash = recomputedHash;
+  }
+
+  return {
+    valid: previousHash === expectedRootHash,
+    tamperedIndex: previousHash === expectedRootHash ? null : entries.length - 1,
+    expectedRootHash,
+    actualRootHash: previousHash,
+  };
+}

--- a/packages/api/rest/src/services/audit-export/verifier.ts
+++ b/packages/api/rest/src/services/audit-export/verifier.ts
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview Integrity verification for completed audit exports.
+ * @description Recomputes the hash chain over the entries stored in an
+ *              export's content and compares it against the export's
+ *              chain root hash, detecting any tampering (edits, deletions,
+ *              insertions, or reordering).
+ * @author Galaxy DevKit Team
+ * @since 2026-07-21
+ */
+
+import { AuditExportError, AuditExportRecord } from '../../types/audit-export-types';
+import { ChainedAuditEvent, ChainVerificationResult, verifyHashChain } from './hash-chain';
+import { readZipArchive } from './zip-writer';
+
+function parseEntries(record: AuditExportRecord): ChainedAuditEvent[] {
+  if (!record.content) {
+    throw new AuditExportError('EXPORT_NOT_READY', 'Export has no content to verify', 409);
+  }
+
+  switch (record.format) {
+    case 'json': {
+      const parsed = JSON.parse(record.content) as { entries: ChainedAuditEvent[] };
+      return parsed.entries;
+    }
+    case 'archive': {
+      const zip = Buffer.from(record.content, 'base64');
+      const entriesFile = readZipArchive(zip).find((e) => e.name === 'entries.json');
+      if (!entriesFile) {
+        throw new AuditExportError('CORRUPT_ARCHIVE', 'entries.json missing from archive', 422);
+      }
+      return JSON.parse(entriesFile.content.toString('utf8')) as ChainedAuditEvent[];
+    }
+    default:
+      throw new AuditExportError(
+        'UNSUPPORTED_FORMAT',
+        `Verification is not supported for the '${record.format}' format; use json or archive`,
+        400
+      );
+  }
+}
+
+export function verifyExportRecord(record: AuditExportRecord): ChainVerificationResult {
+  if (record.status !== 'completed' || !record.chainRootHash) {
+    throw new AuditExportError('EXPORT_NOT_READY', 'Export is not completed', 409);
+  }
+
+  const entries = parseEntries(record);
+  return verifyHashChain(entries, record.chainRootHash);
+}

--- a/packages/api/rest/src/services/audit-export/zip-writer.ts
+++ b/packages/api/rest/src/services/audit-export/zip-writer.ts
@@ -1,0 +1,136 @@
+/**
+ * @fileoverview Minimal, dependency-free ZIP (store-only) archive writer.
+ * @description Produces a valid ZIP file containing uncompressed entries.
+ *              Store-only (no DEFLATE) keeps the implementation small and
+ *              avoids re-implementing a compressor; archives are still
+ *              valid, tool-readable ZIPs — just not size-optimized.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-21
+ */
+
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(buf: Buffer): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) {
+    crc = CRC_TABLE[(crc ^ buf[i]) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function dosDateTime(date: Date): { time: number; date: number } {
+  const time =
+    ((date.getHours() & 0x1f) << 11) |
+    ((date.getMinutes() & 0x3f) << 5) |
+    ((date.getSeconds() >> 1) & 0x1f);
+  const dosYear = Math.max(0, date.getFullYear() - 1980);
+  const date2 = ((dosYear & 0x7f) << 9) | (((date.getMonth() + 1) & 0xf) << 5) | (date.getDate() & 0x1f);
+  return { time, date: date2 };
+}
+
+export interface ZipEntryInput {
+  name: string;
+  content: string | Buffer;
+}
+
+export function buildZipArchive(entries: ZipEntryInput[], now: Date = new Date()): Buffer {
+  const { time, date } = dosDateTime(now);
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const nameBuf = Buffer.from(entry.name, 'utf8');
+    const dataBuf = Buffer.isBuffer(entry.content) ? entry.content : Buffer.from(entry.content, 'utf8');
+    const crc = crc32(dataBuf);
+
+    const localHeader = Buffer.alloc(30);
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(20, 4); // version needed
+    localHeader.writeUInt16LE(0, 6); // flags
+    localHeader.writeUInt16LE(0, 8); // method = store
+    localHeader.writeUInt16LE(time, 10);
+    localHeader.writeUInt16LE(date, 12);
+    localHeader.writeUInt32LE(crc, 14);
+    localHeader.writeUInt32LE(dataBuf.length, 18); // compressed size
+    localHeader.writeUInt32LE(dataBuf.length, 22); // uncompressed size
+    localHeader.writeUInt16LE(nameBuf.length, 26);
+    localHeader.writeUInt16LE(0, 28); // extra length
+
+    localParts.push(localHeader, nameBuf, dataBuf);
+
+    const centralHeader = Buffer.alloc(46);
+    centralHeader.writeUInt32LE(0x02014b50, 0);
+    centralHeader.writeUInt16LE(20, 4); // version made by
+    centralHeader.writeUInt16LE(20, 6); // version needed
+    centralHeader.writeUInt16LE(0, 8); // flags
+    centralHeader.writeUInt16LE(0, 10); // method = store
+    centralHeader.writeUInt16LE(time, 12);
+    centralHeader.writeUInt16LE(date, 14);
+    centralHeader.writeUInt32LE(crc, 16);
+    centralHeader.writeUInt32LE(dataBuf.length, 20);
+    centralHeader.writeUInt32LE(dataBuf.length, 24);
+    centralHeader.writeUInt16LE(nameBuf.length, 28);
+    centralHeader.writeUInt16LE(0, 30); // extra length
+    centralHeader.writeUInt16LE(0, 32); // comment length
+    centralHeader.writeUInt16LE(0, 34); // disk number start
+    centralHeader.writeUInt16LE(0, 36); // internal attrs
+    centralHeader.writeUInt32LE(0, 38); // external attrs
+    centralHeader.writeUInt32LE(offset, 42); // local header offset
+
+    centralParts.push(centralHeader, nameBuf);
+
+    offset += localHeader.length + nameBuf.length + dataBuf.length;
+  }
+
+  const centralDirStart = offset;
+  const centralDirBuf = Buffer.concat(centralParts);
+
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4); // disk number
+  eocd.writeUInt16LE(0, 6); // disk with central dir
+  eocd.writeUInt16LE(entries.length, 8); // entries on this disk
+  eocd.writeUInt16LE(entries.length, 10); // total entries
+  eocd.writeUInt32LE(centralDirBuf.length, 12); // central dir size
+  eocd.writeUInt32LE(centralDirStart, 16); // central dir offset
+  eocd.writeUInt16LE(0, 20); // comment length
+
+  return Buffer.concat([...localParts, centralDirBuf, eocd]);
+}
+
+/**
+ * Reads a store-only ZIP produced by `buildZipArchive`. Walks local file
+ * headers sequentially rather than parsing the central directory — correct
+ * and sufficient for archives this module itself writes.
+ */
+export function readZipArchive(zip: Buffer): ZipEntryInput[] {
+  const entries: ZipEntryInput[] = [];
+  let pos = 0;
+
+  while (pos + 4 <= zip.length && zip.readUInt32LE(pos) === 0x04034b50) {
+    const nameLength = zip.readUInt16LE(pos + 26);
+    const extraLength = zip.readUInt16LE(pos + 28);
+    const compressedSize = zip.readUInt32LE(pos + 18);
+
+    const nameStart = pos + 30;
+    const dataStart = nameStart + nameLength + extraLength;
+    const name = zip.subarray(nameStart, nameStart + nameLength).toString('utf8');
+    const content = zip.subarray(dataStart, dataStart + compressedSize);
+
+    entries.push({ name, content: Buffer.from(content) });
+    pos = dataStart + compressedSize;
+  }
+
+  return entries;
+}

--- a/packages/api/rest/src/services/audit-logger.ts
+++ b/packages/api/rest/src/services/audit-logger.ts
@@ -25,6 +25,7 @@ export interface AuditEvent {
 export interface AuditQueryFilters {
   userId?: string;
   action?: string;
+  resource?: string;
   from?: Date;
   to?: Date;
   /** Opaque cursor returned as `nextCursor` from a previous page. */
@@ -134,6 +135,10 @@ export class AuditLogger {
 
       if (filters.action) {
         query = query.eq('action', filters.action);
+      }
+
+      if (filters.resource) {
+        query = query.eq('resource', filters.resource);
       }
 
       if (filters.from) {

--- a/packages/api/rest/src/types/audit-export-types.ts
+++ b/packages/api/rest/src/types/audit-export-types.ts
@@ -1,0 +1,70 @@
+/**
+ * @fileoverview Types for audit trail export with cryptographic integrity (Issue #338 / Roadmap #70).
+ * @author Galaxy DevKit Team
+ * @since 2026-07-21
+ */
+
+export type ExportFormat = 'json' | 'csv' | 'archive';
+
+export type ExportStatus = 'pending' | 'processing' | 'completed' | 'failed';
+
+export interface ExportFilters {
+  action?: string;
+  resource?: string;
+}
+
+export interface CreateExportInput {
+  format: ExportFormat;
+  from: Date;
+  to: Date;
+  filters?: ExportFilters;
+  /** When true, `from` is widened to the user's last completed export (if more recent). */
+  incremental?: boolean;
+}
+
+export interface AuditExportRecord {
+  id: string;
+  userId: string;
+  format: ExportFormat;
+  status: ExportStatus;
+  periodStart: Date;
+  periodEnd: Date;
+  filterAction: string | null;
+  filterResource: string | null;
+  incremental: boolean;
+  recordCount: number;
+  chainRootHash: string | null;
+  content: string | null;
+  contentType: string | null;
+  errorMessage: string | null;
+  createdAt: Date;
+  completedAt: Date | null;
+}
+
+export interface ExportedManifest {
+  format: ExportFormat;
+  generatedAt: string;
+  period: { from: string; to: string };
+  filters: ExportFilters;
+  recordCount: number;
+  chainRootHash: string;
+}
+
+export class AuditExportError extends Error {
+  readonly code: string;
+  readonly statusCode: number;
+  readonly details: Record<string, unknown>;
+
+  constructor(
+    code: string,
+    message: string,
+    statusCode = 400,
+    details: Record<string, unknown> = {}
+  ) {
+    super(message);
+    this.name = 'AuditExportError';
+    this.code = code;
+    this.statusCode = statusCode;
+    this.details = details;
+  }
+}

--- a/packages/api/rest/src/validators/audit-export-validators.ts
+++ b/packages/api/rest/src/validators/audit-export-validators.ts
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Joi schemas for audit trail export routes.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-21
+ */
+
+import Joi from 'joi';
+
+const exportFormat = Joi.string().valid('json', 'csv', 'archive').default('json');
+
+export const createExportSchema = Joi.object({
+  format: exportFormat,
+  from: Joi.date().iso().required(),
+  to: Joi.date().iso().min(Joi.ref('from')).required(),
+  filters: Joi.object({
+    action: Joi.string().optional(),
+    resource: Joi.string().optional(),
+  })
+    .default({})
+    .unknown(false),
+  incremental: Joi.boolean().default(false),
+}).unknown(false);
+
+export const listExportsQuerySchema = Joi.object({
+  limit: Joi.number().integer().min(1).max(100).default(50),
+  offset: Joi.number().integer().min(0).default(0),
+}).unknown(false);
+
+export const exportIdParamSchema = Joi.object({
+  id: Joi.string().min(1).required(),
+}).unknown(false);

--- a/supabase/migrations/20260721000000_audit_exports.sql
+++ b/supabase/migrations/20260721000000_audit_exports.sql
@@ -1,0 +1,38 @@
+-- Audit trail export tables (Issue #338 / Roadmap #70)
+-- Stores generated exports with hash-chain integrity metadata and tracks
+-- the last completed export per user to support incremental exports.
+
+create table if not exists audit_exports (
+  id                text primary key default gen_random_uuid()::text,
+  user_id           text not null,
+  format            text not null
+                    check (format in ('json', 'csv', 'archive')),
+  status            text not null default 'pending'
+                    check (status in ('pending', 'processing', 'completed', 'failed')),
+  period_start      timestamptz not null,
+  period_end        timestamptz not null,
+  filter_action     text,
+  filter_resource   text,
+  incremental       boolean not null default false,
+  record_count      integer not null default 0,
+  chain_root_hash   text,
+  content           text,
+  content_type      text,
+  error_message     text,
+  created_at        timestamptz not null default now(),
+  completed_at      timestamptz
+);
+
+create index if not exists audit_exports_user_id_idx
+  on audit_exports (user_id);
+
+create index if not exists audit_exports_user_created_idx
+  on audit_exports (user_id, created_at desc);
+
+-- Tracks the last completed export cursor per user, used to compute the
+-- `from` boundary for incremental exports without scanning audit_exports.
+create table if not exists audit_export_cursors (
+  user_id           text primary key,
+  last_exported_at  timestamptz not null,
+  updated_at        timestamptz not null default now()
+);


### PR DESCRIPTION
# Pull Request

## 📋 Description

Adds audit trail export with cryptographic hash-chain integrity verification, building on the existing audit logging (#66 / [audit-logger.ts](packages/api/rest/src/services/audit-logger.ts)) and compliance reporting (#67 / [compliance module](packages/api/rest/src/services/compliance)) infrastructure. Each exported record is linked to the previous one via a SHA-256 hash chain, so any edit, deletion, insertion, or reordering of records is detectable, and organizations can prove an exported audit trail has not been tampered with.

## 🔗 Related Issues

Closes #338

## 🧪 Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed (not applicable — no live Supabase instance available in this environment; verified via unit/route tests with mocked repository/engine)
- [x] All tests passing locally

## 📚 Documentation Updates (Required)

This PR only touches `packages/api/rest/`, which has no dedicated component doc section in the template checklist above; no `docs/AI.md`, `ARCHITECTURE.md`, or package README currently document the audit/compliance REST modules this builds on, so none were updated to keep the PR scoped to the issue.

## 🤖 AI-Friendly Documentation

### New Files Created

```
supabase/migrations/20260721000000_audit_exports.sql - audit_exports + audit_export_cursors tables
packages/api/rest/src/types/audit-export-types.ts - Export/format/status types, AuditExportError
packages/api/rest/src/services/audit-export/hash-chain.ts - SHA-256 hash-chain build/verify
packages/api/rest/src/services/audit-export/zip-writer.ts - Dependency-free store-only ZIP reader/writer
packages/api/rest/src/services/audit-export/exporters.ts - JSON/CSV/signed-archive export formatting
packages/api/rest/src/services/audit-export/verifier.ts - Recomputes and validates a completed export's hash chain
packages/api/rest/src/services/audit-export/export-engine.ts - Background export job orchestration + incremental cursor logic
packages/api/rest/src/repositories/audit-export.repository.ts - Supabase persistence for exports and last-export cursor
packages/api/rest/src/validators/audit-export-validators.ts - Joi schemas for the export routes
packages/api/rest/src/routes/audit-exports/index.ts - REST routes (create/list/status/download/verify)
+ matching __tests__ files for each module above
```

### Key Functions/Classes Added

```typescript
buildHashChain(events: AuditEvent[]): { entries: ChainedAuditEvent[]; rootHash: string }
verifyHashChain(entries: ChainedAuditEvent[], expectedRootHash: string): ChainVerificationResult

class AuditExportEngine {
  startExport(userId: string, input: CreateExportInput): Promise<AuditExportRecord> // returns pending record immediately, processes in background
  getExport(userId: string, exportId: string): Promise<AuditExportRecord>
  listExports(userId: string, opts?): Promise<AuditExportRecord[]>
  verifyExport(userId: string, exportId: string): Promise<ChainVerificationResult>
}

setupAuditExportRoutes(engine?: AuditExportEngine): express.Router
// POST   /api/v1/audit-exports            - start export (202, pending)
// GET    /api/v1/audit-exports            - list exports
// GET    /api/v1/audit-exports/:id        - status/metadata (poll target)
// GET    /api/v1/audit-exports/:id/download - raw content
// POST   /api/v1/audit-exports/:id/verify - integrity check
```

### Patterns Used

Mirrors the existing compliance reporting module's architecture (routes → engine → repository, Joi validators, `XError` class with `code`/`statusCode`/`details`) so the two features stay consistent for future maintainers/AI assistants working in this REST package.

## ⚠️ Breaking Changes

- [x] No breaking changes

## 🔄 Deployment Notes

Requires running the new `20260721000000_audit_exports.sql` Supabase migration before deploying.

## ✅ Final Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console.log or debug code left
- [x] Error handling implemented
- [x] Performance considered (bounded cursor pagination over audit logs, capped at 1000 pages)
- [x] Security reviewed
- [ ] Documentation updated (required) — see note above; no existing docs cover this area
- [ ] ROADMAP.md updated with progress

## Notes for reviewers

- **Signed archive / GPG**: the "signed archive" format produces a ZIP with `manifest.json` (chain root hash + metadata) and `entries.json`. GPG signing is intentionally out of scope — the manifest is the verifiable integrity artifact, and an external signing step can wrap the archive without changing its layout.
- **Streaming**: exports page through audit logs via the existing cursor pagination (200 rows/page, capped at 1000 pages = 200k records) rather than a single unbounded query, to bound memory use per the issue's 100k+ record requirement. A true streamed-to-disk implementation would be a larger change; this follows the same in-memory-content pattern already used by the compliance report engine.
- **CSV verification**: the verification endpoint supports `json` and `archive` formats (both carry the structured hash-chain entries). CSV exports are for spreadsheet consumption and are not re-parsed for verification — re-export as JSON/archive to verify.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audit-trail exports in JSON, CSV, and archive formats.
  * Exports run in the background with status tracking and download support.
  * Added filtering, pagination, and incremental export options.
  * Added hash-chain integrity verification to detect tampering.
  * Added resource-based audit-log filtering.

* **Bug Fixes**
  * Improved validation and error responses for export requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->