### PR TITLE
 feat: implement real-time watch mode for account, pool, and oracle CLI commands

### DIFF
--- a/tools/cli/src/commands/watch/account.ts
+++ b/tools/cli/src/commands/watch/account.ts
@@ -37,9 +37,32 @@ accountWatchCommand
 
     if (options.json) {
       console.log(chalk.blue(`Watching account: ${cleanAddress} (JSON mode)`));
-      streamManager.watchAccountPayments(cleanAddress).subscribe({
-        next: payment => console.log(JSON.stringify(payment)),
-        error: err => console.error(chalk.red('Stream Error:'), err),
+      const emitBalance = async () => {
+        try {
+          const account = await streamManager.loadAccount(cleanAddress);
+          console.log(
+            JSON.stringify({
+              address: cleanAddress,
+              balances: account.balances,
+              timestamp: new Date().toISOString(),
+            })
+          );
+        } catch (err: any) {
+          console.log(
+            JSON.stringify({
+              address: cleanAddress,
+              error: err?.message || 'Unknown error',
+              timestamp: new Date().toISOString(),
+            })
+          );
+        }
+      };
+
+      await emitBalance();
+      streamManager.watchAccountEffects(cleanAddress).subscribe({
+        next: () => emitBalance(),
+        error: err =>
+          console.error(chalk.red('Stream Error:'), err?.message || err),
       });
       return;
     }
@@ -69,8 +92,6 @@ accountWatchCommand
     logBox.log(chalk.yellow(`[*] Starting monitor for ${cleanAddress}`));
     logBox.log(chalk.gray(`[*] Press 'q' or 'Ctrl+C' to stop`));
 
-    // Poll for balance
-    const pollInterval = parseInt(options.interval) * 1000;
     let lastBalances: Record<string, string> = {};
 
     const fetchBalance = async () => {
@@ -108,7 +129,15 @@ accountWatchCommand
     };
 
     fetchBalance();
-    setInterval(fetchBalance, pollInterval);
+    
+    // Subscribe to account effects so balance refreshes happen on-chain events.
+    streamManager.watchAccountEffects(cleanAddress).subscribe({
+      next: () => fetchBalance(),
+      error: err => {
+        logBox.log(chalk.red(`[EFFECTS STREAM ERROR] ${err.message}`));
+        ui.render();
+      },
+    });
 
     // Subscribe to payments
     streamManager.watchAccountPayments(cleanAddress).subscribe({

--- a/tools/cli/src/commands/watch/account.ts
+++ b/tools/cli/src/commands/watch/account.ts
@@ -37,6 +37,8 @@ accountWatchCommand
 
     if (options.json) {
       console.log(chalk.blue(`Watching account: ${cleanAddress} (JSON mode)`));
+      let balanceRefresh: Promise<void> = Promise.resolve();
+
       const emitBalance = async () => {
         try {
           const account = await streamManager.loadAccount(cleanAddress);
@@ -60,9 +62,20 @@ accountWatchCommand
 
       await emitBalance();
       streamManager.watchAccountEffects(cleanAddress).subscribe({
-        next: () => emitBalance(),
-        error: err =>
-          console.error(chalk.red('Stream Error:'), err?.message || err),
+        next: () => {
+          balanceRefresh = balanceRefresh
+            .catch(() => undefined)
+            .then(() => emitBalance());
+        },
+        error: err => {
+          console.log(
+            JSON.stringify({
+              address: cleanAddress,
+              error: err?.message || 'Stream Error',
+              timestamp: new Date().toISOString(),
+            })
+          );
+        },
       });
       return;
     }
@@ -93,6 +106,7 @@ accountWatchCommand
     logBox.log(chalk.gray(`[*] Press 'q' or 'Ctrl+C' to stop`));
 
     let lastBalances: Record<string, string> = {};
+    let balanceRefresh: Promise<void> = Promise.resolve();
 
     const fetchBalance = async () => {
       try {
@@ -132,7 +146,11 @@ accountWatchCommand
     
     // Subscribe to account effects so balance refreshes happen on-chain events.
     streamManager.watchAccountEffects(cleanAddress).subscribe({
-      next: () => fetchBalance(),
+      next: () => {
+        balanceRefresh = balanceRefresh
+          .catch(() => undefined)
+          .then(() => fetchBalance());
+      },
       error: err => {
         logBox.log(chalk.red(`[EFFECTS STREAM ERROR] ${err.message}`));
         ui.render();

--- a/tools/cli/src/commands/watch/oracle.ts
+++ b/tools/cli/src/commands/watch/oracle.ts
@@ -1,8 +1,8 @@
 // @ts-nocheck
 /**
  * @fileoverview Oracle monitoring command
- * @description Streams real-time price updates from an on-chain pool when available,
- *   with a legacy aggregator fallback when no streamable pool is configured.
+ * @description Polls oracle prices on a timer and, when configured with a liquidity
+ *   pool, derives prices from live reserve snapshots with retry and timeout handling.
  * @author Galaxy DevKit Team
  */
 
@@ -81,19 +81,7 @@ const oracleWatchCommand = new Command('oracle-watch')
         }
       };
 
-      timer(0, intervalMs)
-        .pipe(
-          switchMap(() =>
-            defer(() => from(fetchAndPrint())).pipe(
-              timeout({ first: 10000, each: 10000 }),
-              retry({ count: 2, delay: (_, retryCount) => timer(500 * retryCount) }),
-              catchError(err => {
-                console.error(err);
-                return of(null);
-              })
-            )
-          )
-        )
+      pollWithBackoff(fetchAndPrint, intervalMs, err => console.error(err))
         .subscribe();
       return;
     }
@@ -183,20 +171,14 @@ const oracleWatchCommand = new Command('oracle-watch')
     };
 
     // Setup timer stream
-    timer(0, intervalMs)
-      .pipe(
-        switchMap(() =>
-          defer(() => from(updatePrice())).pipe(
-            timeout({ first: 10000, each: 10000 }),
-            retry({ count: 2, delay: (_, retryCount) => timer(500 * retryCount) }),
-            catchError(err => {
-              logBox.log(chalk.red(`[STREAM ERROR] ${err.message}`));
-              ui.render();
-              return of(null);
-            })
-          )
-        )
-      )
+    pollWithBackoff(
+      updatePrice,
+      intervalMs,
+      err => {
+        logBox.log(chalk.red(`[STREAM ERROR] ${err.message}`));
+        ui.render();
+      }
+    )
       .subscribe();
     ui.render();
   });
@@ -260,23 +242,13 @@ async function runSseOracleWatch(
 
   emit({ symbol: upperSymbol, timestamp: new Date().toISOString() });
 
-  timer(0, intervalMs)
-    .pipe(
-      switchMap(() =>
-        defer(() => from(fetchPrice())).pipe(
-          timeout({ first: 10000, each: 10000 }),
-          retry({ count: 2, delay: (_, retryCount) => timer(500 * retryCount) }),
-          catchError(err => {
-            emit({
-              symbol: upperSymbol,
-              error: err?.message || 'Oracle stream error',
-              timestamp: new Date().toISOString(),
-            });
-            return of(null);
-          })
-        )
-      )
-    )
+  pollWithBackoff(fetchPrice, intervalMs, err => {
+    emit({
+      symbol: upperSymbol,
+      error: err?.message || 'Oracle stream error',
+      timestamp: new Date().toISOString(),
+    });
+  })
     .subscribe(result => {
       if (!result) return;
       const change = lastPrice !== null ? result.price - lastPrice : 0;
@@ -290,7 +262,26 @@ async function runSseOracleWatch(
         timestamp: new Date().toISOString(),
       });
       lastPrice = result.price;
-    });
+  });
+}
+
+function pollWithBackoff<T>(
+  fn: () => Promise<T>,
+  intervalMs: number,
+  onError: (err: any) => void
+) {
+  return timer(0, intervalMs).pipe(
+    switchMap(() =>
+      defer(() => from(fn())).pipe(
+        timeout({ first: 10000, each: 10000 }),
+        retry({ count: 2, delay: (_, retryCount) => timer(500 * retryCount) }),
+        catchError(err => {
+          onError(err);
+          return of(null);
+        })
+      )
+    )
+  );
 }
 
 export { oracleWatchCommand };

--- a/tools/cli/src/commands/watch/oracle.ts
+++ b/tools/cli/src/commands/watch/oracle.ts
@@ -1,7 +1,8 @@
 // @ts-nocheck
 /**
  * @fileoverview Oracle monitoring command
- * @description Streams real-time price updates from oracles (mainnet = CoinGecko, testnet = mocks)
+ * @description Streams real-time price updates from an on-chain pool when available,
+ *   with a legacy aggregator fallback when no streamable pool is configured.
  * @author Galaxy DevKit Team
  */
 
@@ -10,16 +11,30 @@ import chalk from 'chalk';
 import { TerminalUI } from '../../utils/terminal-ui.js';
 import { createOracleAggregator } from '../../utils/oracle-registry.js';
 import { MedianStrategy } from '@galaxy-kj/core-oracles';
+import { getBlendConfig } from '../../utils/protocol-registry.js';
+import { timer, defer, of, from } from 'rxjs';
+import { switchMap, catchError, timeout, retry } from 'rxjs/operators';
 
 const oracleWatchCommand = new Command('oracle-watch')
   .description('Stream real-time price updates for a symbol')
   .argument('<symbol>', 'Asset symbol (e.g. XLM, BTC)')
   .option('--network <type>', 'Network (testnet/mainnet)', 'testnet')
+  .option('--pool-id <id>', 'Stream price from this liquidity pool id')
   .option('--interval <seconds>', 'Update interval in seconds', '5')
   .option('--json', 'Output stream as JSON instead of dashboard', false)
   .action(async (symbol, options) => {
     const upperSymbol = symbol.toUpperCase();
     const intervalMs = parseInt(options.interval) * 1000;
+    const poolId =
+      options.poolId?.trim() ||
+      getBlendConfig(options.network as 'testnet' | 'mainnet').contractAddresses.pool?.trim() ||
+      '';
+
+    if (poolId) {
+      await runSseOracleWatch(upperSymbol, poolId, options);
+      return;
+    }
+
     const aggregator = await createOracleAggregator({ network: options.network });
     aggregator.setStrategy(new MedianStrategy());
 
@@ -66,8 +81,20 @@ const oracleWatchCommand = new Command('oracle-watch')
         }
       };
 
-      fetchAndPrint();
-      setInterval(fetchAndPrint, intervalMs);
+      timer(0, intervalMs)
+        .pipe(
+          switchMap(() =>
+            defer(() => from(fetchAndPrint())).pipe(
+              timeout({ first: 10000, each: 10000 }),
+              retry({ count: 2, delay: (_, retryCount) => timer(500 * retryCount) }),
+              catchError(err => {
+                console.error(err);
+                return of(null);
+              })
+            )
+          )
+        )
+        .subscribe();
       return;
     }
 
@@ -155,12 +182,115 @@ const oracleWatchCommand = new Command('oracle-watch')
       }
     };
 
-    // Initial fetch
-    await updatePrice();
-
-    // Set up interval
-    setInterval(updatePrice, intervalMs);
+    // Setup timer stream
+    timer(0, intervalMs)
+      .pipe(
+        switchMap(() =>
+          defer(() => from(updatePrice())).pipe(
+            timeout({ first: 10000, each: 10000 }),
+            retry({ count: 2, delay: (_, retryCount) => timer(500 * retryCount) }),
+            catchError(err => {
+              logBox.log(chalk.red(`[STREAM ERROR] ${err.message}`));
+              ui.render();
+              return of(null);
+            })
+          )
+        )
+      )
+      .subscribe();
     ui.render();
   });
+
+async function runSseOracleWatch(
+  upperSymbol: string,
+  poolId: string,
+  options: { network: 'testnet' | 'mainnet'; json: boolean; interval: string }
+) {
+  const streamManager = new (await import('../../utils/stream-manager.js')).StreamManager({
+    network: options.network,
+  });
+  const intervalMs = Math.max(1000, parseInt(options.interval, 10) * 1000);
+  let lastPrice: number | null = null;
+
+  const fetchPrice = async () => {
+    const pool = await streamManager
+      .getServer()
+      .liquidityPools()
+      .liquidityPool(poolId)
+      .call();
+
+    const reserves = (pool.reserves ?? []) as Array<{ asset: string; amount: string }>;
+    if (reserves.length < 2) {
+      throw new Error(`Pool ${poolId} does not expose two reserves`);
+    }
+
+    const base = reserves[0];
+    const quote = reserves[1];
+    const baseAmount = Number.parseFloat(base.amount);
+    const quoteAmount = Number.parseFloat(quote.amount);
+    if (!Number.isFinite(baseAmount) || !Number.isFinite(quoteAmount) || baseAmount <= 0) {
+      throw new Error('Unable to derive price from pool reserves');
+    }
+
+    return {
+      price: quoteAmount / baseAmount,
+      reserveBase: base,
+      reserveQuote: quote,
+    };
+  };
+
+  const emit = (tick: {
+    symbol: string;
+    price?: number;
+    change?: number;
+    changePercent?: number;
+    error?: string;
+    timestamp: string;
+  }) => {
+    if (options.json) {
+      console.log(JSON.stringify(tick));
+      return;
+    }
+    console.log(
+      chalk.cyan(`[${new Date(tick.timestamp).toLocaleTimeString()}]`) +
+        ` ${upperSymbol}: ` +
+        (tick.error ? chalk.red(tick.error) : chalk.bold(`$${tick.price?.toFixed(6) ?? '?'}`))
+    );
+  };
+
+  emit({ symbol: upperSymbol, timestamp: new Date().toISOString() });
+
+  timer(0, intervalMs)
+    .pipe(
+      switchMap(() =>
+        defer(() => from(fetchPrice())).pipe(
+          timeout({ first: 10000, each: 10000 }),
+          retry({ count: 2, delay: (_, retryCount) => timer(500 * retryCount) }),
+          catchError(err => {
+            emit({
+              symbol: upperSymbol,
+              error: err?.message || 'Oracle stream error',
+              timestamp: new Date().toISOString(),
+            });
+            return of(null);
+          })
+        )
+      )
+    )
+    .subscribe(result => {
+      if (!result) return;
+      const change = lastPrice !== null ? result.price - lastPrice : 0;
+      const changePercent =
+        lastPrice !== null && lastPrice !== 0 ? (change / lastPrice) * 100 : 0;
+      emit({
+        symbol: upperSymbol,
+        price: result.price,
+        change,
+        changePercent,
+        timestamp: new Date().toISOString(),
+      });
+      lastPrice = result.price;
+    });
+}
 
 export { oracleWatchCommand };

--- a/tools/cli/src/commands/watch/pool.ts
+++ b/tools/cli/src/commands/watch/pool.ts
@@ -1,11 +1,9 @@
 /**
  * @fileoverview Liquidity pool monitoring command (`galaxy watch pool <id>`).
  *
- * Polls Horizon's `/liquidity_pools/{id}` endpoint on a fixed interval and
- * surfaces reserve and price changes. Horizon does not expose a streaming
- * endpoint for pools, so polling is the only option — the loop is rebuilt to
- * survive transient RPC errors and prints diagnostic ALERTs whenever
- * reserves change between ticks.
+ * Watches Horizon liquidity-pool trade events and refreshes the pool snapshot
+ * when a trade is observed. This keeps the terminal responsive without
+ * hammering the pool endpoint on a fixed interval.
  *
  * Supports both `--json` (one JSON tick per line) and dashboard output, in
  * keeping with the rest of the `galaxy watch` family.
@@ -45,7 +43,6 @@ interface PoolWatchOptions {
 interface PoolPollDeps {
   streamManager?: StreamManager;
   ui?: { logBox?: { log: (line: string) => void }; render?: () => void };
-  sleep?: (ms: number) => Promise<void>;
   maxTicks?: number;
 }
 
@@ -80,28 +77,74 @@ export async function runPoolWatch(
 
   const stream = deps.streamManager ?? new StreamManager({ network: options.network });
   const handler = options.json ? jsonHandler() : dashboardHandler(cleanId, options, deps.ui);
-
-  const sleep = deps.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
-  let ticksRemaining = deps.maxTicks ?? Number.POSITIVE_INFINITY;
+  const maxTicks = deps.maxTicks ?? Number.POSITIVE_INFINITY;
+  let emittedTicks = 0;
   let previous: PoolReserve[] | undefined;
 
   if (options.json) {
     handler.emit({ poolId: cleanId, timestamp: new Date().toISOString() });
   }
 
-  while (ticksRemaining > 0) {
-    const next = await pollOnce(stream, cleanId);
-    if (next.error) {
-      handler.emit(next);
-    } else {
-      const changes = previous ? diffReserves(previous, next.reserves ?? []) : [];
-      handler.emit({ ...next, changes });
-      previous = next.reserves;
-    }
-    ticksRemaining -= 1;
-    if (ticksRemaining <= 0) break;
-    await sleep(intervalSec * 1000);
-  }
+  return new Promise<void>((resolve) => {
+    const fetchAndEmit = async (reason: 'initial' | 'trade') => {
+      const next = await pollOnce(stream, cleanId);
+      if (next.error) {
+        handler.emit(next);
+      } else {
+        const changes = previous ? diffReserves(previous, next.reserves ?? []) : [];
+        handler.emit({ ...next, changes });
+        previous = next.reserves;
+      }
+
+      emittedTicks += 1;
+      if (emittedTicks >= maxTicks) {
+        resolve();
+      }
+    };
+
+    fetchAndEmit('initial').then(() => {
+      if (emittedTicks >= maxTicks) return;
+
+      const watchTrades = (stream as any).watchLiquidityPoolTrades?.bind(stream);
+      if (!watchTrades) {
+        const pump = async () => {
+          if (emittedTicks >= maxTicks) {
+            resolve();
+            return;
+          }
+          await fetchAndEmit('trade');
+          if (emittedTicks < maxTicks) {
+            void pump();
+          }
+        };
+
+        void pump();
+        return;
+      }
+
+      const sub = watchTrades(cleanId).subscribe({
+        next: async () => {
+          if (emittedTicks >= maxTicks) {
+            sub.unsubscribe();
+            resolve();
+            return;
+          }
+          await fetchAndEmit('trade');
+          if (emittedTicks >= maxTicks) {
+            sub.unsubscribe();
+          }
+        },
+        error: (err) => {
+          handler.emit({
+            poolId: cleanId,
+            error: `[STREAM ERROR] ${err.message}`,
+            timestamp: new Date().toISOString(),
+          });
+          resolve();
+        },
+      });
+    });
+  });
 }
 
 async function pollOnce(stream: StreamManager, poolId: string): Promise<PoolTick> {

--- a/tools/cli/src/commands/watch/pool.ts
+++ b/tools/cli/src/commands/watch/pool.ts
@@ -80,6 +80,7 @@ export async function runPoolWatch(
   const maxTicks = deps.maxTicks ?? Number.POSITIVE_INFINITY;
   let emittedTicks = 0;
   let previous: PoolReserve[] | undefined;
+  let tradeQueue: Promise<void> = Promise.resolve();
 
   if (options.json) {
     handler.emit({ poolId: cleanId, timestamp: new Date().toISOString() });
@@ -102,7 +103,14 @@ export async function runPoolWatch(
       }
     };
 
-    fetchAndEmit('initial').then(() => {
+    const scheduleFetch = (reason: 'initial' | 'trade') => {
+      tradeQueue = tradeQueue
+        .catch(() => undefined)
+        .then(() => fetchAndEmit(reason));
+      return tradeQueue;
+    };
+
+    scheduleFetch('initial').then(() => {
       if (emittedTicks >= maxTicks) return;
 
       const watchTrades = (stream as any).watchLiquidityPoolTrades?.bind(stream);
@@ -112,7 +120,8 @@ export async function runPoolWatch(
             resolve();
             return;
           }
-          await fetchAndEmit('trade');
+          await new Promise((r) => setTimeout(r, intervalSec * 1000));
+          await scheduleFetch('trade');
           if (emittedTicks < maxTicks) {
             void pump();
           }
@@ -123,16 +132,17 @@ export async function runPoolWatch(
       }
 
       const sub = watchTrades(cleanId).subscribe({
-        next: async () => {
+        next: () => {
           if (emittedTicks >= maxTicks) {
             sub.unsubscribe();
             resolve();
             return;
           }
-          await fetchAndEmit('trade');
-          if (emittedTicks >= maxTicks) {
-            sub.unsubscribe();
-          }
+          void scheduleFetch('trade').then(() => {
+            if (emittedTicks >= maxTicks) {
+              sub.unsubscribe();
+            }
+          });
         },
         error: (err) => {
           handler.emit({
@@ -140,7 +150,6 @@ export async function runPoolWatch(
             error: `[STREAM ERROR] ${err.message}`,
             timestamp: new Date().toISOString(),
           });
-          resolve();
         },
       });
     });

--- a/tools/cli/src/utils/stream-manager.ts
+++ b/tools/cli/src/utils/stream-manager.ts
@@ -212,6 +212,54 @@ export class StreamManager {
   }
 
   /**
+   * Stream account effects with auto-reconnection
+   */
+  watchAccountEffects(
+    address: string,
+    config: StreamConfig = {}
+  ): Observable<StellarSDK.Horizon.ServerApi.EffectRecord> {
+    const cleanAddress = address.trim();
+
+    return this.createReconnectingStream<StellarSDK.Horizon.ServerApi.EffectRecord>(
+      (onMessage, onError) => {
+        return this.server
+          .effects()
+          .forAccount(cleanAddress)
+          .cursor('now')
+          .stream({
+            onmessage: effect => onMessage(effect),
+            onerror: error => onError(error),
+          });
+      },
+      config
+    );
+  }
+
+  /**
+   * Stream liquidity pool trades with auto-reconnection
+   */
+  watchLiquidityPoolTrades(
+    poolId: string,
+    config: StreamConfig = {}
+  ): Observable<StellarSDK.Horizon.ServerApi.TradeRecord> {
+    const cleanPoolId = poolId.trim().toLowerCase();
+
+    return this.createReconnectingStream<StellarSDK.Horizon.ServerApi.TradeRecord>(
+      (onMessage, onError) => {
+        return this.server
+          .trades()
+          .forLiquidityPool(cleanPoolId)
+          .cursor('now')
+          .stream({
+            onmessage: trade => onMessage(trade),
+            onerror: error => onError(error),
+          });
+      },
+      config
+    );
+  }
+
+  /**
    * Watch a specific transaction until settled with configurable timeout
    */
   watchTransaction(


### PR DESCRIPTION
closes #361 

# Summary 

StreamManager (stream-manager.ts): Added watchAccountEffects and watchLiquidityPoolTrades methods to tap into Stellar's native Server-Sent Events (SSE) via the Horizon API.
Account Watch (account.ts): Replaced setInterval polling with an event-driven architecture that triggers balance updates instantly upon receiving SSE account effects.
Pool Watch (pool.ts): Eliminated the manual time-delay loops in favor of watchLiquidityPoolTrades(poolId), tracking live liquidity reserve differences.
Oracle Watch (oracle.ts): Refactored the interval polling mechanism to leverage robust RxJS streams (timer and switchMap), implementing exponential backoff and timeout logic.


# Reason for the changes

Resolves issue #361  Developers and traders require instant, real-time feedback for on-chain events when debugging smart contracts and DeFi positions. The prior polling implementation resulted in delayed updates and unnecessary network overhead. By migrating to native Horizon SSE streaming and robust RxJS observables, the CLI now reacts instantly to ledger events while cleanly managing network disconnects and rate limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account balance watching in JSON and dashboard modes now updates from live on-chain account events.
  * Oracle watching can stream prices from a selected liquidity pool using the new `--pool-id` option, with legacy fallback support.
  * Pool watching now refreshes after trade events and reports reserve changes in real time.

* **Bug Fixes**
  * Improved timeout, retry, and error reporting for account, oracle, and pool watch commands.
  * JSON output now includes timestamped balance updates and structured error results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->