### PR TITLE
feat: add interactive prompts to CLI commands when flags are missing

### DIFF
--- a/tools/cli/src/commands/build.ts
+++ b/tools/cli/src/commands/build.ts
@@ -9,6 +9,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
+import inquirer from 'inquirer';
 import { execa } from 'execa';
 import fs from 'fs-extra';
 import path from 'path';
@@ -22,8 +23,13 @@ buildCommand
   .option('--contracts', 'Build smart contracts only')
   .option('--frontend', 'Build frontend only')
   .option('--backend', 'Build backend only')
+  .option('--json', 'Output in JSON format (disables interactive prompts)')
+  .option('-y, --yes', 'Skip confirmation prompts')
   .action(async (options) => {
     try {
+      const isJson = options.json === true;
+      const skipConfirm = options.yes === true;
+
       console.log(chalk.blue('Building Galaxy project...'));
 
       // Check if we're in a Galaxy project
@@ -41,16 +47,87 @@ buildCommand
         process.exit(1);
       }
 
+      // Detect available components
+      const hasContracts = await fs.pathExists(path.join(process.cwd(), 'contracts'));
+      const hasFrontend = await fs.pathExists(path.join(process.cwd(), 'next.config.js'));
+      const hasBackend = await fs.pathExists(path.join(process.cwd(), 'backend')) ||
+                         await fs.pathExists(path.join(process.cwd(), 'api'));
+
+      const componentFlagsProvided = options.contracts || options.frontend || options.backend;
+
+      // If no component flags were provided, prompt interactively
+      if (!componentFlagsProvided) {
+        const availableComponents: string[] = [];
+        if (hasContracts) availableComponents.push('contracts');
+        if (hasFrontend) availableComponents.push('frontend');
+        if (hasBackend) availableComponents.push('backend');
+
+        if (availableComponents.length === 0) {
+          console.log(chalk.yellow('No buildable components found in this project'));
+          process.exit(0);
+        }
+
+        if (isJson) {
+          // In JSON mode, build all available components
+          options.contracts = hasContracts;
+          options.frontend = hasFrontend;
+          options.backend = hasBackend;
+        } else {
+          const choices = [
+            ...availableComponents,
+            { name: chalk.gray('Build all components'), value: '__all__' },
+          ];
+          const answer = await inquirer.prompt([{
+            type: 'checkbox',
+            name: 'components',
+            message: 'Select components to build:',
+            choices,
+            validate: (selected: string[]) => selected.length > 0 ? true : 'Select at least one component',
+          }]);
+
+          const selected = answer.components as string[];
+          const buildAll = selected.includes('__all__');
+          options.contracts = buildAll || selected.includes('contracts');
+          options.frontend = buildAll || selected.includes('frontend');
+          options.backend = buildAll || selected.includes('backend');
+        }
+      }
+
+      // Show build preview
+      if (!skipConfirm && !isJson) {
+        const targets: string[] = [];
+        if (options.contracts) targets.push('contracts');
+        if (options.frontend) targets.push('frontend');
+        if (options.backend) targets.push('backend');
+
+        console.log(chalk.cyan('\n--- Build Preview ---'));
+        console.log(chalk.white(`  Targets:  ${targets.join(', ')}`));
+        console.log(chalk.white(`  Output:   ${options.output}`));
+        console.log(chalk.white(`  Optimize: ${options.optimize ? 'Yes' : 'No'}`));
+        console.log(chalk.cyan('---------------------\n'));
+
+        const { confirm } = await inquirer.prompt([{
+          type: 'confirm',
+          name: 'confirm',
+          message: 'Proceed with build?',
+          default: true,
+        }]);
+
+        if (!confirm) {
+          console.log(chalk.yellow('Build cancelled.'));
+          process.exit(0);
+        }
+      }
+
       // Build based on options
       if (options.contracts) {
         await buildContracts(options);
-      } else if (options.frontend) {
+      }
+      if (options.frontend) {
         await buildFrontend(options);
-      } else if (options.backend) {
+      }
+      if (options.backend) {
         await buildBackend(options);
-      } else {
-        // Build all components
-        await buildAll(options);
       }
 
       console.log(chalk.green('\n✅ Build completed successfully!'));
@@ -188,22 +265,4 @@ async function buildBackend(options: any): Promise<void> {
   }
 }
 
-/**
- * Builds all components
- * @param options - Build options
- */
-async function buildAll(options: any): Promise<void> {
-  console.log(chalk.blue('Building all components...'));
-
-  // Build contracts
-  await buildContracts(options);
-
-  // Build frontend
-  await buildFrontend(options);
-
-  // Build backend
-  await buildBackend(options);
-}
-
 export { buildCommand };
-

--- a/tools/cli/src/commands/deploy.ts
+++ b/tools/cli/src/commands/deploy.ts
@@ -18,12 +18,32 @@ const deployCommand = new Command('deploy');
 
 deployCommand
   .description('Deploy contracts and applications to Stellar networks')
-  .option('-n, --network <network>', 'Network to deploy to', 'testnet')
+  .option('-n, --network <network>', 'Network to deploy to')
   .option('-c, --contract <contract>', 'Contract to deploy')
   .option('--verify', 'Verify contract after deployment')
   .option('--gas-limit <limit>', 'Gas limit for deployment', '1000000')
+  .option('--json', 'Output in JSON format (disables interactive prompts)')
+  .option('-y, --yes', 'Skip confirmation prompts')
   .action(async (options) => {
     try {
+      const isJson = options.json === true;
+      const skipConfirm = options.yes === true;
+
+      // Resolve network interactively if not provided
+      if (!options.network) {
+        if (isJson) {
+          console.error(JSON.stringify({ error: 'Network is required. Use --network flag.' }));
+          process.exit(1);
+        }
+        const answer = await inquirer.prompt([{
+          type: 'list',
+          name: 'network',
+          message: 'Select network to deploy to:',
+          choices: ['testnet', 'mainnet'],
+        }]);
+        options.network = answer.network;
+      }
+
       console.log(chalk.blue('Deploying to Stellar network...'));
       console.log(chalk.gray(`Network: ${options.network}`));
 
@@ -48,6 +68,59 @@ deployCommand
         console.error(chalk.red('Not a Galaxy project'));
         console.error(chalk.yellow('This command must be run from a Galaxy project'));
         process.exit(1);
+      }
+
+      // Resolve contract interactively if not provided
+      if (!options.contract) {
+        const contractsDir = path.join(process.cwd(), 'contracts');
+        if (await fs.pathExists(contractsDir)) {
+          const entries = await fs.readdir(contractsDir);
+          const contractDirs: string[] = [];
+          for (const entry of entries) {
+            const stat = await fs.stat(path.join(contractsDir, entry));
+            if (stat.isDirectory()) {
+              contractDirs.push(entry);
+            }
+          }
+
+          if (contractDirs.length > 0) {
+            if (isJson) {
+              // In JSON mode, deploy all contracts
+              options.contract = null;
+            } else {
+              const choices = [...contractDirs, { name: chalk.gray('Deploy all contracts'), value: '__all__' }];
+              const answer = await inquirer.prompt([{
+                type: 'list',
+                name: 'contract',
+                message: 'Select a contract to deploy:',
+                choices,
+              }]);
+              options.contract = answer.contract === '__all__' ? null : answer.contract;
+            }
+          }
+        }
+      }
+
+      // Show deployment preview
+      if (!skipConfirm && !isJson) {
+        console.log(chalk.cyan('\n--- Deployment Preview ---'));
+        console.log(chalk.white(`  Network:  ${options.network}`));
+        console.log(chalk.white(`  Contract: ${options.contract || 'All contracts'}`));
+        console.log(chalk.white(`  Verify:   ${options.verify ? 'Yes' : 'No'}`));
+        console.log(chalk.white(`  Gas limit: ${options.gasLimit}`));
+        console.log(chalk.cyan('----------------------------\n'));
+
+        const { confirm } = await inquirer.prompt([{
+          type: 'confirm',
+          name: 'confirm',
+          message: 'Proceed with deployment?',
+          default: true,
+        }]);
+
+        if (!confirm) {
+          console.log(chalk.yellow('Deployment cancelled.'));
+          process.exit(0);
+        }
       }
 
       // Deploy contracts if specified
@@ -209,4 +282,3 @@ async function deployApplication(options: any): Promise<void> {
 }
 
 export { deployCommand };
-

--- a/tools/cli/src/commands/dev.ts
+++ b/tools/cli/src/commands/dev.ts
@@ -9,6 +9,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
+import inquirer from 'inquirer';
 import { execa } from 'execa';
 import fs from 'fs-extra';
 import path from 'path';
@@ -17,12 +18,15 @@ const devCommand = new Command('dev');
 
 devCommand
   .description('Start development mode with hot reload')
-  .option('-p, --port <port>', 'Port to run on', '3000')
+  .option('-p, --port <port>', 'Port to run on')
   .option('--hot-reload', 'Enable hot reload')
   .option('--watch', 'Watch for file changes')
   .option('--debug', 'Enable debug mode')
+  .option('--json', 'Output in JSON format (disables interactive prompts)')
   .action(async (options) => {
     try {
+      const isJson = options.json === true;
+
       console.log(chalk.blue('Starting Galaxy development mode...'));
 
       // Check if we're in a Galaxy project
@@ -39,6 +43,70 @@ devCommand
         console.error(chalk.yellow('This command must be run from a Galaxy project'));
         process.exit(1);
       }
+
+      // Resolve options interactively if not explicitly provided via flags
+      const portExplicitlySet = process.argv.includes('-p') || process.argv.includes('--port');
+      const hotReloadExplicitlySet = process.argv.includes('--hot-reload');
+      const watchExplicitlySet = process.argv.includes('--watch');
+      const debugExplicitlySet = process.argv.includes('--debug');
+
+      if (!isJson && (!portExplicitlySet || !hotReloadExplicitlySet || !watchExplicitlySet || !debugExplicitlySet)) {
+        const prompts: any[] = [];
+
+        if (!portExplicitlySet) {
+          prompts.push({
+            type: 'input',
+            name: 'port',
+            message: 'Port to run on:',
+            default: '3000',
+            validate: (val: string) => {
+              const n = parseInt(val, 10);
+              return n > 0 && n <= 65535 ? true : 'Enter a valid port number (1-65535)';
+            },
+          });
+        }
+
+        if (!hotReloadExplicitlySet) {
+          prompts.push({
+            type: 'confirm',
+            name: 'hotReload',
+            message: 'Enable hot reload?',
+            default: true,
+          });
+        }
+
+        if (!watchExplicitlySet) {
+          prompts.push({
+            type: 'confirm',
+            name: 'watch',
+            message: 'Watch for file changes?',
+            default: true,
+          });
+        }
+
+        if (!debugExplicitlySet) {
+          prompts.push({
+            type: 'confirm',
+            name: 'debug',
+            message: 'Enable debug mode?',
+            default: false,
+          });
+        }
+
+        if (prompts.length > 0) {
+          const answers = await inquirer.prompt(prompts);
+          if (!portExplicitlySet) options.port = answers.port;
+          if (!hotReloadExplicitlySet) options.hotReload = answers.hotReload;
+          if (!watchExplicitlySet) options.watch = answers.watch;
+          if (!debugExplicitlySet) options.debug = answers.debug;
+        }
+      }
+
+      // Apply defaults for any still-unset options
+      if (!options.port) options.port = '3000';
+      if (options.hotReload === undefined) options.hotReload = false;
+      if (options.watch === undefined) options.watch = false;
+      if (options.debug === undefined) options.debug = false;
 
       // Start development mode
       await startDevelopmentMode(options);
@@ -225,4 +293,3 @@ app.listen(PORT, () => {
 }
 
 export { devCommand };
-

--- a/tools/cli/src/commands/start.ts
+++ b/tools/cli/src/commands/start.ts
@@ -9,6 +9,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
+import inquirer from 'inquirer';
 import { execa } from 'execa';
 import fs from 'fs-extra';
 import path from 'path';
@@ -17,13 +18,18 @@ const startCommand = new Command('start');
 
 startCommand
   .description('Start development servers and services')
-  .option('-p, --port <port>', 'Port to run on', '3000')
+  .option('-p, --port <port>', 'Port to run on')
   .option('--api', 'Start API server only')
   .option('--frontend', 'Start frontend only')
   .option('--backend', 'Start backend only')
   .option('--dev', 'Start in development mode')
+  .option('--json', 'Output in JSON format (disables interactive prompts)')
+  .option('-y, --yes', 'Skip confirmation prompts')
   .action(async (options) => {
     try {
+      const isJson = options.json === true;
+      const skipConfirm = options.yes === true;
+
       console.log(chalk.blue('Starting Galaxy development environment...'));
 
       // Check if we're in a Galaxy project
@@ -41,15 +47,111 @@ startCommand
         process.exit(1);
       }
 
+      // Detect available services
+      const hasApi = await fs.pathExists(path.join(process.cwd(), 'api')) ||
+                     await fs.pathExists(path.join(process.cwd(), 'backend'));
+      const hasFrontend = await fs.pathExists(path.join(process.cwd(), 'next.config.js'));
+      const hasBackend = await fs.pathExists(path.join(process.cwd(), 'backend')) ||
+                         await fs.pathExists(path.join(process.cwd(), 'api'));
+
+      const componentFlagsProvided = options.api || options.frontend || options.backend;
+
+      // Resolve port interactively if not provided
+      if (!options.port) {
+        if (isJson) {
+          options.port = '3000';
+        } else {
+          const answer = await inquirer.prompt([{
+            type: 'input',
+            name: 'port',
+            message: 'Port to run on:',
+            default: '3000',
+            validate: (val: string) => {
+              const n = parseInt(val, 10);
+              return n > 0 && n <= 65535 ? true : 'Enter a valid port number (1-65535)';
+            },
+          }]);
+          options.port = answer.port;
+        }
+      }
+
+      // If no component flags were provided, prompt interactively
+      if (!componentFlagsProvided) {
+        const availableServices: string[] = [];
+        if (hasApi) availableServices.push('api');
+        if (hasFrontend) availableServices.push('frontend');
+        if (hasBackend) availableServices.push('backend');
+
+        if (availableServices.length === 0) {
+          console.log(chalk.yellow('No services found in this project'));
+          process.exit(0);
+        }
+
+        if (isJson) {
+          // In JSON mode, start all services
+          options.api = hasApi;
+          options.frontend = hasFrontend;
+          options.backend = hasBackend;
+        } else {
+          const choices = [
+            ...availableServices,
+            { name: chalk.gray('Start all services'), value: '__all__' },
+          ];
+          const answer = await inquirer.prompt([{
+            type: 'checkbox',
+            name: 'services',
+            message: 'Select services to start:',
+            choices,
+            validate: (selected: string[]) => selected.length > 0 ? true : 'Select at least one service',
+          }]);
+
+          const selected = answer.services as string[];
+          const startAll = selected.includes('__all__');
+          options.api = startAll || selected.includes('api');
+          options.frontend = startAll || selected.includes('frontend');
+          options.backend = startAll || selected.includes('backend');
+        }
+      }
+
+      // Show start preview
+      if (!skipConfirm && !isJson) {
+        const targets: string[] = [];
+        if (options.api) targets.push('api');
+        if (options.frontend) targets.push('frontend');
+        if (options.backend) targets.push('backend');
+
+        console.log(chalk.cyan('\n--- Start Preview ---'));
+        console.log(chalk.white(`  Services: ${targets.join(', ')}`));
+        console.log(chalk.white(`  Port:     ${options.port}`));
+        console.log(chalk.white(`  Dev mode: ${options.dev ? 'Yes' : 'No'}`));
+        console.log(chalk.cyan('---------------------\n'));
+
+        const { confirm } = await inquirer.prompt([{
+          type: 'confirm',
+          name: 'confirm',
+          message: 'Proceed?',
+          default: true,
+        }]);
+
+        if (!confirm) {
+          console.log(chalk.yellow('Startup cancelled.'));
+          process.exit(0);
+        }
+      }
+
       // Start services based on options
       if (options.api) {
         await startAPIServer(options);
-      } else if (options.frontend) {
+      }
+      if (options.frontend) {
         await startFrontend(options);
-      } else if (options.backend) {
+      }
+      if (options.backend) {
         await startBackend(options);
-      } else {
-        // Start all services
+      }
+
+      // If no specific service was requested, start all
+      if (!options.api && !options.frontend && !options.backend) {
         await startAllServices(options);
       }
 
@@ -208,4 +310,3 @@ async function startAllServices(options: any): Promise<void> {
 }
 
 export { startCommand };
-


### PR DESCRIPTION
## Summary

Add interactive fallback prompts to the `deploy`, `build`, `dev`, and `start` CLI commands. When required flags are omitted, the CLI now guides users through selections using inquirer prompts instead of failing or silently using defaults.

## Changes

- **`deploy`**: Prompts for network selection, contract selection (from available contracts directory), and shows a deployment preview with confirmation gate
- **`build`**: Prompts for component selection via checkbox (contracts/frontend/backend) and shows a build preview with confirmation gate
- **`dev`**: Prompts for port, hot-reload, watch, and debug toggles when not explicitly set via flags
- **`start`**: Prompts for port, service selection via checkbox, and shows a startup preview with confirmation gate

## CI/CD Compatibility

All commands now accept `--json` to disable interactive prompts (for headless/scripted execution) and `-y`/`--yes` to skip confirmation prompts.

## Acceptance Criteria

- [x] Users can run commands without flags and be guided interactively
- [x] Interactive mode can be bypassed completely for CI/CD pipelines (`--json`)
- [x] Prompt selections correctly map to command options

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive component and service selection for build, start, and deploy commands.
  * Added `--json` modes for automated, non-interactive workflows.
  * Added `-y/--yes` options to skip confirmation prompts.
  * Added interactive development settings for port, hot reload, watch mode, and debugging.
  * Added project component autodetection and deployment previews.
* **Improvements**
  * Deploy now requires an explicit network in JSON mode and supports selecting individual or all contracts.
  * Start and build can independently run multiple selected components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->