### PR TITLE
[FEATURE] API: Enhanced structured audit logging system

### DIFF
--- a/packages/api/rest/src/index.ts
+++ b/packages/api/rest/src/index.ts
@@ -39,6 +39,7 @@ import { setupApprovalsRoutes } from './routes/approvals';
 import { setupTeamRoutes } from './routes/teams';
 import { setupComplianceRoutes } from './routes/compliance';
 import { setupAuditExportRoutes } from './routes/audit-exports';
+import { setupAuditLogRoutes } from './routes/audit-logs';
 import { kycRoutes } from './routes/kyc-routes';
 import { setupHealthRoutes } from './routes/health';
 import { setupMetricsRoutes } from './routes/metrics';
@@ -185,6 +186,9 @@ class RestApiServer {
 
     // Audit trail export with cryptographic integrity (Issue #338 / Roadmap #70)
     router.use('/audit-exports', setupAuditExportRoutes());
+
+    // Enhanced structured audit log query API (Issue #334)
+    router.use('/audit-logs', setupAuditLogRoutes());
 
     // KYC/AML Integration (Issue #337)
     router.use('/kyc', authenticate(), auditRequest(), kycRoutes);

--- a/packages/api/rest/src/routes/audit-logs/__tests__/audit-logs.routes.test.ts
+++ b/packages/api/rest/src/routes/audit-logs/__tests__/audit-logs.routes.test.ts
@@ -1,0 +1,100 @@
+import express from 'express';
+import request from 'supertest';
+import { setupAuditLogRoutes } from '../index';
+import { AuditEvent } from '../../../services/audit-logger';
+
+jest.mock('../../../middleware/auth', () => ({
+  authenticate: () => (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.user = {
+      userId: 'user-1',
+      email: 'user@example.com',
+    } as never;
+    next();
+  },
+}));
+
+jest.mock('../../../middleware/audit', () => ({
+  auditRequest: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+    next(),
+}));
+
+function buildApp(logger: unknown) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/audit-logs', setupAuditLogRoutes(logger as never));
+  app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(500).json({ error: { code: 'INTERNAL', message: err.message, details: {} } });
+  });
+  return app;
+}
+
+const sampleEvent: AuditEvent = {
+  id: 'log-1',
+  timestamp: '2026-07-22T00:00:00.000Z',
+  user_id: 'user-1',
+  organization_id: 'org-1',
+  action: 'defi.blend.supply',
+  resource: '/api/v1/defi/blend/supply',
+  resource_id: 'GABC...',
+  ip_address: '1.2.3.4',
+  success: true,
+  severity: 'info',
+  correlation_id: 'req-1',
+  metadata: { asset: 'XLM', amount: '100' },
+};
+
+describe('audit log query routes', () => {
+  it('lists the caller\'s own audit logs scoped by their userId', async () => {
+    const logger = { query: jest.fn().mockResolvedValue({ items: [sampleEvent], nextCursor: null }) };
+    const res = await request(buildApp(logger)).get('/api/v1/audit-logs');
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].actor).toEqual({ userId: 'user-1', organizationId: 'org-1' });
+    expect(res.body.items[0].details).toEqual({ asset: 'XLM', amount: '100' });
+    expect(logger.query).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-1' })
+    );
+  });
+
+  it('forwards action/severity/date filters and pagination cursor to the logger', async () => {
+    const logger = { query: jest.fn().mockResolvedValue({ items: [], nextCursor: 'next-cursor' }) };
+    const res = await request(buildApp(logger)).get('/api/v1/audit-logs').query({
+      action: 'defi.blend.supply',
+      severity: 'warning',
+      from: '2026-07-01T00:00:00.000Z',
+      to: '2026-07-22T00:00:00.000Z',
+      cursor: 'abc',
+      limit: 10,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.nextCursor).toBe('next-cursor');
+    expect(logger.query).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        action: 'defi.blend.supply',
+        severity: 'warning',
+        cursor: 'abc',
+        limit: 10,
+      })
+    );
+  });
+
+  it('rejects an invalid severity value', async () => {
+    const logger = { query: jest.fn() };
+    const res = await request(buildApp(logger)).get('/api/v1/audit-logs').query({ severity: 'nope' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    expect(logger.query).not.toHaveBeenCalled();
+  });
+
+  it('propagates query errors to the error handler', async () => {
+    const logger = { query: jest.fn().mockRejectedValue(new Error('db down')) };
+    const res = await request(buildApp(logger)).get('/api/v1/audit-logs');
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.message).toBe('db down');
+  });
+});

--- a/packages/api/rest/src/routes/audit-logs/index.ts
+++ b/packages/api/rest/src/routes/audit-logs/index.ts
@@ -1,0 +1,88 @@
+/**
+ * @fileoverview REST routes for querying structured audit logs (Issue #334).
+ * @author Galaxy DevKit Team
+ * @since 2026-07-22
+ */
+
+import express, { Request, Response } from 'express';
+import { authenticate } from '../../middleware/auth';
+import { auditRequest } from '../../middleware/audit';
+import { validate } from '../../middleware/validate';
+import { AuditLogger, AuditEvent } from '../../services/audit-logger';
+import { listAuditLogsQuerySchema } from '../../validators/audit-log-validators';
+
+function requireUser(req: Request, res: Response): string | null {
+  if (!req.user) {
+    res.status(401).json({
+      error: { code: 'AUTH_ERROR', message: 'Authentication required', details: {} },
+    });
+    return null;
+  }
+  return req.user.userId;
+}
+
+function serializeAuditEvent(event: AuditEvent) {
+  return {
+    id: event.id,
+    timestamp: event.timestamp,
+    actor: {
+      userId: event.user_id,
+      organizationId: event.organization_id ?? null,
+    },
+    action: event.action,
+    resource: event.resource,
+    resourceId: event.resource_id ?? null,
+    success: event.success,
+    errorCode: event.error_code ?? null,
+    severity: event.severity ?? 'info',
+    correlationId: event.correlation_id ?? null,
+    details: event.metadata ?? null,
+  };
+}
+
+export function setupAuditLogRoutes(logger: AuditLogger = new AuditLogger()): express.Router {
+  const router = express.Router();
+
+  router.use(authenticate(), auditRequest());
+
+  // GET /audit-logs — query the caller's own audit trail with filters.
+  router.get('/', validate(listAuditLogsQuerySchema, 'query'), async (req, res, next) => {
+    const userId = requireUser(req, res);
+    if (!userId) return;
+    try {
+      const query = req.query as unknown as {
+        action?: string;
+        resource?: string;
+        organizationId?: string;
+        severity?: 'info' | 'warning' | 'critical';
+        correlationId?: string;
+        from?: string;
+        to?: string;
+        cursor?: string;
+        limit: number;
+      };
+
+      const result = await logger.query({
+        userId,
+        action: query.action,
+        resource: query.resource,
+        organizationId: query.organizationId,
+        severity: query.severity,
+        correlationId: query.correlationId,
+        from: query.from ? new Date(query.from) : undefined,
+        to: query.to ? new Date(query.to) : undefined,
+        cursor: query.cursor,
+        limit: query.limit,
+      });
+
+      res.json({
+        items: result.items.map(serializeAuditEvent),
+        nextCursor: result.nextCursor,
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/packages/api/rest/src/routes/defi.routes.test.ts
+++ b/packages/api/rest/src/routes/defi.routes.test.ts
@@ -95,6 +95,26 @@ jest.mock('../middleware/auth', () => ({
     }
 }));
 
+// Mock AuditLogger so route tests don't need real Supabase credentials, and
+// so we can assert DeFi mutations are recorded in the audit trail. The mock's
+// `log` fn is self-contained in the factory (not an outer closure variable)
+// to avoid a TDZ hazard: `jest.mock` factories are hoisted above imports, but
+// `./defi.routes` (imported above) eagerly constructs a singleton
+// `new AuditLogger()` at module load time, before any later `const` in this
+// file would have run.
+jest.mock('../services/audit-logger', () => ({
+    AuditLogger: jest.fn().mockImplementation(() => ({
+        log: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+// `./defi.routes` has already been imported above by this point, so the
+// singleton `new AuditLogger()` it constructs at module load already exists
+// — safe to grab its `log` mock reference here (this statement itself runs
+// in normal textual order, well after that import).
+const mockAuditLog: jest.Mock = jest.requireMock('../services/audit-logger').AuditLogger.mock
+    .results[0].value.log;
+
 describe('DeFi Routes', () => {
     let app: express.Application;
 
@@ -370,6 +390,70 @@ describe('DeFi Routes', () => {
 
             expect(response.status).toBe(400);
             expect(response.body.error.code).toBe('VALIDATION_ERROR');
+        });
+    });
+
+    describe('Audit logging for DeFi mutations', () => {
+        it('records a successful defi.blend.supply audit event', async () => {
+            await request(app)
+                .post('/api/v1/defi/blend/supply')
+                .send({ asset: 'USDC', amount: '100', signerPublicKey: 'GD...SIGNER' });
+
+            expect(mockAuditLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    user_id: 'mock-user-id',
+                    action: 'defi.blend.supply',
+                    resource_id: 'GD...SIGNER',
+                    success: true,
+                    severity: 'info',
+                })
+            );
+        });
+
+        it('records a successful defi.soroswap.swap audit event', async () => {
+            await request(app)
+                .post('/api/v1/defi/swap')
+                .send({
+                    assetIn: 'XLM',
+                    assetOut: 'USDC',
+                    amountIn: '100',
+                    minAmountOut: '98',
+                    signerPublicKey: 'GD...SIGNER',
+                });
+
+            expect(mockAuditLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    action: 'defi.soroswap.swap',
+                    resource_id: 'GD...SIGNER',
+                    success: true,
+                })
+            );
+        });
+
+        it('records a failed audit event when the protocol call throws', async () => {
+            const { ProtocolFactory } = jest.requireMock('@galaxy-kj/core-defi-protocols');
+            ProtocolFactory.getInstance().createProtocol.mockReturnValueOnce({
+                initialize: jest.fn().mockResolvedValue(undefined),
+                supply: jest.fn().mockRejectedValue(new Error('rpc unreachable')),
+            });
+
+            await request(app)
+                .post('/api/v1/defi/blend/supply')
+                .send({ asset: 'USDC', amount: '100', signerPublicKey: 'GD...SIGNER' });
+
+            expect(mockAuditLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    action: 'defi.blend.supply',
+                    resource_id: 'GD...SIGNER',
+                    success: false,
+                    severity: 'warning',
+                })
+            );
+        });
+
+        it('does not log an audit event for a 400 validation failure', async () => {
+            await request(app).post('/api/v1/defi/blend/supply').send({ asset: 'USDC' });
+            expect(mockAuditLog).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/api/rest/src/routes/defi.routes.ts
+++ b/packages/api/rest/src/routes/defi.routes.ts
@@ -7,6 +7,34 @@
 import express, { Request, Response, NextFunction } from 'express';
 import { authenticate } from '../middleware/auth';
 import { ProtocolFactory, ProtocolConfig, Asset, DexAggregatorService } from '@galaxy-kj/core-defi-protocols';
+import { AuditLogger } from '../services/audit-logger';
+
+const auditLogger = new AuditLogger();
+
+/**
+ * Records a DeFi protocol operation (supply/borrow/swap/liquidity) in the
+ * audit trail. Fire-and-forget, mirroring the rest of the audit logging
+ * system — a logging failure must never block the DeFi response.
+ */
+function logDefiOperation(
+    req: Request,
+    action: string,
+    success: boolean,
+    resourceId: string | null,
+    metadata: Record<string, unknown>
+): void {
+    void auditLogger.log({
+        user_id: req.user?.userId || null,
+        action,
+        resource: `${req.baseUrl}${req.path}`,
+        resource_id: resourceId,
+        ip_address: req.ip || null,
+        success,
+        severity: success ? 'info' : 'warning',
+        correlation_id: (req.headers['x-request-id'] as string) || null,
+        metadata,
+    });
+}
 
 // Default configuration for protocols (can be moved to a config file or env vars)
 const defaultConfig: Omit<ProtocolConfig, 'protocolId'> = {
@@ -192,8 +220,16 @@ export function setupDefiRoutes(): express.Router {
             // Pass an empty string for privateKey so the transaction doesn't sign/submit
             const result = await protocol.swap(signerPublicKey, '', tokenIn, tokenOut, amountIn, minAmountOut);
 
+            logDefiOperation(req, 'defi.soroswap.swap', true, signerPublicKey, {
+                assetIn, assetOut, amountIn, minAmountOut,
+            });
             res.json(result);
         } catch (error) {
+            const { signerPublicKey, assetIn, assetOut, amountIn, minAmountOut } = req.body ?? {};
+            logDefiOperation(req, 'defi.soroswap.swap', false, signerPublicKey ?? null, {
+                assetIn, assetOut, amountIn, minAmountOut,
+                error: error instanceof Error ? error.message : String(error),
+            });
             next(error);
         }
     });
@@ -274,8 +310,13 @@ export function setupDefiRoutes(): express.Router {
             // Empty string for privateKey means it will just return the unsigned XDR
             const result = await protocol.supply(signerPublicKey, '', tokenAsset, amount);
 
+            logDefiOperation(req, 'defi.blend.supply', true, signerPublicKey, { asset, amount });
             res.json(result);
         } catch (error) {
+            const { asset, amount, signerPublicKey } = req.body ?? {};
+            logDefiOperation(req, 'defi.blend.supply', false, signerPublicKey ?? null, {
+                asset, amount, error: error instanceof Error ? error.message : String(error),
+            });
             next(error);
         }
     });
@@ -309,8 +350,13 @@ export function setupDefiRoutes(): express.Router {
 
             const result = await protocol.withdraw(signerPublicKey, '', tokenAsset, amount);
 
+            logDefiOperation(req, 'defi.blend.withdraw', true, signerPublicKey, { asset, amount });
             res.json(result);
         } catch (error) {
+            const { asset, amount, signerPublicKey } = req.body ?? {};
+            logDefiOperation(req, 'defi.blend.withdraw', false, signerPublicKey ?? null, {
+                asset, amount, error: error instanceof Error ? error.message : String(error),
+            });
             next(error);
         }
     });
@@ -344,8 +390,13 @@ export function setupDefiRoutes(): express.Router {
 
             const result = await protocol.borrow(signerPublicKey, '', tokenAsset, amount);
 
+            logDefiOperation(req, 'defi.blend.borrow', true, signerPublicKey, { asset, amount });
             res.json(result);
         } catch (error) {
+            const { asset, amount, signerPublicKey } = req.body ?? {};
+            logDefiOperation(req, 'defi.blend.borrow', false, signerPublicKey ?? null, {
+                asset, amount, error: error instanceof Error ? error.message : String(error),
+            });
             next(error);
         }
     });
@@ -379,8 +430,13 @@ export function setupDefiRoutes(): express.Router {
 
             const result = await protocol.repay(signerPublicKey, '', tokenAsset, amount);
 
+            logDefiOperation(req, 'defi.blend.repay', true, signerPublicKey, { asset, amount });
             res.json(result);
         } catch (error) {
+            const { asset, amount, signerPublicKey } = req.body ?? {};
+            logDefiOperation(req, 'defi.blend.repay', false, signerPublicKey ?? null, {
+                asset, amount, error: error instanceof Error ? error.message : String(error),
+            });
             next(error);
         }
     });
@@ -418,8 +474,16 @@ export function setupDefiRoutes(): express.Router {
             }
             const result = await protocol.addLiquidity(signerPublicKey, '', tokenA, tokenB, amountA, amountB);
 
+            logDefiOperation(req, 'defi.soroswap.liquidity.add', true, signerPublicKey, {
+                assetA, assetB, amountA, amountB,
+            });
             res.json(result);
         } catch (error) {
+            const { assetA, assetB, amountA, amountB, signerPublicKey } = req.body ?? {};
+            logDefiOperation(req, 'defi.soroswap.liquidity.add', false, signerPublicKey ?? null, {
+                assetA, assetB, amountA, amountB,
+                error: error instanceof Error ? error.message : String(error),
+            });
             next(error);
         }
     });
@@ -457,8 +521,16 @@ export function setupDefiRoutes(): express.Router {
             }
             const result = await protocol.removeLiquidity(signerPublicKey, '', tokenA, tokenB, poolAddress, lpAmount, minAmountA, minAmountB);
 
+            logDefiOperation(req, 'defi.soroswap.liquidity.remove', true, signerPublicKey, {
+                assetA, assetB, poolAddress, lpAmount, minAmountA, minAmountB,
+            });
             res.json(result);
         } catch (error) {
+            const { assetA, assetB, poolAddress, lpAmount, minAmountA, minAmountB, signerPublicKey } = req.body ?? {};
+            logDefiOperation(req, 'defi.soroswap.liquidity.remove', false, signerPublicKey ?? null, {
+                assetA, assetB, poolAddress, lpAmount, minAmountA, minAmountB,
+                error: error instanceof Error ? error.message : String(error),
+            });
             next(error);
         }
     });

--- a/packages/api/rest/src/routes/wallets/submit-tx.route.ts
+++ b/packages/api/rest/src/routes/wallets/submit-tx.route.ts
@@ -120,6 +120,29 @@ async function pollTransaction(
 }
 
 import { userSubmitTxLimiter, globalSubmitTxLimiter } from "../../middleware/rate-limit";
+import { AuditLogger } from "../../services/audit-logger";
+
+const auditLogger = new AuditLogger();
+
+function logSubmitTxEvent(
+  req: Request,
+  success: boolean,
+  userId: string | null,
+  walletId: string | null,
+  metadata: Record<string, unknown>
+): void {
+  void auditLogger.log({
+    user_id: userId,
+    action: "smart_wallet.transaction_submitted",
+    resource: `${req.baseUrl}${req.path}`,
+    resource_id: walletId,
+    ip_address: req.ip || null,
+    success,
+    severity: success ? "info" : "warning",
+    correlation_id: (req.headers["x-request-id"] as string) || null,
+    metadata,
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Route
@@ -177,6 +200,10 @@ router.post(
         feeBumpTx = buildFeeBump(innerTx);
       } catch (buildErr) {
         console.error("[submit-tx] Fee-bump build failed");
+        logSubmitTxEvent(req, false, wallet.user_id, wallet.id, {
+          stage: "build_fee_bump",
+          error: "Internal error building fee-bump transaction",
+        });
         return res.status(500).json({
           error: "Internal error building fee-bump transaction",
         });
@@ -192,6 +219,10 @@ router.post(
           "[submit-tx] Stellar RPC submission failed:",
           rpcErr?.message ?? rpcErr
         );
+        logSubmitTxEvent(req, false, wallet.user_id, wallet.id, {
+          stage: "rpc_submit",
+          error: "Stellar RPC submission failed",
+        });
         return res.status(502).json({
           error: "Stellar RPC submission failed",
         });
@@ -202,6 +233,10 @@ router.post(
           "[submit-tx] Stellar RPC returned ERROR:",
           rpcResult.errorResult?.toXDR("base64")
         );
+        logSubmitTxEvent(req, false, wallet.user_id, wallet.id, {
+          stage: "rpc_submit",
+          error: "Stellar RPC returned an error",
+        });
         return res.status(502).json({
           error: "Stellar RPC returned an error",
         });
@@ -221,6 +256,11 @@ router.post(
             "[submit-tx] Transaction failed after submission:",
             confirmed.status
           );
+          logSubmitTxEvent(req, false, wallet.user_id, wallet.id, {
+            stage: "confirmation",
+            transactionHash: txHash,
+            error: "Transaction failed after submission",
+          });
           return res.status(502).json({
             error: "Transaction failed after submission",
           });
@@ -238,6 +278,11 @@ router.post(
       } catch (logErr) {
         console.error("[submit-tx] Failed to log wallet event:", logErr);
       }
+
+      logSubmitTxEvent(req, true, wallet.user_id, wallet.id, {
+        transactionHash: txHash,
+        ledger: ledger ?? null,
+      });
 
       // ---- 8. Respond -----------------------------------------------
       return res.status(200).json({

--- a/packages/api/rest/src/services/__tests__/audit-logger.test.ts
+++ b/packages/api/rest/src/services/__tests__/audit-logger.test.ts
@@ -1,0 +1,155 @@
+const mockInsert = jest.fn();
+const mockOrder = jest.fn();
+const mockLimit = jest.fn();
+const mockSelect = jest.fn();
+const mockEq = jest.fn();
+const mockGte = jest.fn();
+const mockLte = jest.fn();
+const mockLt = jest.fn();
+
+function buildQueryChain() {
+  const chain: Record<string, jest.Mock> = {};
+  chain.eq = mockEq.mockReturnValue(chain);
+  chain.gte = mockGte.mockReturnValue(chain);
+  chain.lte = mockLte.mockReturnValue(chain);
+  chain.lt = mockLt.mockReturnValue(chain);
+  chain.order = mockOrder.mockReturnValue(chain);
+  chain.limit = mockLimit;
+  return chain;
+}
+
+const mockFrom = jest.fn((_table: string) => ({
+  insert: mockInsert,
+  select: mockSelect.mockReturnValue(buildQueryChain()),
+}));
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({ from: mockFrom })),
+}));
+
+process.env.SUPABASE_URL = 'https://test.supabase.co';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key';
+
+import { AuditLogger } from '../audit-logger';
+
+describe('AuditLogger', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInsert.mockResolvedValue({ error: null });
+    mockLimit.mockResolvedValue({ data: [], error: null });
+  });
+
+  describe('log', () => {
+    it('writes the structured fields, defaulting severity to info', async () => {
+      const logger = new AuditLogger();
+      await logger.log({
+        user_id: 'user-1',
+        action: 'defi.blend.supply',
+        resource: '/defi/blend/supply',
+        ip_address: '1.2.3.4',
+        success: true,
+      });
+
+      expect(mockFrom).toHaveBeenCalledWith('audit_logs');
+      expect(mockInsert).toHaveBeenCalledWith([
+        expect.objectContaining({
+          user_id: 'user-1',
+          organization_id: null,
+          action: 'defi.blend.supply',
+          resource: '/defi/blend/supply',
+          resource_id: null,
+          success: true,
+          severity: 'info',
+          correlation_id: null,
+        }),
+      ]);
+    });
+
+    it('persists explicit severity, correlationId, organizationId and resourceId', async () => {
+      const logger = new AuditLogger();
+      await logger.log({
+        user_id: 'user-1',
+        organization_id: 'org-1',
+        action: 'defi.blend.borrow',
+        resource: '/defi/blend/borrow',
+        resource_id: 'GABC',
+        ip_address: null,
+        success: false,
+        severity: 'critical',
+        correlation_id: 'req-42',
+      });
+
+      expect(mockInsert).toHaveBeenCalledWith([
+        expect.objectContaining({
+          organization_id: 'org-1',
+          resource_id: 'GABC',
+          severity: 'critical',
+          correlation_id: 'req-42',
+        }),
+      ]);
+    });
+
+    it('strips sensitive metadata keys before writing', async () => {
+      const logger = new AuditLogger();
+      await logger.log({
+        user_id: 'user-1',
+        action: 'auth.login',
+        resource: null,
+        ip_address: null,
+        success: true,
+        metadata: { password: 'shh', nested: { token: 'x', keep: 'y' } },
+      });
+
+      expect(mockInsert).toHaveBeenCalledWith([
+        expect.objectContaining({
+          metadata: { nested: { keep: 'y' } },
+        }),
+      ]);
+    });
+
+    it('is fire-and-forget by default: swallows write failures', async () => {
+      mockInsert.mockResolvedValueOnce({ error: new Error('db down') });
+      const logger = new AuditLogger();
+
+      await expect(
+        logger.log({ user_id: 'user-1', action: 'x', resource: null, ip_address: null, success: true })
+      ).resolves.toBeUndefined();
+    });
+
+    it('rethrows write failures when { sync: true } is passed', async () => {
+      mockInsert.mockResolvedValueOnce({ error: new Error('db down') });
+      const logger = new AuditLogger();
+
+      await expect(
+        logger.log(
+          { user_id: 'user-1', action: 'x', resource: null, ip_address: null, success: true },
+          { sync: true }
+        )
+      ).rejects.toThrow('db down');
+    });
+  });
+
+  describe('query', () => {
+    it('applies the new structured filters (organizationId, severity, correlationId)', async () => {
+      const logger = new AuditLogger();
+      await logger.query({
+        userId: 'user-1',
+        organizationId: 'org-1',
+        severity: 'critical',
+        correlationId: 'req-42',
+      });
+
+      expect(mockEq).toHaveBeenCalledWith('user_id', 'user-1');
+      expect(mockEq).toHaveBeenCalledWith('organization_id', 'org-1');
+      expect(mockEq).toHaveBeenCalledWith('severity', 'critical');
+      expect(mockEq).toHaveBeenCalledWith('correlation_id', 'req-42');
+    });
+
+    it('returns an empty page instead of throwing when the query fails', async () => {
+      mockLimit.mockResolvedValueOnce({ data: null, error: new Error('boom') });
+      const logger = new AuditLogger();
+      const result = await logger.query({ userId: 'user-1' });
+      expect(result).toEqual({ items: [], nextCursor: null });
+    });
+  });
+});

--- a/packages/api/rest/src/services/audit-export/__tests__/hash-chain.test.ts
+++ b/packages/api/rest/src/services/audit-export/__tests__/hash-chain.test.ts
@@ -39,6 +39,17 @@ describe('buildHashChain', () => {
     const { rootHash: rootB } = buildHashChain([makeEvent({ id: '1', success: false })]);
     expect(rootA).not.toBe(rootB);
   });
+
+  it('covers the enhanced structured fields (severity, correlation_id, organization_id, resource_id)', () => {
+    const base = makeEvent({ id: '1' });
+    const { rootHash: rootA } = buildHashChain([base]);
+    const { rootHash: rootB } = buildHashChain([{ ...base, severity: 'critical' }]);
+    const { rootHash: rootC } = buildHashChain([{ ...base, correlation_id: 'req-123' }]);
+    const { rootHash: rootD } = buildHashChain([{ ...base, organization_id: 'org-1' }]);
+    const { rootHash: rootE } = buildHashChain([{ ...base, resource_id: 'wallet-1' }]);
+
+    expect(new Set([rootA, rootB, rootC, rootD, rootE]).size).toBe(5);
+  });
 });
 
 describe('verifyHashChain', () => {

--- a/packages/api/rest/src/services/audit-export/hash-chain.ts
+++ b/packages/api/rest/src/services/audit-export/hash-chain.ts
@@ -31,11 +31,15 @@ function canonicalize(event: AuditEvent): string {
     id: event.id,
     timestamp: event.timestamp,
     user_id: event.user_id,
+    organization_id: event.organization_id ?? null,
     action: event.action,
     resource: event.resource,
+    resource_id: event.resource_id ?? null,
     ip_address: event.ip_address,
     success: event.success,
     error_code: event.error_code ?? null,
+    severity: event.severity ?? 'info',
+    correlation_id: event.correlation_id ?? null,
     metadata: event.metadata ?? null,
   });
 }

--- a/packages/api/rest/src/services/audit-logger.ts
+++ b/packages/api/rest/src/services/audit-logger.ts
@@ -10,28 +10,50 @@ import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { withQueryLogging } from '../utils/query-metrics';
 import { buildCursorPage, decodeCursor, CursorPageResult } from '../utils/pagination';
 
+export type AuditSeverity = 'info' | 'warning' | 'critical';
+
 export interface AuditEvent {
   id: string;
   timestamp: string; // ISO 8601
   user_id: string | null;
+  /** Organization/team the actor was operating under (Issue #61 team accounts). */
+  organization_id?: string | null;
   action: string;
   resource: string | null;
+  /** Concrete identifier of the affected resource (wallet id, pool address, tx hash, ...). */
+  resource_id?: string | null;
   ip_address: string | null;
   success: boolean;
   error_code?: string;
+  /** Defaults to 'info' when not provided. */
+  severity?: AuditSeverity;
+  /** Groups related events across a single request/operation (e.g. x-request-id). */
+  correlation_id?: string | null;
   metadata?: Record<string, unknown>;
 }
 
 export interface AuditQueryFilters {
   userId?: string;
+  organizationId?: string;
   action?: string;
   resource?: string;
+  severity?: AuditSeverity;
+  correlationId?: string;
   from?: Date;
   to?: Date;
   /** Opaque cursor returned as `nextCursor` from a previous page. */
   cursor?: string;
   /** Page size, capped at 200. Defaults to 50. */
   limit?: number;
+}
+
+export interface AuditLogOptions {
+  /**
+   * When true, the write is awaited and a failure is rethrown to the caller
+   * instead of being swallowed. Use for operations where a lost audit entry
+   * must not go unnoticed. Defaults to false (fire-and-forget).
+   */
+  sync?: boolean;
 }
 
 const DEFAULT_QUERY_LIMIT = 50;
@@ -98,23 +120,34 @@ export class AuditLogger {
     this.supabase = initializeSupabaseClient();
   }
 
-  async log(event: Omit<AuditEvent, 'id' | 'timestamp'>): Promise<void> {
+  async log(event: Omit<AuditEvent, 'id' | 'timestamp'>, options?: AuditLogOptions): Promise<void> {
     try {
       const sanitizedMetadata = sanitizeMetadata(event.metadata);
 
-      await this.supabase.from('audit_logs').insert([
+      const { error } = await this.supabase.from('audit_logs').insert([
         {
           user_id: event.user_id,
+          organization_id: event.organization_id ?? null,
           action: event.action,
           resource: event.resource,
+          resource_id: event.resource_id ?? null,
           ip_address: event.ip_address,
           success: event.success,
           error_code: event.error_code,
+          severity: event.severity ?? 'info',
+          correlation_id: event.correlation_id ?? null,
           metadata: sanitizedMetadata,
         },
       ]);
+
+      if (error) {
+        throw error;
+      }
     } catch (error) {
       console.warn('Failed to write audit log:', error);
+      if (options?.sync) {
+        throw error;
+      }
     }
   }
 
@@ -133,12 +166,24 @@ export class AuditLogger {
         query = query.eq('user_id', filters.userId);
       }
 
+      if (filters.organizationId) {
+        query = query.eq('organization_id', filters.organizationId);
+      }
+
       if (filters.action) {
         query = query.eq('action', filters.action);
       }
 
       if (filters.resource) {
         query = query.eq('resource', filters.resource);
+      }
+
+      if (filters.severity) {
+        query = query.eq('severity', filters.severity);
+      }
+
+      if (filters.correlationId) {
+        query = query.eq('correlation_id', filters.correlationId);
       }
 
       if (filters.from) {

--- a/packages/api/rest/src/tests/submit-tx.test.ts
+++ b/packages/api/rest/src/tests/submit-tx.test.ts
@@ -10,12 +10,16 @@ import request from "supertest";
 // Supabase mock
 // ---------------------------------------------------------------------------
 const mockInsert = jest.fn().mockResolvedValue({ error: null });
+const mockAuditInsert = jest.fn().mockResolvedValue({ error: null });
 const mockSingle = jest.fn();
 const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
 const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
 const mockFrom = jest.fn((table: string) => {
   if (table === "wallet_events") {
     return { insert: mockInsert };
+  }
+  if (table === "audit_logs") {
+    return { insert: mockAuditInsert };
   }
   return { select: mockSelect };
 });
@@ -132,6 +136,7 @@ describe("POST /submit-tx", () => {
     mockSendTransaction.mockResolvedValue({ status: "PENDING", hash: FAKE_HASH });
     mockGetTransaction.mockResolvedValue({ status: "SUCCESS", ledger: 42 });
     mockInsert.mockResolvedValue({ error: null });
+    mockAuditInsert.mockResolvedValue({ error: null });
   });
 
   // ---- Success ----
@@ -162,6 +167,36 @@ describe("POST /submit-tx", () => {
   it("queries smart_wallets table (not invisible_wallets)", async () => {
     await request(buildApp()).post("/submit-tx").send(VALID_BODY).expect(200);
     expect(mockFrom).toHaveBeenCalledWith("smart_wallets");
+  });
+
+  it("writes a successful audit log entry with the wallet owner as actor", async () => {
+    await request(buildApp()).post("/submit-tx").send(VALID_BODY).expect(200);
+
+    expect(mockFrom).toHaveBeenCalledWith("audit_logs");
+    expect(mockAuditInsert).toHaveBeenCalledWith([
+      expect.objectContaining({
+        user_id: "user-1",
+        resource_id: "known-wallet",
+        action: "smart_wallet.transaction_submitted",
+        success: true,
+        severity: "info",
+      }),
+    ]);
+  });
+
+  it("writes a failed audit log entry when Stellar RPC submission fails", async () => {
+    mockSendTransaction.mockRejectedValueOnce(new Error("connection refused"));
+    await request(buildApp()).post("/submit-tx").send(VALID_BODY).expect(502);
+
+    expect(mockAuditInsert).toHaveBeenCalledWith([
+      expect.objectContaining({
+        user_id: "user-1",
+        resource_id: "known-wallet",
+        action: "smart_wallet.transaction_submitted",
+        success: false,
+        severity: "warning",
+      }),
+    ]);
   });
 
   // ---- 400: missing fields ----

--- a/packages/api/rest/src/validators/audit-log-validators.ts
+++ b/packages/api/rest/src/validators/audit-log-validators.ts
@@ -1,0 +1,19 @@
+/**
+ * @fileoverview Joi schemas for the audit log query routes.
+ * @author Galaxy DevKit Team
+ * @since 2026-07-22
+ */
+
+import Joi from 'joi';
+
+export const listAuditLogsQuerySchema = Joi.object({
+  action: Joi.string().optional(),
+  resource: Joi.string().optional(),
+  organizationId: Joi.string().optional(),
+  severity: Joi.string().valid('info', 'warning', 'critical').optional(),
+  correlationId: Joi.string().optional(),
+  from: Joi.date().iso().optional(),
+  to: Joi.date().iso().min(Joi.ref('from')).optional(),
+  cursor: Joi.string().optional(),
+  limit: Joi.number().integer().min(1).max(200).default(50),
+}).unknown(false);

--- a/packages/core/invisible-wallet/src/services/invisible-wallet.service.ts
+++ b/packages/core/invisible-wallet/src/services/invisible-wallet.service.ts
@@ -850,6 +850,9 @@ export class InvisibleWalletService {
     resource?: string | null;
     success: boolean;
     errorCode?: string;
+    /** Defaults to 'info' on success and 'warning' on failure when omitted. */
+    severity?: 'info' | 'warning' | 'critical';
+    correlationId?: string | null;
     metadata?: Record<string, unknown>;
   }): Promise<void> {
     try {
@@ -861,6 +864,8 @@ export class InvisibleWalletService {
           ip_address: null,
           success: params.success,
           error_code: params.errorCode,
+          severity: params.severity ?? (params.success ? 'info' : 'warning'),
+          correlation_id: params.correlationId ?? null,
           metadata: this.sanitizeAuditMetadata(params.metadata),
         },
       ]);

--- a/supabase/migrations/20260722000000_audit_logs_enhancements.sql
+++ b/supabase/migrations/20260722000000_audit_logs_enhancements.sql
@@ -1,0 +1,55 @@
+-- Enhanced structured audit logging (Issue #334)
+-- Adds actor/severity/correlation fields to the structured log format,
+-- makes audit_logs append-only, and provides a retention helper.
+
+alter table audit_logs
+  add column if not exists organization_id text,
+  add column if not exists resource_id     text,
+  add column if not exists severity        text not null default 'info',
+  add column if not exists correlation_id  text;
+
+alter table audit_logs
+  drop constraint if exists audit_logs_severity_check;
+
+alter table audit_logs
+  add constraint audit_logs_severity_check
+  check (severity in ('info', 'warning', 'critical'));
+
+create index if not exists audit_logs_organization_id_idx on audit_logs (organization_id);
+create index if not exists audit_logs_severity_idx on audit_logs (severity);
+create index if not exists audit_logs_correlation_id_idx on audit_logs (correlation_id);
+
+-- Append-only: audit_logs is written by AuditLogger using the service role.
+-- Revoke UPDATE/DELETE so entries can only ever be inserted or read, never
+-- altered or removed through the application's own credentials. Combined
+-- with the export hash-chain (Issue #338), this makes tampering both
+-- structurally prevented (writes) and detectable (exports).
+revoke update, delete on audit_logs from service_role;
+revoke update, delete on audit_logs from authenticated;
+revoke update, delete on audit_logs from anon;
+
+-- Retention: deletes audit_logs entries older than `retention_days`.
+-- Intentionally NOT scheduled from this migration (no pg_cron usage exists
+-- elsewhere in this project) -- invoke from an external scheduler/ops job,
+-- e.g. `select purge_audit_logs(365);`. Runs as the function owner so it
+-- can bypass the append-only revoke above for genuine retention cleanup.
+create or replace function purge_audit_logs(retention_days integer)
+returns bigint
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  deleted_count bigint;
+begin
+  if retention_days is null or retention_days <= 0 then
+    raise exception 'retention_days must be a positive integer';
+  end if;
+
+  delete from audit_logs
+  where "timestamp" < now() - (retention_days || ' days')::interval;
+
+  get diagnostics deleted_count = row_count;
+  return deleted_count;
+end;
+$$;


### PR DESCRIPTION
## Summary
- Extends the Issue #132 audit log schema with `organization_id`, `resource_id`, `severity`, and `correlation_id`, keeping it additive/backward-compatible with the existing `audit_logs` table and the Issue #338 export hash-chain.
- Instruments all DeFi mutations (Blend supply/withdraw/borrow/repay, Soroswap swap, liquidity add/remove) and the smart-wallet `submit-tx` endpoint with audit log entries on both success and failure.
- Adds a filterable `GET /api/v1/audit-logs` query endpoint (action, resource, organization, severity, correlationId, date range, cursor pagination), scoped to the caller's own logs.
- Makes `audit_logs` append-only at the DB level (`REVOKE UPDATE, DELETE`) and adds a `purge_audit_logs(retention_days)` retention helper.
- `AuditLogger.log()` now supports an optional `{ sync: true }` mode that awaits the write and rethrows on failure, in addition to the existing fire-and-forget default.

## Scope notes
- Smart wallet lifecycle coverage is limited to what's actually reachable via REST today (DeFi ops + `submit-tx`). `SessionKeyManager`, `WebAuthNProvider`, and `MultiSigWallet` (core packages) have no signer/session-key REST endpoints yet, so they were intentionally left uninstrumented rather than adding unused hooks.
- Tamper-resistance is handled via DB-level append-only grants; per-row entry signing was intentionally not added, relying on the existing Issue #338 export-time hash-chain instead.
- `organization_id` is modeled and filterable but not yet populated by any call site — no request path currently carries an active-organization context to source it from.

## Test plan
- [x] `packages/api/rest/src/services/__tests__/audit-logger.test.ts` (new): `log()` sync/async, sanitization, `query()` filters
- [x] `packages/api/rest/src/routes/audit-logs/__tests__/audit-logs.routes.test.ts` (new): query route filters/pagination/validation
- [x] `packages/api/rest/src/routes/defi.routes.test.ts`: added assertions that DeFi mutations write audit events (success/failure), fixed a crash from the new `AuditLogger` singleton needing Supabase env vars in tests
- [x] `packages/api/rest/src/tests/submit-tx.test.ts`: added audit_logs insert assertions for success/failure paths
- [x] `packages/api/rest/src/services/audit-export/__tests__/hash-chain.test.ts`: covers the new structured fields in the hash chain

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)