### PR TITLE
fix(core/wallet): extract the real WebAuthn public key in SocialLoginProvider

### DIFF
--- a/packages/core/wallet/auth/src/providers/SocialLoginProvider.ts
+++ b/packages/core/wallet/auth/src/providers/SocialLoginProvider.ts
@@ -90,38 +90,27 @@ export class SocialLoginProvider {
   }
 
   /**
-   * Extract the public key bytes from a WebAuthn credential.
-   * The public key is encoded in the attestation object response.
-   * 
-   * IMPORTANT: This is a placeholder implementation.
-   * In production, you would:
-   * 1. Store the credential.response.getPublicKey() during registration
-   * 2. Or parse the attestationObject from credential.response.attestationObject
-   * 3. Extract the COSE public key and convert to raw 65-byte format (0x04 + x + y for ES256)
-   * 
+   * Extract the public key bytes for a WebAuthn credential.
+   *
+   * The real key is extracted and verified by `WebAuthNProvider.registerCredential()`
+   * at registration time (via `extractPublicKey()` + a signature self-check) and
+   * persisted alongside the credential id. This just reads it back from that shared
+   * storage so it never has to be re-derived.
+   *
    * @param credentialId - The credential ID to look up
    * @returns 65-byte public key in uncompressed format
    * @private
    */
   private async extractPublicKey(credentialId: string): Promise<Uint8Array> {
-    // PLACEHOLDER: Returns a mock 65-byte public key
-    // Real implementation would:
-    // 1. Parse attestationObject from the credential response
-    // 2. Extract authData and decode CBOR
-    // 3. Get credentialPublicKey from authData
-    // 4. Convert COSE key to raw format
-    
-    // For now, return a placeholder that follows the correct format:
-    // Byte 0: 0x04 (uncompressed point indicator for ES256)
-    // Bytes 1-32: x coordinate (32 bytes)
-    // Bytes 33-64: y coordinate (32 bytes)
-    const publicKey = new Uint8Array(65);
-    publicKey[0] = 0x04; // Uncompressed point indicator
-    
-    // Fill with deterministic but fake data for now
-    // In production, this must be the actual public key from WebAuthn
-    crypto.getRandomValues(publicKey.subarray(1));
-    
+    const publicKey = this.webAuthnProvider.getStoredPublicKey(credentialId);
+
+    if (!publicKey) {
+      throw new Error(
+        `SocialLoginProvider: no public key found for credential "${credentialId}". ` +
+        'The credential must be registered via WebAuthNProvider.registerCredential() first.'
+      );
+    }
+
     return publicKey;
   }
 

--- a/packages/core/wallet/auth/src/providers/WebAuthNProvider.ts
+++ b/packages/core/wallet/auth/src/providers/WebAuthNProvider.ts
@@ -6,25 +6,47 @@ import {
   BiometricType,
 } from '../BiometricAuth';
 
+/** COSE Algorithm Identifier for ES256 (ECDSA w/ SHA-256 over P-256). */
+const COSE_ALG_ES256 = -7;
+
 export function extractPublicKey(credential: PublicKeyCredential): Uint8Array {
   const response = credential.response as AuthenticatorAttestationResponse;
 
-  if (typeof response.getPublicKey !== 'function') {
+  if (!('attestationObject' in response) || !response.attestationObject) {
     throw new Error(
       'extractPublicKey: credential.response is not an AuthenticatorAttestationResponse. ' +
       'Pass the credential returned by navigator.credentials.create(), not .get().'
     );
   }
 
-  // getPublicKey() returns the DER SubjectPublicKeyInfo blob directly (72 bytes for P-256).
-  const spki = response.getPublicKey();
-  if (!spki) {
-    throw new Error(
-      'extractPublicKey: getPublicKey() returned null. ' +
-      'The authenticator may not support P-256 or the attestation format is unsupported.'
-    );
+  // Reject non-ES256 credentials explicitly, up front, when the browser exposes the
+  // algorithm actually negotiated with the authenticator (WebAuthn Level 2+).
+  if (typeof response.getPublicKeyAlgorithm === 'function') {
+    const alg = response.getPublicKeyAlgorithm();
+    if (alg !== COSE_ALG_ES256) {
+      throw new Error(
+        `extractPublicKey: unsupported public key algorithm ${alg} — only ES256 (-7 / P-256) ` +
+        'is supported. Refusing to coerce a non-EC key into an EC point.'
+      );
+    }
   }
 
+  // Preferred path: getPublicKey() returns the DER SubjectPublicKeyInfo blob directly
+  // (72 bytes for P-256).
+  if (typeof response.getPublicKey === 'function') {
+    const spki = response.getPublicKey();
+    if (spki) {
+      return spkiToRawPoint(spki);
+    }
+  }
+
+  // Fallback: not every authenticator/browser implements getPublicKey() (notably some
+  // older Firefox releases). Parse the CBOR attestationObject ourselves.
+  return attestationObjectToRawPoint(response.attestationObject);
+}
+
+/** Convert a DER SubjectPublicKeyInfo blob for a P-256 key into a raw 65-byte point. */
+function spkiToRawPoint(spki: ArrayBuffer): Uint8Array {
   // P-256 SPKI is 72 bytes; the 65-byte uncompressed point starts at offset 27.
   const SPKI_HEADER_LENGTH = 26;
   const UNCOMPRESSED_POINT_LENGTH = 65;
@@ -49,6 +71,202 @@ export function extractPublicKey(credential: PublicKeyCredential): Uint8Array {
   // Return a copy — never return a view into the original ArrayBuffer since
   // the caller may hold a reference and the buffer could be GC'd or mutated.
   return point.slice();
+}
+
+/**
+ * Parse a WebAuthn `attestationObject` (CBOR-encoded) and extract the credential's
+ * public key as a raw 65-byte SEC-1 uncompressed P-256 point.
+ *
+ * Used as a fallback when `AuthenticatorAttestationResponse.getPublicKey()` is
+ * unavailable or returns null.
+ */
+function attestationObjectToRawPoint(attestationObject: ArrayBuffer): Uint8Array {
+  if (attestationObject.byteLength === 0) {
+    throw new Error(
+      'extractPublicKey: getPublicKey() is unavailable and attestationObject is empty — ' +
+      'cannot extract a public key.'
+    );
+  }
+
+  const { value: attObj } = decodeCBORValue(new Uint8Array(attestationObject), 0);
+  if (!(attObj instanceof Map)) {
+    throw new Error('extractPublicKey: attestationObject did not decode to a CBOR map.');
+  }
+
+  const authData = attObj.get('authData');
+  if (!(authData instanceof Uint8Array)) {
+    throw new Error('extractPublicKey: attestationObject is missing an authData byte string.');
+  }
+
+  return authDataToRawPoint(authData);
+}
+
+/** Parse WebAuthn `authData` bytes and extract the attested credential's public key. */
+function authDataToRawPoint(authData: Uint8Array): Uint8Array {
+  const RP_ID_HASH_LENGTH = 32;
+  const FLAGS_LENGTH = 1;
+  const SIGN_COUNT_LENGTH = 4;
+  const AAGUID_LENGTH = 16;
+  const CRED_ID_LEN_LENGTH = 2;
+  const ATTESTED_CREDENTIAL_DATA_FLAG = 0x40;
+
+  const FIXED_HEADER_LENGTH = RP_ID_HASH_LENGTH + FLAGS_LENGTH + SIGN_COUNT_LENGTH;
+  if (authData.length < FIXED_HEADER_LENGTH) {
+    throw new Error(
+      `extractPublicKey: authData is ${authData.length} bytes — too short to contain ` +
+      `rpIdHash, flags, and signCount.`
+    );
+  }
+
+  const flags = authData[RP_ID_HASH_LENGTH];
+  if ((flags & ATTESTED_CREDENTIAL_DATA_FLAG) === 0) {
+    throw new Error(
+      'extractPublicKey: authData does not have the attested-credential-data flag set — ' +
+      'this is not a registration ceremony response.'
+    );
+  }
+
+  let offset = FIXED_HEADER_LENGTH + AAGUID_LENGTH;
+  if (offset + CRED_ID_LEN_LENGTH > authData.length) {
+    throw new Error('extractPublicKey: authData is truncated before credentialIdLength.');
+  }
+
+  const credentialIdLength = (authData[offset] << 8) | authData[offset + 1];
+  offset += CRED_ID_LEN_LENGTH + credentialIdLength;
+
+  if (offset >= authData.length) {
+    throw new Error('extractPublicKey: authData is truncated before credentialPublicKey.');
+  }
+
+  const { value: coseKey } = decodeCBORValue(authData, offset);
+  if (!(coseKey instanceof Map)) {
+    throw new Error('extractPublicKey: credentialPublicKey did not decode to a CBOR map.');
+  }
+
+  return coseKeyToRawPoint(coseKey);
+}
+
+/** Convert a decoded COSE_Key map to a raw 65-byte SEC-1 uncompressed P-256 point. */
+function coseKeyToRawPoint(coseKey: Map<unknown, unknown>): Uint8Array {
+  const COSE_KTY_EC2 = 2;
+  const COSE_CRV_P256 = 1;
+
+  const kty = coseKey.get(1);
+  const alg = coseKey.get(3);
+  const crv = coseKey.get(-1);
+  const x = coseKey.get(-2);
+  const y = coseKey.get(-3);
+
+  if (alg !== COSE_ALG_ES256) {
+    throw new Error(
+      `extractPublicKey: unsupported COSE algorithm ${alg} — only ES256 (-7) is supported. ` +
+      'Refusing to coerce a non-EC key into an EC point.'
+    );
+  }
+  if (kty !== COSE_KTY_EC2) {
+    throw new Error(`extractPublicKey: unsupported COSE key type ${kty} — only EC2 (2) is supported.`);
+  }
+  if (crv !== COSE_CRV_P256) {
+    throw new Error(`extractPublicKey: unsupported COSE curve ${crv} — only P-256 (1) is supported.`);
+  }
+  if (!(x instanceof Uint8Array) || x.length !== 32 || !(y instanceof Uint8Array) || y.length !== 32) {
+    throw new Error('extractPublicKey: malformed COSE_Key — expected 32-byte x and y coordinates.');
+  }
+
+  const point = new Uint8Array(65);
+  point[0] = 0x04;
+  point.set(x, 1);
+  point.set(y, 33);
+  return point;
+}
+
+// ── Minimal CBOR decoder ──────────────────────────────────────────────────────
+// WebAuthn's attestationObject and COSE_Key structures use canonical, definite-length
+// CBOR (RFC 8949). We only need to decode the major types that actually appear there:
+// unsigned/negative integers, byte strings, text strings, arrays, and maps.
+
+interface CBORDecodeResult {
+  value: unknown;
+  offset: number;
+}
+
+function decodeCBORLength(
+  view: DataView,
+  offset: number,
+  additionalInfo: number
+): { length: number; offset: number } {
+  if (additionalInfo < 24) return { length: additionalInfo, offset };
+  if (additionalInfo === 24) return { length: view.getUint8(offset), offset: offset + 1 };
+  if (additionalInfo === 25) return { length: view.getUint16(offset), offset: offset + 2 };
+  if (additionalInfo === 26) return { length: view.getUint32(offset), offset: offset + 4 };
+  if (additionalInfo === 27) {
+    const high = view.getUint32(offset);
+    const low = view.getUint32(offset + 4);
+    return { length: high * 2 ** 32 + low, offset: offset + 8 };
+  }
+  throw new Error(
+    `decodeCBOR: unsupported additional info ${additionalInfo} — indefinite-length CBOR is not supported.`
+  );
+}
+
+function decodeCBORValue(bytes: Uint8Array, offset: number): CBORDecodeResult {
+  if (offset >= bytes.length) {
+    throw new Error('decodeCBOR: unexpected end of input.');
+  }
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const initialByte = bytes[offset];
+  const majorType = initialByte >> 5;
+  const additionalInfo = initialByte & 0x1f;
+  const { length, offset: dataStart } = decodeCBORLength(view, offset + 1, additionalInfo);
+
+  switch (majorType) {
+    case 0: // unsigned integer
+      return { value: length, offset: dataStart };
+    case 1: // negative integer
+      return { value: -1 - length, offset: dataStart };
+    case 2: // byte string
+      return { value: bytes.slice(dataStart, dataStart + length), offset: dataStart + length };
+    case 3: // text string
+      return {
+        value: new TextDecoder().decode(bytes.slice(dataStart, dataStart + length)),
+        offset: dataStart + length,
+      };
+    case 4: { // array
+      const arr: unknown[] = [];
+      let cur = dataStart;
+      for (let i = 0; i < length; i++) {
+        const item = decodeCBORValue(bytes, cur);
+        arr.push(item.value);
+        cur = item.offset;
+      }
+      return { value: arr, offset: cur };
+    }
+    case 5: { // map
+      const map = new Map<unknown, unknown>();
+      let cur = dataStart;
+      for (let i = 0; i < length; i++) {
+        const key = decodeCBORValue(bytes, cur);
+        const val = decodeCBORValue(bytes, key.offset);
+        map.set(key.value, val.value);
+        cur = val.offset;
+      }
+      return { value: map, offset: cur };
+    }
+    default:
+      throw new Error(`decodeCBOR: unsupported major type ${majorType} at offset ${offset}.`);
+  }
+}
+
+function concatUint8Arrays(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+  return result;
 }
 
 
@@ -254,6 +472,9 @@ export class WebAuthNProvider extends BiometricAuthProvider {
       throw new Error('Failed to create credential');
     }
 
+    const publicKey = extractPublicKey(credential);
+    await this.verifyRegistrationSelfCheck(credential, publicKey);
+
     const credentialId = this.arrayBufferToBase64(credential.rawId);
 
     const biometricCredential: BiometricCredential = {
@@ -264,8 +485,93 @@ export class WebAuthNProvider extends BiometricAuthProvider {
     };
 
     this.storeCredentialId(credentialId);
+    this.storePublicKey(credentialId, publicKey);
 
     return biometricCredential;
+  }
+
+  /**
+   * Look up the public key persisted for a credential during `registerCredential()`.
+   * Shared storage format used by `SocialLoginProvider` so the key never has to be
+   * re-derived.
+   */
+  getStoredPublicKey(credentialId: string): Uint8Array | null {
+    const stored = localStorage.getItem(`webauthn_pubkey_${credentialId}`);
+    if (!stored) return null;
+    return new Uint8Array(this.base64ToArrayBuffer(stored));
+  }
+
+  /**
+   * Registration-time safety check: sign a fresh challenge with the just-created
+   * credential and verify the signature against the public key we extracted. This
+   * catches a mis-parsed or mismatched public key before the wallet is ever
+   * considered usable, rather than failing silently on the first real signature.
+   *
+   * @throws if the assertion ceremony is cancelled or the signature does not verify.
+   */
+  private async verifyRegistrationSelfCheck(
+    credential: PublicKeyCredential,
+    publicKey: Uint8Array
+  ): Promise<void> {
+    const challenge = this.generateChallenge();
+
+    const assertion = (await navigator.credentials.get({
+      publicKey: {
+        challenge,
+        rpId: this.rpId,
+        allowCredentials: [{ type: 'public-key', id: credential.rawId }],
+        userVerification: 'required',
+        timeout: 60000,
+      },
+    })) as PublicKeyCredential | null;
+
+    if (!assertion) {
+      throw new Error(
+        'registerCredential: self-check assertion was cancelled — refusing to register a ' +
+        'credential whose public key has not been verified.'
+      );
+    }
+
+    const response = assertion.response as AuthenticatorAssertionResponse;
+    const signature = convertSignatureDERtoCompact(response.signature);
+    const clientDataHash = await crypto.subtle.digest('SHA-256', response.clientDataJSON);
+    const signedData = concatUint8Arrays(
+      new Uint8Array(response.authenticatorData),
+      new Uint8Array(clientDataHash)
+    );
+
+    const cryptoKey = await crypto.subtle.importKey(
+      'raw',
+      publicKey.buffer as ArrayBuffer,
+      { name: 'ECDSA', namedCurve: 'P-256' },
+      false,
+      ['verify']
+    );
+
+    const verified = await crypto.subtle.verify(
+      { name: 'ECDSA', hash: 'SHA-256' },
+      cryptoKey,
+      signature.buffer as ArrayBuffer,
+      signedData.buffer as ArrayBuffer
+    );
+
+    if (!verified) {
+      throw new Error(
+        'registerCredential: self-check failed — the signature does not verify against the ' +
+        'extracted public key. Refusing to register an unusable wallet signer.'
+      );
+    }
+  }
+
+  /**
+   * Persist the public key alongside its credential id, using the same localStorage-based
+   * format that `getStoredPublicKey()` reads from.
+   */
+  private storePublicKey(credentialId: string, publicKey: Uint8Array): void {
+    localStorage.setItem(
+      `webauthn_pubkey_${credentialId}`,
+      this.arrayBufferToBase64(publicKey.buffer as ArrayBuffer)
+    );
   }
 
   async removeCredential(id: string): Promise<boolean> {

--- a/packages/core/wallet/auth/src/tests/SocialLoginProvider.test.ts
+++ b/packages/core/wallet/auth/src/tests/SocialLoginProvider.test.ts
@@ -47,6 +47,7 @@ if (typeof crypto === 'undefined') {
  */
 class MockWebAuthNProvider extends WebAuthNProvider {
   private mockCredentials: Map<string, BiometricCredential> = new Map();
+  private mockPublicKeys: Map<string, Uint8Array> = new Map();
   private shouldAuthSucceed = true;
   private mockCredentialId = 'mock-credential-id-123';
 
@@ -63,11 +64,23 @@ class MockWebAuthNProvider extends WebAuthNProvider {
     };
 
     this.mockCredentials.set(credential.id, credential);
-    
+
+    // A fixed, valid-shaped 65-byte uncompressed P-256 point — stands in for the real
+    // key that WebAuthNProvider.registerCredential() extracts and self-checks before
+    // persisting it via storePublicKey().
+    const publicKey = new Uint8Array(65);
+    publicKey[0] = 0x04;
+    publicKey.set(new Uint8Array(64).fill(0x11), 1);
+    this.mockPublicKeys.set(credential.id, publicKey);
+
     // Store in localStorage to simulate real behavior
     localStorage.setItem('webauthn_credentials', JSON.stringify([credential.id]));
 
     return credential;
+  }
+
+  getStoredPublicKey(credentialId: string): Uint8Array | null {
+    return this.mockPublicKeys.get(credentialId) ?? null;
   }
 
   async authenticate(prompt: string): Promise<BiometricAuthResult> {
@@ -101,6 +114,7 @@ class MockWebAuthNProvider extends WebAuthNProvider {
 
   clearCredentials(): void {
     this.mockCredentials.clear();
+    this.mockPublicKeys.clear();
     localStorage.removeItem('webauthn_credentials');
   }
 }
@@ -338,6 +352,14 @@ describe('SocialLoginProvider', () => {
 
       await expect(socialLogin.onboard('unsupported-user')).rejects.toThrow(
         'WebAuthn not supported'
+      );
+    });
+
+    it('should throw if the credential was registered but no public key was persisted', async () => {
+      jest.spyOn(mockWebAuthn, 'getStoredPublicKey').mockReturnValueOnce(null);
+
+      await expect(socialLogin.onboard('user-missing-key')).rejects.toThrow(
+        /no public key found for credential/
       );
     });
 

--- a/packages/core/wallet/auth/src/tests/WebAuthNProvider.test.ts
+++ b/packages/core/wallet/auth/src/tests/WebAuthNProvider.test.ts
@@ -1,7 +1,17 @@
+import { webcrypto } from 'node:crypto';
 import {
   extractPublicKey,
   convertSignatureDERtoCompact,
+  WebAuthNProvider,
 } from '../providers/WebAuthNProvider';
+
+// jsdom doesn't provide TextEncoder/TextDecoder globally.
+if (typeof TextEncoder === 'undefined') {
+  (global as any).TextEncoder = require('util').TextEncoder;
+}
+if (typeof TextDecoder === 'undefined') {
+  (global as any).TextDecoder = require('util').TextDecoder;
+}
 
 const SPKI_HEX =
   '3049' +
@@ -13,6 +23,10 @@ const SPKI_HEX =
     '04' +
     '60fed4ba255a9d31c961eb74c6356d68c049b8923b61fa6ce669622e60f29fb6' +
     '7903fe1008b8bc99a41ae9e95628bc64f2f1b20c2d7e9f5177a3c294d4462299';
+
+// The fixed 26-byte SPKI header for an EC P-256 SubjectPublicKeyInfo — everything in
+// SPKI_HEX up to (not including) the raw uncompressed point.
+const SPKI_HEADER_HEX = SPKI_HEX.slice(0, 52);
 
 const EXPECTED_PUBLIC_KEY_HEX =
   '04' +
@@ -48,6 +62,17 @@ function bufferToHex(buf: Uint8Array): string {
   return Array.from(buf).map(b => b.toString(16).padStart(2, '0')).join('');
 }
 
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, p) => sum + p.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
 function makeRegistrationCredential(spkiHex: string): PublicKeyCredential {
   const spki = hexToBuffer(spkiHex);
   return {
@@ -78,6 +103,115 @@ function makeAssertionCredential(): PublicKeyCredential {
   } as unknown as PublicKeyCredential;
 }
 
+// ── Minimal CBOR encoder — the mirror image of the decoder under test, used only
+// to build attestationObject/authData/COSE_Key fixtures with real P-256 bytes. ──
+
+function encodeHeader(majorType: number, n: number): Uint8Array {
+  if (n < 24) return Uint8Array.of((majorType << 5) | n);
+  if (n < 256) return Uint8Array.of((majorType << 5) | 24, n);
+  if (n < 65536) {
+    const buf = new Uint8Array(3);
+    buf[0] = (majorType << 5) | 25;
+    new DataView(buf.buffer).setUint16(1, n);
+    return buf;
+  }
+  throw new Error('encodeHeader: fixture value too large');
+}
+
+function encodeCBORUint(n: number): Uint8Array {
+  return encodeHeader(0, n);
+}
+
+function encodeCBORNegInt(v: number): Uint8Array {
+  return encodeHeader(1, -1 - v);
+}
+
+function encodeCBORByteString(bytes: Uint8Array): Uint8Array {
+  return concatBytes(encodeHeader(2, bytes.length), bytes);
+}
+
+function encodeCBORTextString(str: string): Uint8Array {
+  const bytes = new TextEncoder().encode(str);
+  return concatBytes(encodeHeader(3, bytes.length), bytes);
+}
+
+function encodeCBORMapHeader(count: number): Uint8Array {
+  return encodeHeader(5, count);
+}
+
+/** Build a CBOR-encoded COSE_Key for an EC2 key with the given alg/crv/x/y. */
+function buildCoseKey(opts: { alg: number; crv?: number; x: Uint8Array; y: Uint8Array }): Uint8Array {
+  return concatBytes(
+    encodeCBORMapHeader(5),
+    encodeCBORUint(1), encodeCBORUint(2), // kty: EC2
+    encodeCBORUint(3), encodeCBORNegInt(opts.alg), // alg
+    encodeCBORNegInt(-1), encodeCBORUint(opts.crv ?? 1), // crv: P-256
+    encodeCBORNegInt(-2), encodeCBORByteString(opts.x), // x
+    encodeCBORNegInt(-3), encodeCBORByteString(opts.y), // y
+  );
+}
+
+/** Build WebAuthn authData bytes wrapping the given CBOR-encoded COSE_Key. */
+function buildAuthData(coseKey: Uint8Array, opts: { flags?: number } = {}): Uint8Array {
+  const rpIdHash = new Uint8Array(32).fill(0xab);
+  const flags = Uint8Array.of(opts.flags ?? 0x45); // UP | UV | AT
+  const signCount = Uint8Array.of(0, 0, 0, 1);
+  const aaguid = new Uint8Array(16).fill(0);
+  const credentialId = new Uint8Array(16).fill(0xcd);
+  const credentialIdLength = Uint8Array.of((credentialId.length >> 8) & 0xff, credentialId.length & 0xff);
+  return concatBytes(rpIdHash, flags, signCount, aaguid, credentialIdLength, credentialId, coseKey);
+}
+
+/** Build a CBOR-encoded attestationObject { fmt: "none", attStmt: {}, authData } fixture. */
+function buildAttestationObject(authData: Uint8Array): ArrayBuffer {
+  const map = concatBytes(
+    encodeCBORMapHeader(3),
+    encodeCBORTextString('fmt'), encodeCBORTextString('none'),
+    encodeCBORTextString('attStmt'), encodeCBORMapHeader(0),
+    encodeCBORTextString('authData'), encodeCBORByteString(authData),
+  );
+  return map.buffer as ArrayBuffer;
+}
+
+/** x/y coordinates matching EXPECTED_PUBLIC_KEY_HEX, reused across fixtures for consistency. */
+const expectedPoint = new Uint8Array(hexToBuffer(EXPECTED_PUBLIC_KEY_HEX));
+const X_COORD = expectedPoint.slice(1, 33);
+const Y_COORD = expectedPoint.slice(33, 65);
+
+function makeFallbackRegistrationCredential(
+  attestationObject: ArrayBuffer,
+  opts: {
+    /** Simulates a browser whose response has a getPublicKey() that returns null. */
+    getPublicKeyReturnsNull?: boolean;
+    /** Simulates a browser that doesn't implement getPublicKey() at all. */
+    noGetPublicKey?: boolean;
+    getPublicKeyAlgorithm?: number;
+  } = {}
+): PublicKeyCredential {
+  const response: Record<string, unknown> = {
+    attestationObject,
+    clientDataJSON: new ArrayBuffer(0),
+  };
+
+  if (opts.getPublicKeyReturnsNull) {
+    response.getPublicKey = () => null;
+  } else if (!opts.noGetPublicKey) {
+    response.getPublicKey = () => null;
+  }
+
+  if (opts.getPublicKeyAlgorithm !== undefined) {
+    response.getPublicKeyAlgorithm = () => opts.getPublicKeyAlgorithm;
+  }
+
+  return {
+    id: 'mock-credential-id',
+    rawId: new ArrayBuffer(16),
+    type: 'public-key',
+    response: response as unknown as AuthenticatorAttestationResponse,
+    getClientExtensionResults: () => ({}),
+  } as unknown as PublicKeyCredential;
+}
+
 describe('extractPublicKey()', () => {
   it('returns a 65-byte Uint8Array', () => {
     const key = extractPublicKey(makeRegistrationCredential(SPKI_HEX));
@@ -103,18 +237,10 @@ describe('extractPublicKey()', () => {
     expect(key2[0]).toBe(0x04);
   });
 
-  it('throws when response is an assertion (no getPublicKey method)', () => {
+  it('throws when response is an assertion (no getPublicKey method, no attestationObject)', () => {
     expect(() => extractPublicKey(makeAssertionCredential())).toThrow(
       /not an AuthenticatorAttestationResponse/
     );
-  });
-
-  it('throws when getPublicKey() returns null', () => {
-    const credential = {
-      ...makeRegistrationCredential(SPKI_HEX),
-      response: { getPublicKey: () => null } as unknown as AuthenticatorAttestationResponse,
-    } as unknown as PublicKeyCredential;
-    expect(() => extractPublicKey(credential)).toThrow(/getPublicKey\(\) returned null/);
   });
 
   it('throws when SPKI blob is too short', () => {
@@ -127,6 +253,69 @@ describe('extractPublicKey()', () => {
     spkiBytes[26] = 0x02;
     expect(() => extractPublicKey(makeRegistrationCredential(bufferToHex(spkiBytes))))
       .toThrow(/0x02/);
+  });
+
+  it('rejects a non-ES256 algorithm reported via getPublicKeyAlgorithm(), before parsing', () => {
+    const credential = makeFallbackRegistrationCredential(new ArrayBuffer(0), {
+      noGetPublicKey: true,
+      getPublicKeyAlgorithm: -257, // RS256
+    });
+    expect(() => extractPublicKey(credential)).toThrow(
+      /unsupported public key algorithm -257/
+    );
+  });
+
+  describe('CBOR attestationObject fallback', () => {
+    function fixtureWithCoseKey(alg: number, crv = 1): ArrayBuffer {
+      const coseKey = buildCoseKey({ alg, crv, x: X_COORD, y: Y_COORD });
+      const authData = buildAuthData(coseKey);
+      return buildAttestationObject(authData);
+    }
+
+    it('falls back to attestationObject parsing when getPublicKey() is not implemented', () => {
+      const attestationObject = fixtureWithCoseKey(-7);
+      const credential = makeFallbackRegistrationCredential(attestationObject, { noGetPublicKey: true });
+      const key = extractPublicKey(credential);
+      expect(bufferToHex(key)).toBe(EXPECTED_PUBLIC_KEY_HEX);
+    });
+
+    it('falls back to attestationObject parsing when getPublicKey() returns null', () => {
+      const attestationObject = fixtureWithCoseKey(-7);
+      const credential = makeFallbackRegistrationCredential(attestationObject, { getPublicKeyReturnsNull: true });
+      const key = extractPublicKey(credential);
+      expect(bufferToHex(key)).toBe(EXPECTED_PUBLIC_KEY_HEX);
+    });
+
+    it('throws a clear error when getPublicKey() is unavailable and attestationObject is empty', () => {
+      const credential = makeFallbackRegistrationCredential(new ArrayBuffer(0), { noGetPublicKey: true });
+      expect(() => extractPublicKey(credential)).toThrow(/attestationObject is empty/);
+    });
+
+    it('rejects a non-ES256 COSE algorithm (RS256) found in the attestationObject', () => {
+      const attestationObject = fixtureWithCoseKey(-257);
+      const credential = makeFallbackRegistrationCredential(attestationObject, { noGetPublicKey: true });
+      expect(() => extractPublicKey(credential)).toThrow(
+        /unsupported COSE algorithm -257/
+      );
+    });
+
+    it('rejects a non-P-256 curve found in the attestationObject', () => {
+      const attestationObject = fixtureWithCoseKey(-7, 2); // crv 2 = P-384
+      const credential = makeFallbackRegistrationCredential(attestationObject, { noGetPublicKey: true });
+      expect(() => extractPublicKey(credential)).toThrow(
+        /unsupported COSE curve 2/
+      );
+    });
+
+    it('throws when the attested-credential-data flag is not set', () => {
+      const coseKey = buildCoseKey({ alg: -7, x: X_COORD, y: Y_COORD });
+      const authData = buildAuthData(coseKey, { flags: 0x05 }); // UP | UV, no AT
+      const attestationObject = buildAttestationObject(authData);
+      const credential = makeFallbackRegistrationCredential(attestationObject, { noGetPublicKey: true });
+      expect(() => extractPublicKey(credential)).toThrow(
+        /attested-credential-data flag/
+      );
+    });
   });
 });
 
@@ -194,5 +383,204 @@ describe('convertSignatureDERtoCompact()', () => {
     const bad = new Uint8Array(hexToBuffer(DER_70_HEX));
     bad[1] = 0xff;
     expect(() => convertSignatureDERtoCompact(bad.buffer)).toThrow(/exceeds buffer size/);
+  });
+});
+
+// ── registerCredential(): real-key extraction, self-check, and shared storage ──
+//
+// Uses Node's real WebCrypto (via node:crypto's `webcrypto`) so the self-check
+// exercises genuine P-256 ECDSA sign/verify rather than a mocked stub.
+
+describe('WebAuthNProvider.registerCredential()', () => {
+  class LocalStorageMock {
+    private store: Record<string, string> = {};
+    getItem(key: string): string | null { return this.store[key] ?? null; }
+    setItem(key: string, value: string): void { this.store[key] = value; }
+    removeItem(key: string): void { delete this.store[key]; }
+    clear(): void { this.store = {}; }
+  }
+
+  function derFromRawSignature(raw: Uint8Array): ArrayBuffer {
+    const r = raw.slice(0, 32);
+    const s = raw.slice(32, 64);
+
+    const encodeInt = (bytes: Uint8Array): Uint8Array => {
+      let start = 0;
+      while (start < bytes.length - 1 && bytes[start] === 0) start++;
+      let trimmed = bytes.slice(start);
+      if (trimmed[0] & 0x80) {
+        const padded = new Uint8Array(trimmed.length + 1);
+        padded.set(trimmed, 1);
+        trimmed = padded;
+      }
+      return concatBytes(Uint8Array.of(0x02, trimmed.length), trimmed);
+    };
+
+    const body = concatBytes(encodeInt(r), encodeInt(s));
+    return concatBytes(Uint8Array.of(0x30, body.length), body).buffer as ArrayBuffer;
+  }
+
+  async function signAssertion(
+    privateKey: CryptoKey,
+    authenticatorData: Uint8Array,
+    clientDataJSON: ArrayBuffer
+  ): Promise<ArrayBuffer> {
+    const clientDataHash = new Uint8Array(await webcrypto.subtle.digest('SHA-256', clientDataJSON));
+    const signedData = concatBytes(authenticatorData, clientDataHash);
+    const rawSignature = new Uint8Array(
+      await webcrypto.subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, privateKey, signedData)
+    );
+    return derFromRawSignature(rawSignature);
+  }
+
+  beforeEach(() => {
+    (global as any).localStorage = new LocalStorageMock();
+    Object.defineProperty(global, 'crypto', { value: webcrypto, writable: true, configurable: true });
+  });
+
+  it('extracts the real public key, runs the self-check, and persists it for later lookup', async () => {
+    const keyPair = (await webcrypto.subtle.generateKey(
+      { name: 'ECDSA', namedCurve: 'P-256' },
+      true,
+      ['sign', 'verify']
+    )) as CryptoKeyPair;
+    const rawPoint = new Uint8Array(await webcrypto.subtle.exportKey('raw', keyPair.publicKey));
+
+    const authenticatorData = new Uint8Array(37).fill(0x01);
+    const clientDataJSON = new TextEncoder().encode(JSON.stringify({ type: 'webauthn.get' })).buffer;
+
+    const create = jest.fn(async () => ({
+      id: 'cred-id',
+      rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+      type: 'public-key',
+      response: {
+        getPublicKey: () => concatBytes(new Uint8Array(hexToBuffer(SPKI_HEADER_HEX)), rawPoint).buffer,
+        attestationObject: new ArrayBuffer(0),
+        clientDataJSON: new ArrayBuffer(0),
+      },
+      getClientExtensionResults: () => ({}),
+    }));
+
+    const get = jest.fn(async () => ({
+      id: 'cred-id',
+      rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+      type: 'public-key',
+      response: {
+        authenticatorData: authenticatorData.buffer,
+        clientDataJSON,
+        signature: await signAssertion(keyPair.privateKey, authenticatorData, clientDataJSON),
+        userHandle: null,
+      },
+      getClientExtensionResults: () => ({}),
+    }));
+
+    Object.defineProperty(global, 'navigator', {
+      value: { credentials: { create, get } },
+      writable: true,
+      configurable: true,
+    });
+
+    const provider = new WebAuthNProvider({ rpId: 'localhost', rpName: 'Test' });
+    const credential = await provider.registerCredential('any');
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledTimes(1);
+
+    const storedKey = provider.getStoredPublicKey(credential.id);
+    expect(storedKey).not.toBeNull();
+    expect(bufferToHex(storedKey!)).toBe(bufferToHex(rawPoint));
+  });
+
+  it('returns null for a credential id that was never registered', () => {
+    const provider = new WebAuthNProvider({ rpId: 'localhost', rpName: 'Test' });
+    expect(provider.getStoredPublicKey('never-registered')).toBeNull();
+  });
+
+  it('rejects registration when the self-check signature does not verify against the extracted key', async () => {
+    const registeredKeyPair = (await webcrypto.subtle.generateKey(
+      { name: 'ECDSA', namedCurve: 'P-256' },
+      true,
+      ['sign', 'verify']
+    )) as CryptoKeyPair;
+    const wrongKeyPair = (await webcrypto.subtle.generateKey(
+      { name: 'ECDSA', namedCurve: 'P-256' },
+      true,
+      ['sign', 'verify']
+    )) as CryptoKeyPair;
+    const rawPoint = new Uint8Array(await webcrypto.subtle.exportKey('raw', registeredKeyPair.publicKey));
+
+    const authenticatorData = new Uint8Array(37).fill(0x02);
+    const clientDataJSON = new TextEncoder().encode(JSON.stringify({ type: 'webauthn.get' })).buffer;
+
+    const create = jest.fn(async () => ({
+      id: 'cred-id',
+      rawId: new Uint8Array([9, 9, 9, 9]).buffer,
+      type: 'public-key',
+      response: {
+        getPublicKey: () => concatBytes(new Uint8Array(hexToBuffer(SPKI_HEADER_HEX)), rawPoint).buffer,
+        attestationObject: new ArrayBuffer(0),
+        clientDataJSON: new ArrayBuffer(0),
+      },
+      getClientExtensionResults: () => ({}),
+    }));
+
+    // Signed with a *different* private key than the one whose public key was extracted.
+    const get = jest.fn(async () => ({
+      id: 'cred-id',
+      rawId: new Uint8Array([9, 9, 9, 9]).buffer,
+      type: 'public-key',
+      response: {
+        authenticatorData: authenticatorData.buffer,
+        clientDataJSON,
+        signature: await signAssertion(wrongKeyPair.privateKey, authenticatorData, clientDataJSON),
+        userHandle: null,
+      },
+      getClientExtensionResults: () => ({}),
+    }));
+
+    Object.defineProperty(global, 'navigator', {
+      value: { credentials: { create, get } },
+      writable: true,
+      configurable: true,
+    });
+
+    const provider = new WebAuthNProvider({ rpId: 'localhost', rpName: 'Test' });
+
+    await expect(provider.registerCredential('any')).rejects.toThrow(/self-check failed/);
+    expect(provider.getStoredPublicKey('cred-id')).toBeNull();
+  });
+
+  it('rejects registration when the self-check assertion ceremony is cancelled', async () => {
+    const keyPair = (await webcrypto.subtle.generateKey(
+      { name: 'ECDSA', namedCurve: 'P-256' },
+      true,
+      ['sign', 'verify']
+    )) as CryptoKeyPair;
+    const rawPoint = new Uint8Array(await webcrypto.subtle.exportKey('raw', keyPair.publicKey));
+
+    const create = jest.fn(async () => ({
+      id: 'cred-id',
+      rawId: new Uint8Array([5, 5, 5, 5]).buffer,
+      type: 'public-key',
+      response: {
+        getPublicKey: () => concatBytes(new Uint8Array(hexToBuffer(SPKI_HEADER_HEX)), rawPoint).buffer,
+        attestationObject: new ArrayBuffer(0),
+        clientDataJSON: new ArrayBuffer(0),
+      },
+      getClientExtensionResults: () => ({}),
+    }));
+
+    const get = jest.fn(async () => null);
+
+    Object.defineProperty(global, 'navigator', {
+      value: { credentials: { create, get } },
+      writable: true,
+      configurable: true,
+    });
+
+    const provider = new WebAuthNProvider({ rpId: 'localhost', rpName: 'Test' });
+
+    await expect(provider.registerCredential('any')).rejects.toThrow(/self-check assertion was cancelled/);
+    expect(provider.getStoredPublicKey('cred-id')).toBeNull();
   });
 });


### PR DESCRIPTION
# Pull Request

## 📋 Description

`SocialLoginProvider.extractPublicKey()` returned 65 random bytes (with a `0x04` prefix to look plausible) instead of the WebAuthn credential's real P-256 public key. Every social-login wallet was therefore bound to a signer that no private key corresponds to — the wallet's first real signature attempt would always fail verification, and any funds sent to it would be unrecoverable. The failure was silent at registration time.

This PR implements the real extraction in `WebAuthNProvider` (which already had a working `getPublicKey()`/SPKI path used by its own tests, but it was never wired into registration or shared with `SocialLoginProvider`) and adds the pieces the issue calls for:

- `extractPublicKey()` now falls back to decoding the CBOR `attestationObject` (`authData` → COSE_Key) when `getPublicKey()` isn't available, converting the COSE EC2/P-256 key to the raw 65-byte SEC-1 uncompressed form.
- Non-ES256 credentials are rejected explicitly (via `getPublicKeyAlgorithm()` when the browser exposes it, and via the COSE `alg` field in the CBOR fallback) rather than being coerced into an EC point.
- `registerCredential()` runs a registration-time self-check: it signs a fresh challenge with the just-created credential and verifies the signature against the extracted key with real ECDSA (`crypto.subtle`) before the credential is ever considered usable. If it doesn't verify, registration fails loudly and nothing is persisted.
- The verified key is persisted alongside the credential id in `WebAuthNProvider`'s own storage (`getStoredPublicKey()` / a new `storePublicKey()`), so it never has to be re-derived.
- `SocialLoginProvider.extractPublicKey()` is now a thin read of that shared, self-checked key instead of a random-bytes generator — this is the alignment the issue asked for between the two providers.

## 🔗 Related Issues

Closes #385

## 🧪 Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed (see test run output below; no browser/authenticator available in this environment for a live WebAuthn ceremony)
- [x] All tests passing locally

`WebAuthNProvider.test.ts` was extended with:
- CBOR `attestationObject` fixtures built from real P-256 x/y coordinates, proving the fallback path produces the exact same key as the `getPublicKey()`/SPKI path.
- Explicit rejection tests for non-ES256 algorithms (RS256) and non-P-256 curves, both at the `getPublicKeyAlgorithm()` and COSE_Key levels.
- An end-to-end `registerCredential()` suite using Node's real WebCrypto (`node:crypto`'s `webcrypto`) to generate a genuine P-256 keypair, sign a real ECDSA assertion, and confirm `getStoredPublicKey()` returns the exact extracted point — plus negative cases where the self-check correctly rejects a mismatched key or a cancelled assertion ceremony, storing nothing in either case.

`SocialLoginProvider.test.ts` was updated so its mock `WebAuthNProvider` exposes a stored public key through `getStoredPublicKey()` (mirroring the real provider's shared-storage contract) instead of the removed random-bytes placeholder, plus a new test for the "credential registered but no key persisted" error path.

```
npx jest src/tests/WebAuthNProvider.test.ts src/tests/SocialLoginProvider.test.ts
Test Suites: 2 passed, 2 total
Tests:       51 passed, 51 total
```

Three unrelated pre-existing failures in this package (`BiometricIntegration.test.ts`, `Sessionkeymanager.test.ts`, `LedgerWallet.test.ts` — all TypeScript strictness issues predating this change) were verified to also fail on `main` before this branch, and are untouched here.

## 📚 Documentation Updates

This is a security bug fix scoped to `packages/core/wallet/auth/`, which isn't one of the components with a dedicated documentation checklist in this template (stellar-sdk / invisible-wallet / automation / defi-protocols / oracles / contracts / cli). No public API surface changed shape — `SocialLoginProvider`'s public methods and `WebAuthNProvider`'s constructor/`registerCredential()` signature are unchanged; `WebAuthNProvider` gained one new public method (`getStoredPublicKey`), documented inline via JSDoc at its declaration.

- [x] Added inline JSDoc/TSDoc comments
- [ ] Updated `docs/AI.md` — N/A, no new cross-cutting pattern introduced
- [ ] Updated ARCHITECTURE.md — N/A, no architecture change
- [ ] Updated ROADMAP.md — left to maintainers/GrantFox tracking

## ⚠️ Breaking Changes

- [x] No breaking changes

`BiometricCredential` and the public constructor/method signatures used by callers are unchanged. `SocialLoginProvider.onboard()` will now throw if a credential's key wasn't persisted (previously it silently returned fake bytes), which is the intended fix, not a breaking API change.

## ✅ Final Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console.log or debug code left
- [x] Error handling implemented
- [x] Security reviewed (this *is* the security fix)
- [x] All tests passing locally