### PR TITLE
feat(oracle): add windowed TWAP ring buffer and off-chain verificatio…

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -98,7 +98,7 @@ gantt
 - [ ] **#36** Create on-chain oracle Soroban contract (Issue #276 🔄)
 - [ ] **#37** Implement off-chain oracle aggregator service (Issue #277 🔄)
 - [ ] **#38** Add price feed integrations (CoinGecko, CMC) (Issue #278 🔄)
-- [ ] **#39** Implement TWAP (Time-Weighted Average Price) (Issue #279 🔄)
+- [x] **#39** Implement TWAP (Time-Weighted Average Price) (Issue #279 ✅)
 - [ ] **#40** Add oracle data validation and anomaly detection (Issue #280 🔄)
 
 ---

--- a/docs/guides/oracle-integration.md
+++ b/docs/guides/oracle-integration.md
@@ -129,27 +129,50 @@ See [Oracle CLI reference](../cli/oracle.md) for the full command reference.
 
 ## Layer 2 — On-chain Soroban oracle
 
-> **Status:** The on-chain Soroban oracle contract is tracked in issue #167. The TypeScript interface described here matches the planned contract surface.
-
-The on-chain oracle stores a price feed on Stellar/Soroban so that other Soroban contracts can read price data directly without an off-chain call.
+The on-chain oracle (`packages/contracts/price-oracle`) stores a bounded price-history ring buffer per asset pair on Stellar/Soroban, so other Soroban contracts — and DeFi integrations that need manipulation-resistant pricing — can read price data and a Time-Weighted Average Price (TWAP) directly without an off-chain call.
 
 ### Contract interface
 
 ```rust
-// Soroban oracle contract (planned — issue #167)
-pub fn set_price(env: Env, asset: Symbol, price: i128, timestamp: u64);
-pub fn get_price(env: Env, asset: Symbol) -> Option<PriceData>;
-pub fn get_prices(env: Env, assets: Vec<Symbol>) -> Vec<Option<PriceData>>;
+// packages/contracts/price-oracle — deployed contract surface
+pub fn initialize(env: &Env, admin: Address);
+pub fn add_pusher(env: &Env, admin: Address, pusher: Address);
+pub fn remove_pusher(env: &Env, admin: Address, pusher: Address);
+
+pub fn push_price(env: &Env, pusher: Address, base: Symbol, quote: Symbol, price: i128);
+
+pub fn get_price(env: &Env, base: Symbol, quote: Symbol) -> PriceEntry;
+pub fn get_price_history(env: &Env, base: Symbol, quote: Symbol) -> Vec<PriceEntry>;
+pub fn get_price_checked(env: &Env, base: Symbol, quote: Symbol, max_age_seconds: u64) -> PriceResult;
+pub fn get_price_strict(env: &Env, base: Symbol, quote: Symbol, max_age_seconds: u64) -> PriceEntry;
+pub fn get_all_prices(env: &Env) -> Map<(Symbol, Symbol), PriceEntry>;
+
+// TWAP — manipulation-resistant pricing
+pub fn get_twap(env: &Env, base: Symbol, quote: Symbol) -> i128;
+pub fn get_twap_window(env: &Env, base: Symbol, quote: Symbol, window_seconds: u64) -> i128;
+pub fn get_twap_5m(env: &Env, base: Symbol, quote: Symbol) -> i128;
+pub fn get_twap_15m(env: &Env, base: Symbol, quote: Symbol) -> i128;
+pub fn get_twap_1h(env: &Env, base: Symbol, quote: Symbol) -> i128;
 ```
 
-### TypeScript SDK usage (planned)
+Prices are scaled by 1,000,000 (six implied decimals). Price history is a fixed-capacity ring buffer (`TWAP_WINDOW_SIZE = 10` observations per pair) — `get_twap_window` computes a time-weighted average over the requested window using whichever of those observations fall inside it, correctly holding the last known price constant across gaps larger than the window.
+
+### TypeScript SDK usage
 
 ```ts
-import { OracleAggregator } from '@galaxy-kj/core-oracles';
+import { OnChainOracleSource, verifyOnChainTwap } from '@galaxy-kj/core-oracles';
 
-// Once the on-chain oracle contract is deployed, the SDK will expose:
-const price = await oracle.getPrice('XLM/USDC');
-// Returns: { price: number, timestamp: Date, confidence: number }
+const source = new OnChainOracleSource(contractId, rpcUrl);
+
+const price = await source.getPrice('XLM/USDC');
+// { price: number, timestamp: Date, source: 'on-chain-oracle', metadata: {...} }
+
+const twap5m = await source.getTwapWindow('XLM/USDC', 300);
+
+// Independently recompute the TWAP from raw history and compare against the
+// contract's own get_twap_window result, to catch a manipulated/diverging value.
+const verification = await verifyOnChainTwap(source, 'XLM/USDC', 300);
+// { matches: boolean, onChainTwap, recomputedTwap, diffBps, history }
 ```
 
 ### Update cadence

--- a/packages/contracts/price-oracle/src/lib.rs
+++ b/packages/contracts/price-oracle/src/lib.rs
@@ -25,8 +25,11 @@
 
 #![no_std]
 
+mod twap;
 mod types;
 pub use types::{OracleError, PriceEntry, PriceResult};
+use twap::{compute_twap, compute_twap_window};
+use types::PriceRingBuffer;
 
 use soroban_sdk::{
     contract, contractimpl, panic_with_error, symbol_short, Address, Env, Map, Symbol, Vec,
@@ -39,7 +42,7 @@ use soroban_sdk::{
 /// Symbol keys for instance storage.
 const KEY_ADMIN: Symbol = symbol_short!("ADMIN");
 const KEY_PUSHERS: Symbol = symbol_short!("PUSHERS");
-/// `Map<(Symbol, Symbol), Vec<PriceEntry>>` — rolling TWAP window per pair.
+/// `Map<(Symbol, Symbol), PriceRingBuffer>` — rolling TWAP window per pair.
 const KEY_PRICES: Symbol = symbol_short!("PRICES");
 
 /// Maximum number of historical observations retained per pair.
@@ -52,6 +55,19 @@ pub const TWAP_WINDOW_SIZE: u32 = 10;
 /// units" — astronomically above any real-world supply limit.  This constant
 /// prevents overflow in the `weighted_sum` computation inside `get_twap`.
 pub const MAX_SAFE_PRICE: i128 = 1_000_000_000_000_000_000_000_000_000_000_i128; // 10^30
+
+/// Convenience window lengths (seconds) for [`PriceOracleContract::get_twap_5m`],
+/// [`PriceOracleContract::get_twap_15m`] and [`PriceOracleContract::get_twap_1h`].
+///
+/// Note: actual window *coverage* is bounded by however much history fits in
+/// `TWAP_WINDOW_SIZE` observations. If the pusher updates more often than
+/// `window_seconds / TWAP_WINDOW_SIZE`, the oldest requested seconds of the
+/// window will simply have no observation to draw from and are excluded from
+/// the weighted average — this is a best-effort window, not a guarantee of
+/// full coverage.
+pub const WINDOW_5M: u64 = 300;
+pub const WINDOW_15M: u64 = 900;
+pub const WINDOW_1H: u64 = 3600;
 
 // ---------------------------------------------------------------------------
 // Event topic symbols  (≤ 9 ASCII chars for symbol_short!)
@@ -87,7 +103,7 @@ impl PriceOracleContract {
         storage.set(&KEY_ADMIN, &admin);
         let empty_pushers: Vec<Address> = Vec::new(env);
         storage.set(&KEY_PUSHERS, &empty_pushers);
-        let empty_prices: Map<(Symbol, Symbol), Vec<PriceEntry>> = Map::new(env);
+        let empty_prices: Map<(Symbol, Symbol), PriceRingBuffer> = Map::new(env);
         storage.set(&KEY_PRICES, &empty_prices);
 
         env.events().publish((EVT_INIT,), admin);
@@ -203,29 +219,24 @@ impl PriceOracleContract {
         }
 
         let storage = env.storage().instance();
-        let mut prices: Map<(Symbol, Symbol), Vec<PriceEntry>> =
+        let mut prices: Map<(Symbol, Symbol), PriceRingBuffer> =
             storage.get(&KEY_PRICES).unwrap_or(Map::new(env));
 
         let key = (base.clone(), quote.clone());
-        let mut history: Vec<PriceEntry> = prices.get(key.clone()).unwrap_or(Vec::new(env));
+        let mut buffer: PriceRingBuffer = prices.get(key.clone()).unwrap_or(PriceRingBuffer::new(env));
 
-        history.push_back(PriceEntry {
-            price,
-            timestamp: env.ledger().timestamp(),
-            pusher: pusher.clone(),
-        });
+        // O(1) amortized: overwrites the oldest slot in place once full,
+        // instead of rebuilding the whole vector on every push past capacity.
+        buffer.push(
+            PriceEntry {
+                price,
+                timestamp: env.ledger().timestamp(),
+                pusher: pusher.clone(),
+            },
+            TWAP_WINDOW_SIZE,
+        );
 
-        // Bound the rolling window by evicting the oldest entry when full
-        if history.len() > TWAP_WINDOW_SIZE {
-            let mut trimmed: Vec<PriceEntry> = Vec::new(env);
-            let start = history.len() - TWAP_WINDOW_SIZE;
-            for i in start..history.len() {
-                trimmed.push_back(history.get(i).unwrap());
-            }
-            history = trimmed;
-        }
-
-        prices.set(key, history);
+        prices.set(key, buffer);
         storage.set(&KEY_PRICES, &prices);
 
         env.events().publish((EVT_PRICE,), (base, quote, price));
@@ -246,13 +257,17 @@ impl PriceOracleContract {
         history.get(history.len() - 1).unwrap()
     }
 
-    /// Return the full rolling history (up to `TWAP_WINDOW_SIZE` entries).
+    /// Return the full rolling history (up to `TWAP_WINDOW_SIZE` entries),
+    /// oldest-to-newest.
     pub fn get_price_history(env: &Env, base: Symbol, quote: Symbol) -> Vec<PriceEntry> {
         let storage = env.storage().instance();
-        let prices: Map<(Symbol, Symbol), Vec<PriceEntry>> =
+        let prices: Map<(Symbol, Symbol), PriceRingBuffer> =
             storage.get(&KEY_PRICES).unwrap_or(Map::new(env));
         let key = (base, quote);
-        prices.get(key).unwrap_or(Vec::new(env))
+        match prices.get(key) {
+            Some(buffer) => buffer.chronological(env, TWAP_WINDOW_SIZE),
+            None => Vec::new(env),
+        }
     }
 
     // =======================================================================
@@ -323,6 +338,47 @@ impl PriceOracleContract {
         compute_twap(&history, now)
     }
 
+    /// Compute the Time-Weighted Average Price over the last `window_seconds`.
+    ///
+    /// Unlike [`get_twap`], this never requires a minimum number of
+    /// observations: a single price inside the window degrades gracefully to
+    /// that price, and a price observed before the window started is treated
+    /// as held constant since `window_start` (correctly handles gaps larger
+    /// than `window_seconds` between updates).
+    ///
+    /// Panics with [`OracleError::PriceNotFound`] only when the pair has no
+    /// price data at all.
+    ///
+    /// Actual coverage is bounded by however many of the last
+    /// `TWAP_WINDOW_SIZE` observations fall inside the window — see the
+    /// [`WINDOW_5M`]/[`WINDOW_15M`]/[`WINDOW_1H`] doc note.
+    pub fn get_twap_window(env: &Env, base: Symbol, quote: Symbol, window_seconds: u64) -> i128 {
+        let history = Self::get_price_history(env, base, quote);
+
+        if history.is_empty() {
+            panic_with_error!(env, OracleError::PriceNotFound);
+        }
+
+        let now = env.ledger().timestamp();
+        let window_start = now.saturating_sub(window_seconds);
+        compute_twap_window(&history, now, window_start)
+    }
+
+    /// TWAP over the last 5 minutes. See [`get_twap_window`](Self::get_twap_window).
+    pub fn get_twap_5m(env: &Env, base: Symbol, quote: Symbol) -> i128 {
+        Self::get_twap_window(env, base, quote, WINDOW_5M)
+    }
+
+    /// TWAP over the last 15 minutes. See [`get_twap_window`](Self::get_twap_window).
+    pub fn get_twap_15m(env: &Env, base: Symbol, quote: Symbol) -> i128 {
+        Self::get_twap_window(env, base, quote, WINDOW_15M)
+    }
+
+    /// TWAP over the last hour. See [`get_twap_window`](Self::get_twap_window).
+    pub fn get_twap_1h(env: &Env, base: Symbol, quote: Symbol) -> i128 {
+        Self::get_twap_window(env, base, quote, WINDOW_1H)
+    }
+
     // =======================================================================
     // Multi-asset helpers
     // =======================================================================
@@ -333,11 +389,12 @@ impl PriceOracleContract {
     /// [`PriceEntry`].  Pairs that have no data are omitted.
     pub fn get_all_prices(env: &Env) -> Map<(Symbol, Symbol), PriceEntry> {
         let storage = env.storage().instance();
-        let prices: Map<(Symbol, Symbol), Vec<PriceEntry>> =
+        let prices: Map<(Symbol, Symbol), PriceRingBuffer> =
             storage.get(&KEY_PRICES).unwrap_or(Map::new(env));
 
         let mut latest: Map<(Symbol, Symbol), PriceEntry> = Map::new(env);
-        for (key, history) in prices.iter() {
+        for (key, buffer) in prices.iter() {
+            let history = buffer.chronological(env, TWAP_WINDOW_SIZE);
             if !history.is_empty() {
                 let last = history.get(history.len() - 1).unwrap();
                 latest.set(key, last);

--- a/packages/contracts/price-oracle/src/test.rs
+++ b/packages/contracts/price-oracle/src/test.rs
@@ -347,6 +347,141 @@ fn test_twap_multiple_observations() {
 }
 
 // ---------------------------------------------------------------------------
+// Ring buffer
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_ring_buffer_wraparound_preserves_chronological_order() {
+    let (env, contract_id, admin, pusher) = setup();
+    let client = init_client(&env, &contract_id, &admin);
+    client.add_pusher(&admin, &pusher);
+    let base = Symbol::new(&env, "XLM");
+    let quote = Symbol::new(&env, "USDC");
+
+    // Push 15 observations — 5 more than TWAP_WINDOW_SIZE (10), forcing the
+    // ring buffer to wrap around and overwrite the oldest 5 slots in place.
+    for i in 0..15u32 {
+        env.ledger().with_mut(|li| li.timestamp += 10);
+        client.push_price(&pusher, &base, &quote, &(1_000_000 + i as i128));
+    }
+
+    let history = client.get_price_history(&base, &quote);
+    assert_eq!(history.len(), 10);
+
+    // Surviving entries must still read oldest-to-newest (pushes 5..14).
+    for (idx, i) in (5u32..15u32).enumerate() {
+        assert_eq!(history.get(idx as u32).unwrap().price, 1_000_000 + i as i128);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Windowed TWAP (get_twap_window / get_twap_5m / get_twap_15m / get_twap_1h)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic]
+fn test_twap_window_empty_buffer_panics() {
+    let (env, contract_id, admin, _) = setup();
+    let client = init_client(&env, &contract_id, &admin);
+    let base = Symbol::new(&env, "XLM");
+    let quote = Symbol::new(&env, "USDC");
+    client.get_twap_window(&base, &quote, &300_u64);
+}
+
+#[test]
+fn test_twap_window_single_data_point_returns_price_without_panic() {
+    let (env, contract_id, admin, pusher) = setup();
+    let client = init_client(&env, &contract_id, &admin);
+    client.add_pusher(&admin, &pusher);
+    let base = Symbol::new(&env, "XLM");
+    let quote = Symbol::new(&env, "USDC");
+
+    client.push_price(&pusher, &base, &quote, &1_500_000);
+
+    // A single observation is insufficient for `get_twap` (which panics),
+    // but `get_twap_window` must degrade gracefully to that one price.
+    let twap = client.get_twap_window(&base, &quote, &300_u64);
+    assert_eq!(twap, 1_500_000);
+}
+
+#[test]
+fn test_twap_window_large_gap_holds_last_price_constant() {
+    let (env, contract_id, admin, pusher) = setup();
+    let client = init_client(&env, &contract_id, &admin);
+    client.add_pusher(&admin, &pusher);
+    let base = Symbol::new(&env, "XLM");
+    let quote = Symbol::new(&env, "USDC");
+
+    client.push_price(&pusher, &base, &quote, &1_000_000);
+    // No further updates for far longer than the requested window.
+    env.ledger().with_mut(|li| li.timestamp += 10_000);
+
+    let twap = client.get_twap_window(&base, &quote, &300_u64); // 5m window
+    assert_eq!(twap, 1_000_000);
+}
+
+#[test]
+fn test_twap_window_covering_full_history_matches_get_twap() {
+    let (env, contract_id, admin, pusher) = setup();
+    let client = init_client(&env, &contract_id, &admin);
+    client.add_pusher(&admin, &pusher);
+    let base = Symbol::new(&env, "XLM");
+    let quote = Symbol::new(&env, "USDC");
+
+    client.push_price(&pusher, &base, &quote, &1_000_000);
+    env.ledger().with_mut(|li| li.timestamp += 60);
+    client.push_price(&pusher, &base, &quote, &1_200_000);
+
+    let full = client.get_twap(&base, &quote);
+    let windowed = client.get_twap_window(&base, &quote, &1_000_u64); // window > total history
+    assert_eq!(full, windowed);
+}
+
+#[test]
+fn test_twap_window_partial_excludes_data_before_window_start() {
+    let (env, contract_id, admin, pusher) = setup();
+    let client = init_client(&env, &contract_id, &admin);
+    client.add_pusher(&admin, &pusher);
+    let base = Symbol::new(&env, "XLM");
+    let quote = Symbol::new(&env, "USDC");
+
+    client.push_price(&pusher, &base, &quote, &1_000_000); // t=0
+    env.ledger().with_mut(|li| li.timestamp += 500);
+    client.push_price(&pusher, &base, &quote, &2_000_000); // t=500
+    env.ledger().with_mut(|li| li.timestamp += 100); // now = 600
+
+    // 50s window covers only [550, 600] — entirely after the price changed.
+    let twap = client.get_twap_window(&base, &quote, &50_u64);
+    assert_eq!(twap, 2_000_000);
+}
+
+#[test]
+fn test_twap_named_windows_delegate_to_get_twap_window() {
+    let (env, contract_id, admin, pusher) = setup();
+    let client = init_client(&env, &contract_id, &admin);
+    client.add_pusher(&admin, &pusher);
+    let base = Symbol::new(&env, "XLM");
+    let quote = Symbol::new(&env, "USDC");
+
+    client.push_price(&pusher, &base, &quote, &1_000_000);
+    env.ledger().with_mut(|li| li.timestamp += 60);
+    client.push_price(&pusher, &base, &quote, &1_200_000);
+
+    assert_eq!(
+        client.get_twap_5m(&base, &quote),
+        client.get_twap_window(&base, &quote, &300_u64)
+    );
+    assert_eq!(
+        client.get_twap_15m(&base, &quote),
+        client.get_twap_window(&base, &quote, &900_u64)
+    );
+    assert_eq!(
+        client.get_twap_1h(&base, &quote),
+        client.get_twap_window(&base, &quote, &3600_u64)
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Staleness checks
 // ---------------------------------------------------------------------------
 

--- a/packages/contracts/price-oracle/src/twap.rs
+++ b/packages/contracts/price-oracle/src/twap.rs
@@ -1,12 +1,25 @@
-use soroban_sdk::{Env, Vec};
 use crate::types::PriceEntry;
+use soroban_sdk::Vec;
 
-/// Compute the time-weighted average price for a rolling price history.
+/// Compute the time-weighted average price over `[window_start, now]`.
 ///
 /// TWAP = Σ(price_i × Δt_i) / Σ(Δt_i)
-/// where Δt_i is the time between the current entry and the next one, or
-/// the current ledger timestamp for the last entry.
-pub fn compute_twap(history: &Vec<PriceEntry>, now: u64) -> i128 {
+///
+/// For each entry, Δt_i is the overlap between its active interval
+/// (`[entry.timestamp, next_entry.timestamp_or_now]`) and the requested
+/// window — this correctly "carries forward" a stale price across the
+/// entire window when the observation predates `window_start` (handles
+/// large gaps between updates), and naturally excludes any interval before
+/// `window_start`.
+///
+/// Passing `window_start = 0` computes the TWAP over the *entire* stored
+/// history, which is what [`compute_twap`] does.
+///
+/// # Panics
+/// None directly, but assumes `history` is non-empty — callers must check
+/// that first (see [`crate::OracleError::PriceNotFound`] /
+/// [`crate::OracleError::InsufficientHistory`]).
+pub fn compute_twap_window(history: &Vec<PriceEntry>, now: u64, window_start: u64) -> i128 {
     let mut weighted_sum: i128 = 0;
     let mut total_time: i128 = 0;
 
@@ -17,18 +30,43 @@ pub fn compute_twap(history: &Vec<PriceEntry>, now: u64) -> i128 {
         } else {
             now
         };
-        let duration = end_time.saturating_sub(entry.timestamp) as i128;
+
+        let segment_start = entry.timestamp.max(window_start);
+        let segment_end = end_time.min(now);
+        let duration = segment_end.saturating_sub(segment_start) as i128;
+
         weighted_sum += entry.price * duration;
         total_time += duration;
     }
 
     if total_time == 0 {
+        // Degenerate case: no observation carried positive weight inside the
+        // window (all timestamps identical, or a single observation exactly
+        // at `now`). Fall back to the arithmetic mean of whichever
+        // observations actually fall within `[window_start, now]` — with
+        // `window_start = 0` this is every entry, matching the old
+        // full-history behaviour. If none fall inside (a window narrower
+        // than the age of the only available observation), fall back to the
+        // most recent observation so the call still degrades gracefully
+        // instead of panicking.
         let mut sum: i128 = 0;
+        let mut count: i128 = 0;
         for entry in history.iter() {
-            sum += entry.price;
+            if entry.timestamp >= window_start && entry.timestamp <= now {
+                sum += entry.price;
+                count += 1;
+            }
         }
-        return sum / history.len() as i128;
+        if count > 0 {
+            return sum / count;
+        }
+        return history.get(history.len() - 1).unwrap().price;
     }
 
     weighted_sum / total_time
+}
+
+/// Compute the TWAP over the entire stored history (no window bound).
+pub fn compute_twap(history: &Vec<PriceEntry>, now: u64) -> i128 {
+    compute_twap_window(history, now, 0)
 }

--- a/packages/contracts/price-oracle/src/types.rs
+++ b/packages/contracts/price-oracle/src/types.rs
@@ -2,7 +2,7 @@
 //!
 //! All SDK-annotated items live here so that `lib.rs` can stay focused on logic.
 
-use soroban_sdk::{contracterror, contracttype, Address};
+use soroban_sdk::{contracterror, contracttype, Address, Env, Vec};
 
 // ---------------------------------------------------------------------------
 // Error codes
@@ -74,4 +74,71 @@ pub struct PriceResult {
     pub age_seconds: u64,
     /// `true` when `age_seconds` exceeds the requested `max_age` threshold.
     pub is_stale: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Ring buffer
+// ---------------------------------------------------------------------------
+
+/// Fixed-capacity circular buffer of [`PriceEntry`] observations for one pair.
+///
+/// Unlike a plain `Vec` that gets rebuilt (read + copy + write of every
+/// element) each time it overflows, this buffer overwrites the oldest slot
+/// in place once `count` reaches capacity — writes become O(1) instead of
+/// O(capacity). Chronological ordering is only reconstructed on read via
+/// [`PriceRingBuffer::chronological`], which is the cheaper place to pay
+/// that cost since reads don't consume write-fee budget.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PriceRingBuffer {
+    /// Backing storage. Grows via `push_back` until it reaches capacity,
+    /// after which entries are overwritten in place by index.
+    pub entries: Vec<PriceEntry>,
+    /// Index of the next slot to overwrite once the buffer is full.
+    /// Meaningless while `count < entries.len()`'s capacity.
+    pub head: u32,
+    /// Number of valid entries currently stored (`<= capacity`).
+    pub count: u32,
+}
+
+impl PriceRingBuffer {
+    /// Create an empty buffer.
+    pub fn new(env: &Env) -> Self {
+        PriceRingBuffer {
+            entries: Vec::new(env),
+            head: 0,
+            count: 0,
+        }
+    }
+
+    /// Push a new entry, evicting the oldest one in place once `capacity`
+    /// is reached.
+    pub fn push(&mut self, entry: PriceEntry, capacity: u32) {
+        if self.count < capacity {
+            self.entries.push_back(entry);
+            self.count += 1;
+            self.head = self.count % capacity;
+        } else {
+            self.entries.set(self.head, entry);
+            self.head = (self.head + 1) % capacity;
+        }
+    }
+
+    /// Return all stored entries ordered oldest-to-newest.
+    ///
+    /// `capacity` must be the same value passed to [`PriceRingBuffer::push`]
+    /// (i.e. `TWAP_WINDOW_SIZE`) — it cannot be inferred from `entries.len()`
+    /// alone, since that also equals `count` while the buffer is still filling.
+    pub fn chronological(&self, env: &Env, capacity: u32) -> Vec<PriceEntry> {
+        if self.count < capacity {
+            // Never wrapped yet — insertion order is already chronological.
+            return self.entries.clone();
+        }
+        let mut ordered: Vec<PriceEntry> = Vec::new(env);
+        for i in 0..capacity {
+            let idx = (self.head + i) % capacity;
+            ordered.push_back(self.entries.get(idx).unwrap());
+        }
+        ordered
+    }
 }

--- a/packages/core/oracles/__tests__/sources/on-chain-oracle-source.test.ts
+++ b/packages/core/oracles/__tests__/sources/on-chain-oracle-source.test.ts
@@ -145,6 +145,85 @@ describe('OnChainOracleSource', () => {
     });
   });
 
+  // ── getPriceHistory ────────────────────────────────────────────────────────
+
+  describe('getPriceHistory', () => {
+    it('decodes the raw price history oldest-to-newest', async () => {
+      mockSimulateTransaction.mockResolvedValueOnce({
+        result: { retval: {} },
+      });
+      mockScValToNative.mockReturnValueOnce([
+        { price: 1000000n, timestamp: 1716767000n, pusher: 'GAAAAAA' },
+        { price: 1250000n, timestamp: 1716768000n, pusher: 'GBBBBBB' },
+      ]);
+
+      const history = await source.getPriceHistory('XLM');
+
+      expect(history).toHaveLength(2);
+      expect(history[0].price).toBe(1.0);
+      expect(history[0].timestamp).toEqual(new Date(1716767000 * 1000));
+      expect(history[0].pusher).toBe('GAAAAAA');
+      expect(history[1].price).toBe(1.25);
+    });
+
+    it('throws if scValToNative does not return an array', async () => {
+      mockSimulateTransaction.mockResolvedValueOnce({
+        result: { retval: {} },
+      });
+      mockIsSimulationError.mockReturnValueOnce(false);
+      mockScValToNative.mockReturnValueOnce(null);
+
+      await expect(source.getPriceHistory('XLM')).rejects.toThrow(
+        'Failed to decode price history'
+      );
+    });
+
+    it('throws if simulation returns an error', async () => {
+      mockSimulateTransaction.mockResolvedValueOnce({
+        error: 'Contract panicked: PriceNotFound',
+      });
+      mockIsSimulationError.mockReturnValueOnce(true);
+
+      await expect(source.getPriceHistory('XLM')).rejects.toThrow(
+        'Soroban RPC simulation failed'
+      );
+    });
+  });
+
+  // ── getTwapWindow ──────────────────────────────────────────────────────────
+
+  describe('getTwapWindow', () => {
+    it('decodes the on-chain windowed TWAP', async () => {
+      mockSimulateTransaction.mockResolvedValueOnce({
+        result: { retval: {} },
+      });
+      mockScValToNative.mockReturnValueOnce(1250000n); // 1.25
+
+      const twap = await source.getTwapWindow('XLM', 300);
+
+      expect(twap).toBe(1.25);
+    });
+
+    it('throws if scValToNative does not return a bigint', async () => {
+      mockSimulateTransaction.mockResolvedValueOnce({
+        result: { retval: {} },
+      });
+      mockIsSimulationError.mockReturnValueOnce(false);
+      mockScValToNative.mockReturnValueOnce({ not: 'a bigint' });
+
+      await expect(source.getTwapWindow('XLM', 300)).rejects.toThrow('Failed to decode TWAP');
+    });
+
+    it('throws if simulation returns no result', async () => {
+      mockSimulateTransaction.mockResolvedValueOnce({});
+      mockIsSimulationError.mockReturnValueOnce(false);
+
+      await expect(source.getTwapWindow('XLM', 300)).rejects.toThrow(
+        'Invalid simulation response'
+      );
+    });
+  });
+
   // ── getPrices ──────────────────────────────────────────────────────────────
 
   describe('getPrices', () => {

--- a/packages/core/oracles/__tests__/verification/twap-math.test.ts
+++ b/packages/core/oracles/__tests__/verification/twap-math.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @fileoverview twap-math tests
+ * @description Mirrors the edge cases covered on-chain in
+ *   packages/contracts/price-oracle/src/test.rs (empty buffer, single data
+ *   point, large gaps, partial windows) so both implementations agree.
+ */
+
+import { computeTwapWindow, type TwapObservation } from '../../src/verification/twap-math.js';
+
+describe('computeTwapWindow', () => {
+  it('throws on an empty history', () => {
+    expect(() => computeTwapWindow([], 1000, 0)).toThrow('empty price history');
+  });
+
+  it('degrades to the single price when only one observation is in the window', () => {
+    const history: TwapObservation[] = [{ price: 1.5, timestamp: 1000 }];
+    const twap = computeTwapWindow(history, 1000, 700); // window [700, 1000]
+    expect(twap).toBe(1.5);
+  });
+
+  it('holds the last known price constant across a gap larger than the window', () => {
+    const history: TwapObservation[] = [{ price: 1.0, timestamp: 0 }];
+    const nowMs = 10_000;
+    const windowMs = 300; // window [9700, 10000], far after the only observation
+    const twap = computeTwapWindow(history, nowMs, nowMs - windowMs);
+    expect(twap).toBe(1.0);
+  });
+
+  it('matches a plain average when window covers the full history with identical timestamps', () => {
+    const history: TwapObservation[] = [
+      { price: 1.0, timestamp: 500 },
+      { price: 2.0, timestamp: 500 },
+    ];
+    const twap = computeTwapWindow(history, 500, 0);
+    expect(twap).toBe(1.5);
+  });
+
+  it('excludes data before windowStart', () => {
+    const history: TwapObservation[] = [
+      { price: 1.0, timestamp: 0 },
+      { price: 2.0, timestamp: 500 },
+    ];
+    const nowMs = 600;
+    const windowStartMs = 550; // [550, 600] — entirely after the price changed to 2.0
+    const twap = computeTwapWindow(history, nowMs, windowStartMs);
+    expect(twap).toBe(2.0);
+  });
+
+  it('time-weights a partial-window overlap correctly', () => {
+    const history: TwapObservation[] = [
+      { price: 1.0, timestamp: 0 },
+      { price: 2.0, timestamp: 500 },
+    ];
+    const nowMs = 500;
+    const windowStartMs = 400; // [400, 500]: 100ms of price 1.0, 0ms of price 2.0
+    const twap = computeTwapWindow(history, nowMs, windowStartMs);
+    expect(twap).toBe(1.0);
+  });
+});

--- a/packages/core/oracles/__tests__/verification/twap-verifier.test.ts
+++ b/packages/core/oracles/__tests__/verification/twap-verifier.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @fileoverview twap-verifier tests
+ */
+
+import { verifyOnChainTwap } from '../../src/verification/twap-verifier.js';
+import type { OnChainOracleSource } from '../../src/sources/real/OnChainOracleSource.js';
+
+const NOW_MS = 1_700_000_000_000;
+
+function mockSource(
+  history: { price: number; timestamp: Date; pusher: string }[],
+  onChainTwap: number
+): OnChainOracleSource {
+  return {
+    getPriceHistory: jest.fn().mockResolvedValue(history),
+    getTwapWindow: jest.fn().mockResolvedValue(onChainTwap),
+  } as unknown as OnChainOracleSource;
+}
+
+describe('verifyOnChainTwap', () => {
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW_MS);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('matches when the on-chain TWAP agrees with the recomputation', async () => {
+    const history = [{ price: 2.0, timestamp: new Date(NOW_MS - 100_000), pusher: 'GPUSHER' }];
+    const source = mockSource(history, 2.0);
+
+    const result = await verifyOnChainTwap(source, 'XLM/USDC', 300);
+
+    expect(result.matches).toBe(true);
+    expect(result.onChainTwap).toBe(2.0);
+    expect(result.recomputedTwap).toBe(2.0);
+    expect(result.diffBps).toBe(0);
+  });
+
+  it('flags a mismatch beyond tolerance as not matching', async () => {
+    const history = [{ price: 2.0, timestamp: new Date(NOW_MS - 100_000), pusher: 'GPUSHER' }];
+    const source = mockSource(history, 3.0); // deliberately wrong on-chain value
+
+    const result = await verifyOnChainTwap(source, 'XLM/USDC', 300);
+
+    expect(result.matches).toBe(false);
+    expect(result.recomputedTwap).toBe(2.0);
+    expect(result.diffBps).toBeGreaterThan(10);
+  });
+
+  it('accepts a mismatch within a widened tolerance', async () => {
+    const history = [{ price: 2.0, timestamp: new Date(NOW_MS - 100_000), pusher: 'GPUSHER' }];
+    const source = mockSource(history, 2.001); // 0.05% off
+
+    const result = await verifyOnChainTwap(source, 'XLM/USDC', 300, 50);
+
+    expect(result.matches).toBe(true);
+  });
+
+  it('throws when the on-chain price history is empty', async () => {
+    const source = mockSource([], 0);
+
+    await expect(verifyOnChainTwap(source, 'XLM/USDC', 300)).rejects.toThrow(
+      'price history is empty'
+    );
+  });
+});

--- a/packages/core/oracles/src/index.ts
+++ b/packages/core/oracles/src/index.ts
@@ -52,3 +52,7 @@ export * from './utils/retry-utils.js';
 export * from './sources/mocks/MockOracleSources.js';
 export * from './sources/real/index.js';
 export { BaseSource, type BaseSourceConfig } from './sources/base-source.js';
+
+// TWAP verification
+export { computeTwapWindow, type TwapObservation } from './verification/twap-math.js';
+export { verifyOnChainTwap, type TwapVerificationResult } from './verification/twap-verifier.js';

--- a/packages/core/oracles/src/sources/real/OnChainOracleSource.ts
+++ b/packages/core/oracles/src/sources/real/OnChainOracleSource.ts
@@ -149,6 +149,105 @@ export class OnChainOracleSource implements IOracleSource {
   }
 
   /**
+   * Fetch the raw on-chain price history (up to the contract's ring-buffer
+   * capacity) for a symbol, oldest-to-newest.
+   */
+  async getPriceHistory(
+    symbol: string
+  ): Promise<{ price: number; timestamp: Date; pusher: string }[]> {
+    const { base, quote } = this.parseSymbol(symbol);
+    const contract = new Contract(this.contractId);
+
+    const getHistoryOp = contract.call(
+      'get_price_history',
+      xdr.ScVal.scvSymbol(base),
+      xdr.ScVal.scvSymbol(quote)
+    );
+
+    const dummyAccount = new Account(SIMULATION_PUBLIC_KEY, '0');
+    const tx = new TransactionBuilder(dummyAccount, {
+      fee: '100',
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(getHistoryOp)
+      .setTimeout(30)
+      .build();
+
+    try {
+      const simulation = await this.rpcServer.simulateTransaction(tx);
+
+      if (SorobanRpc.Api.isSimulationError(simulation)) {
+        throw new Error(`Soroban RPC simulation failed: ${simulation.error}`);
+      }
+
+      if (!simulation.result || !simulation.result.retval) {
+        throw new Error(`Invalid simulation response: no return value for ${symbol}`);
+      }
+
+      const native = scValToNative(simulation.result.retval);
+      if (!Array.isArray(native)) {
+        throw new Error(`Failed to decode price history for ${symbol}`);
+      }
+
+      return native.map((entry: { price: bigint; timestamp: bigint; pusher: string }) => ({
+        price: Number(entry.price) / Number(PRICE_SCALE),
+        timestamp: new Date(Number(entry.timestamp) * 1000),
+        pusher: entry.pusher,
+      }));
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to get on-chain price history for ${symbol}: ${message}`);
+    }
+  }
+
+  /**
+   * Fetch the on-chain TWAP for a symbol over the last `windowSeconds`,
+   * computed by the contract's `get_twap_window` view method.
+   */
+  async getTwapWindow(symbol: string, windowSeconds: number): Promise<number> {
+    const { base, quote } = this.parseSymbol(symbol);
+    const contract = new Contract(this.contractId);
+
+    const getTwapOp = contract.call(
+      'get_twap_window',
+      xdr.ScVal.scvSymbol(base),
+      xdr.ScVal.scvSymbol(quote),
+      nativeToScVal(windowSeconds, { type: 'u64' })
+    );
+
+    const dummyAccount = new Account(SIMULATION_PUBLIC_KEY, '0');
+    const tx = new TransactionBuilder(dummyAccount, {
+      fee: '100',
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(getTwapOp)
+      .setTimeout(30)
+      .build();
+
+    try {
+      const simulation = await this.rpcServer.simulateTransaction(tx);
+
+      if (SorobanRpc.Api.isSimulationError(simulation)) {
+        throw new Error(`Soroban RPC simulation failed: ${simulation.error}`);
+      }
+
+      if (!simulation.result || !simulation.result.retval) {
+        throw new Error(`Invalid simulation response: no return value for ${symbol}`);
+      }
+
+      const native = scValToNative(simulation.result.retval);
+      if (typeof native !== 'bigint') {
+        throw new Error(`Failed to decode TWAP for ${symbol}`);
+      }
+
+      return Number(native) / Number(PRICE_SCALE);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to get on-chain TWAP for ${symbol}: ${message}`);
+    }
+  }
+
+  /**
    * Fetch prices for multiple symbols in parallel.
    */
   async getPrices(symbols: string[]): Promise<PriceData[]> {

--- a/packages/core/oracles/src/verification/twap-math.ts
+++ b/packages/core/oracles/src/verification/twap-math.ts
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview TWAP window math
+ * @description Pure segment-weighted TWAP calculation, mirroring the
+ *   on-chain `compute_twap_window` in `packages/contracts/price-oracle/src/twap.rs`
+ *   so that on-chain and off-chain results can be compared directly.
+ */
+
+export interface TwapObservation {
+  price: number;
+  timestamp: number; // epoch milliseconds
+}
+
+/**
+ * Compute the time-weighted average price over `[windowStartMs, nowMs]`.
+ *
+ * For each observation, the weighted interval is the overlap between its
+ * active range (`[observation.timestamp, nextObservation.timestamp_or_now]`)
+ * and the requested window. An observation older than `windowStartMs` still
+ * contributes for the portion of the window it was the latest known price —
+ * this correctly handles gaps larger than the window between updates.
+ *
+ * Falls back to the mean of whichever observations fall inside the window
+ * when every segment collapses to zero duration (e.g. a single observation,
+ * or all observations sharing one timestamp); if none fall inside the
+ * window either, falls back further to the most recent observation.
+ */
+export function computeTwapWindow(
+  history: TwapObservation[],
+  nowMs: number,
+  windowStartMs: number
+): number {
+  if (history.length === 0) {
+    throw new Error('Cannot compute TWAP over an empty price history');
+  }
+
+  let weightedSum = 0;
+  let totalDuration = 0;
+
+  for (let i = 0; i < history.length; i += 1) {
+    const entry = history[i]!;
+    const endTime = i + 1 < history.length ? history[i + 1]!.timestamp : nowMs;
+
+    const segmentStart = Math.max(entry.timestamp, windowStartMs);
+    const segmentEnd = Math.min(endTime, nowMs);
+    const duration = Math.max(0, segmentEnd - segmentStart);
+
+    weightedSum += entry.price * duration;
+    totalDuration += duration;
+  }
+
+  if (totalDuration === 0) {
+    const inWindow = history.filter(
+      (entry) => entry.timestamp >= windowStartMs && entry.timestamp <= nowMs
+    );
+    if (inWindow.length > 0) {
+      return inWindow.reduce((sum, entry) => sum + entry.price, 0) / inWindow.length;
+    }
+    return history[history.length - 1]!.price;
+  }
+
+  return weightedSum / totalDuration;
+}

--- a/packages/core/oracles/src/verification/twap-verifier.ts
+++ b/packages/core/oracles/src/verification/twap-verifier.ts
@@ -1,0 +1,72 @@
+/**
+ * @fileoverview On-chain TWAP integrity verifier
+ * @description Independently recomputes the TWAP from raw on-chain price
+ *   history and compares it against the contract's own `get_twap_window`
+ *   result, to detect a manipulated or diverging on-chain value.
+ */
+
+import { OnChainOracleSource } from '../sources/real/OnChainOracleSource.js';
+import { computeTwapWindow, type TwapObservation } from './twap-math.js';
+
+export interface TwapVerificationResult {
+  /** `true` when the on-chain and recomputed TWAP agree within `toleranceBps`. */
+  matches: boolean;
+  /** TWAP as reported by the contract's `get_twap_window`. */
+  onChainTwap: number;
+  /** TWAP recomputed off-chain from the raw price history. */
+  recomputedTwap: number;
+  /** Absolute difference between the two values, in basis points. */
+  diffBps: number;
+  /** Raw price history used for the recomputation. */
+  history: TwapObservation[];
+}
+
+/** Default tolerance: 0.10%, to absorb the small clock skew between the
+ * ledger timestamp used on-chain and the wall-clock time read here. */
+const DEFAULT_TOLERANCE_BPS = 10;
+
+/**
+ * Verify that `source`'s on-chain TWAP over `windowSeconds` matches an
+ * independent off-chain recomputation from the same raw history.
+ *
+ * Throws if the pair has no on-chain price history at all.
+ */
+export async function verifyOnChainTwap(
+  source: OnChainOracleSource,
+  symbol: string,
+  windowSeconds: number,
+  toleranceBps: number = DEFAULT_TOLERANCE_BPS
+): Promise<TwapVerificationResult> {
+  const [rawHistory, onChainTwap] = await Promise.all([
+    source.getPriceHistory(symbol),
+    source.getTwapWindow(symbol, windowSeconds),
+  ]);
+
+  if (rawHistory.length === 0) {
+    throw new Error(`Cannot verify TWAP for ${symbol}: on-chain price history is empty`);
+  }
+
+  const history: TwapObservation[] = rawHistory.map((entry) => ({
+    price: entry.price,
+    timestamp: entry.timestamp.getTime(),
+  }));
+
+  const nowMs = Date.now();
+  const windowStartMs = nowMs - windowSeconds * 1000;
+  const recomputedTwap = computeTwapWindow(history, nowMs, windowStartMs);
+
+  const diffBps =
+    onChainTwap === 0
+      ? recomputedTwap === 0
+        ? 0
+        : Number.POSITIVE_INFINITY
+      : (Math.abs(recomputedTwap - onChainTwap) / Math.abs(onChainTwap)) * 10_000;
+
+  return {
+    matches: diffBps <= toleranceBps,
+    onChainTwap,
+    recomputedTwap,
+    diffBps,
+    history,
+  };
+}


### PR DESCRIPTION
# Pull Request

## 📋 Description

Implements Time-Weighted Average Price (TWAP) for the on-chain Soroban price oracle, closing the gaps left by the existing implementation: a real ring buffer for gas-efficient price storage, configurable TWAP time windows (5m/15m/1h + arbitrary `window_seconds`), and an off-chain utility that independently verifies the on-chain TWAP against a client-side recomputation.

**On-chain (`packages/contracts/price-oracle`)**
- Replaced the `Vec`-rebuild-on-overflow price history with a real `PriceRingBuffer` (head/count indices) — `push_price` now overwrites the oldest slot in place instead of copying the whole history on every push past capacity.
- Generalized TWAP math into `compute_twap_window(history, now, window_start)`, which time-weights price segments against the requested window, correctly holding the last known price constant across gaps larger than the window.
- Added `get_twap_window(base, quote, window_seconds)` plus `get_twap_5m` / `get_twap_15m` / `get_twap_1h` convenience wrappers. Existing `get_twap()` (full-history) behavior is unchanged.
- Fixed a pre-existing compile error: `twap.rs` was never declared as a module in `lib.rs`.

**Off-chain (`packages/core/oracles`)**
- Extended `OnChainOracleSource` with `getPriceHistory` and `getTwapWindow`.
- Added a `verification/` module: `computeTwapWindow` (mirrors the on-chain math for cross-parity) and `verifyOnChainTwap`, which compares the contract's `get_twap_window` result against an independent off-chain recomputation within a configurable basis-point tolerance.

## 🔗 Related Issues

Closes #371

<!-- ⚠️ Please confirm this is the correct issue number before submitting — I inferred it from the ROADMAP.md TWAP entry, I did not have direct access to the GitHub issue tracker. -->

## 🧪 Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [x] All tests passing locally

**Rust** (`cd packages/contracts/price-oracle && cargo test`): 42/42 passing (35 existing + 7 new — ring buffer wraparound order, empty-buffer panic, single-data-point degradation, large-gap handling, partial-window exclusion, full-window parity with `get_twap()`, named-window delegation).

**TypeScript** (`cd packages/core/oracles && npx jest`): 191/191 passing, including new `twap-math.test.ts`, `twap-verifier.test.ts`, and extended `on-chain-oracle-source.test.ts` coverage.

No integration tests or manual/testnet testing were performed — this PR is unit-tested only. If the team wants a testnet deployment smoke test before merging, that's still outstanding.

## 📚 Documentation Updates (Required)

- [ ] Updated `docs/AI.md` with new patterns/examples
- [ ] Updated API reference in relevant package README
- [x] Added/updated code examples
- [ ] Updated ARCHITECTURE.md (if architecture changed)
- [x] Added inline JSDoc/TSDoc comments
- [x] Updated ROADMAP.md progress (mark issue as completed)

<!-- Honest status: docs/guides/oracle-integration.md was corrected (it described a contract interface that was never actually implemented) and now documents the new TWAP window methods with usage examples. ROADMAP.md #39 is checked off. docs/AI.md, ARCHITECTURE.md, and packages/core/oracles/README.md were NOT touched — flagging so the team can decide whether those are required before merge. -->

### Documentation Checklist by Component:

#### If you modified `packages/core/oracles/`:
- [ ] Updated `packages/core/oracles/README.md`
- [x] Added oracle source documentation *(contract interface + TWAP usage in `docs/guides/oracle-integration.md`)*
- [x] Updated price feed examples

#### If you modified `packages/contracts/`:
- [x] Added Rust documentation comments (///)
- [ ] Updated contract README with deployment instructions *(no README exists for `price-oracle` yet)*
- [x] Added contract interaction examples *(in `docs/guides/oracle-integration.md`)*

## 🤖 AI-Friendly Documentation

### New Files Created

```
packages/core/oracles/src/verification/twap-math.ts - Pure, side-effect-free TWAP-over-a-window calculation; mirrors the Rust compute_twap_window logic so on-chain/off-chain results are directly comparable.
packages/core/oracles/src/verification/twap-verifier.ts - verifyOnChainTwap(): fetches on-chain price history + get_twap_window result, recomputes independently, flags divergence beyond a tolerance (bps).
packages/core/oracles/__tests__/verification/twap-math.test.ts - Edge-case tests: empty history, single data point, large gaps, partial windows.
packages/core/oracles/__tests__/verification/twap-verifier.test.ts - Mocked OnChainOracleSource tests: match, mismatch, tolerance, empty history.
```

### Key Functions/Classes Added

```rust
// packages/contracts/price-oracle/src/types.rs
pub struct PriceRingBuffer { pub entries: Vec<PriceEntry>, pub head: u32, pub count: u32 }
impl PriceRingBuffer {
    pub fn push(&mut self, entry: PriceEntry, capacity: u32);
    pub fn chronological(&self, env: &Env, capacity: u32) -> Vec<PriceEntry>;
}

// packages/contracts/price-oracle/src/twap.rs
pub fn compute_twap_window(history: &Vec<PriceEntry>, now: u64, window_start: u64) -> i128;

// packages/contracts/price-oracle/src/lib.rs
pub fn get_twap_window(env: &Env, base: Symbol, quote: Symbol, window_seconds: u64) -> i128;
pub fn get_twap_5m(env: &Env, base: Symbol, quote: Symbol) -> i128;
pub fn get_twap_15m(env: &Env, base: Symbol, quote: Symbol) -> i128;
pub fn get_twap_1h(env: &Env, base: Symbol, quote: Symbol) -> i128;
```

```typescript
// packages/core/oracles/src/sources/real/OnChainOracleSource.ts
async getPriceHistory(symbol: string): Promise<{ price: number; timestamp: Date; pusher: string }[]>;
async getTwapWindow(symbol: string, windowSeconds: number): Promise<number>;

// packages/core/oracles/src/verification/twap-verifier.ts
async function verifyOnChainTwap(
  source: OnChainOracleSource,
  symbol: string,
  windowSeconds: number,
  toleranceBps?: number
): Promise<TwapVerificationResult>;
```

### Patterns Used

- **Ring buffer over rebuild-on-overflow**: overwrite in place at a tracked `head` index instead of copying the whole collection on every write past capacity — apply this pattern to any other bounded on-chain history (e.g. future oracle-adjacent contracts) where writes are the gas-sensitive path and reads can afford the reordering cost.
- **Segment-weighted time windowing**: clamp each observation's active interval to `[window_start, now]` rather than filtering entries in/out of the window — this is what makes stale prices "carry forward" correctly across update gaps.
- **Cross-language math parity**: the off-chain `computeTwapWindow` intentionally re-implements the exact same algorithm as the on-chain `compute_twap_window` (same fallback branches) so verification isn't comparing two different formulas by accident.

## 📸 Screenshots (if applicable)

N/A — backend/contract logic only, no UI changes.

## ⚠️ Breaking Changes

- [x] No breaking changes

`get_twap()` and `get_price_history()` keep their existing signatures and observable behavior; `PriceRingBuffer` replacing the raw `Vec` in storage is an internal representation change transparent to callers.

## 🔄 Deployment Notes

This changes the on-chain storage value type for `KEY_PRICES` (`Map<(Symbol,Symbol), Vec<PriceEntry>>` → `Map<(Symbol,Symbol), PriceRingBuffer>`). **This is not backward-compatible with already-deployed contract instances** — any existing testnet/mainnet deployment holding price history in the old format will fail to deserialize storage on upgrade. This must ship as a fresh contract deployment (or paired with a storage migration), not an in-place upgrade of a live instance.

## ✅ Final Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console.log or debug code left
- [x] Error handling implemented
- [x] Performance considered
- [ ] Security reviewed *(no independent security review performed — recommend one given this touches oracle pricing logic)*
- [ ] Documentation updated (required) *(partially — see documentation section above)*
- [x] ROADMAP.md updated with progress

---

**By submitting this PR, I confirm that**:
- ⚠️ Documentation is partially updated — see the Documentation Updates section for what's outstanding (`docs/AI.md`, `ARCHITECTURE.md`, `packages/core/oracles/README.md`)
- ⚠️ AI.md does not yet include the new patterns from this change
- ✅ Examples are provided for new features (in `docs/guides/oracle-integration.md` and inline doc comments)
- ✅ The documentation that was updated is accurate and reflects the real, deployed contract interface (it previously did not)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounded price history for each asset pair, with chronological history retrieval.
  * Added configurable and preset 5-minute, 15-minute, and 1-hour TWAP queries.
  * Added on-chain price history and TWAP access through the oracle integration.
  * Added off-chain TWAP calculation and verification against on-chain values, including configurable tolerance reporting.

* **Documentation**
  * Updated oracle integration guidance with the deployed contract interface and TWAP verification examples.
  * Marked the TWAP oracle roadmap item as complete.

* **Tests**
  * Added coverage for price history, buffer behavior, TWAP windows, and verification edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->