### PR TITLE
Fix/automation execution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18627,7 +18627,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -22909,6 +22908,7 @@
       "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
+        "@galaxy-kj/core-automation": "*",
         "@galaxy-kj/core-oracles": "*",
         "@supabase/supabase-js": "^2.38.0",
         "cors": "^2.8.5",

--- a/packages/api/websocket/package.json
+++ b/packages/api/websocket/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@galaxy-kj/core-oracles": "*",
+    "@galaxy-kj/core-automation": "*",
     "@supabase/supabase-js": "^2.38.0",
     "cors": "^2.8.5",
     "express": "^4.18.2",

--- a/packages/api/websocket/src/__tests__/handlers/automation-handler.test.ts
+++ b/packages/api/websocket/src/__tests__/handlers/automation-handler.test.ts
@@ -1,0 +1,288 @@
+import { Server } from 'socket.io';
+import { EventBroadcaster } from '../../services/event-broadcaster';
+import {
+  AutomationHandler,
+  AutomationRuntime,
+  ExecutionAttempt,
+  StoredAutomation,
+} from '../../handlers/automation-handler';
+
+const USER_ID = 'user-1';
+const AUTOMATION_ID = 'auto-1';
+const REAL_HASH = 'f9a3c1d4e8b7a6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1';
+
+function storedAutomation(
+  overrides: Partial<StoredAutomation> = {}
+): StoredAutomation {
+  return {
+    id: AUTOMATION_ID,
+    user_id: USER_ID,
+    wallet_id: 'wallet-1',
+    name: 'XLM stop',
+    status: 'active',
+    trigger_conditions: {
+      type: 'price',
+      assetIn: 'XLM',
+      assetOut: 'USDC',
+      condition: 'below',
+      threshold: '0.10',
+    },
+    action_config: {
+      executionType: 'STELLAR_PAYMENT',
+      paymentConfig: {
+        destination: 'GDEST',
+        asset: {},
+        amount: '1',
+      },
+    },
+    ...overrides,
+  };
+}
+
+function createQuery(result: { data: unknown; error: unknown }) {
+  const query: Record<string, unknown> = {};
+  query.select = jest.fn(() => query);
+  query.eq = jest.fn(() => query);
+  query.update = jest.fn(() => query);
+  query.order = jest.fn(() => query);
+  query.single = jest.fn(async () => result);
+  query.then = (
+    onFulfilled: (value: typeof result) => unknown,
+    onRejected?: (reason: unknown) => unknown
+  ) => Promise.resolve(result).then(onFulfilled, onRejected);
+  return query;
+}
+
+function createSupabase(automations: StoredAutomation[]) {
+  const query = createQuery({ data: automations, error: null });
+  return {
+    from: jest.fn(() => query),
+    channel: jest.fn(() => ({
+      on: jest.fn().mockReturnThis(),
+      subscribe: jest.fn(),
+    })),
+    removeAllChannels: jest.fn(),
+  };
+}
+
+function createRuntime(
+  overrides: Partial<AutomationRuntime> = {}
+): AutomationRuntime & { claims: string[] } {
+  const inFlight = new Set<string>();
+  const claims: string[] = [];
+
+  const runtime: AutomationRuntime & { claims: string[] } = {
+    claims,
+    isInFlight: jest.fn((id: string) => inFlight.has(id)),
+    tryBeginExecution: jest.fn(async (id: string) => {
+      if (inFlight.has(id)) {
+        return null;
+      }
+      inFlight.add(id);
+      claims.push(id);
+      const attempt: ExecutionAttempt = {
+        id: `attempt-${claims.length}`,
+        automationId: id,
+        status: 'pending',
+      };
+      return attempt;
+    }),
+    completeExecution: jest.fn((id: string) => {
+      inFlight.delete(id);
+    }),
+    confirmExecution: jest.fn(async () => undefined),
+    evaluatePersistedAutomation: jest.fn(async () => ({
+      met: true,
+      triggerType: 'PRICE',
+      triggerData: { assetIn: 'XLM' },
+    })),
+    executePersistedAutomation: jest.fn(async () => ({
+      ruleId: AUTOMATION_ID,
+      executionId: 'exec-1',
+      success: true,
+      timestamp: new Date(),
+      duration: 12,
+      transactionHash: REAL_HASH,
+    })),
+    ...overrides,
+  };
+
+  return runtime;
+}
+
+interface TestContext {
+  handler: AutomationHandler;
+  runtime: ReturnType<typeof createRuntime>;
+  emitted: Array<{ target: string; event: { type: string; data: Record<string, unknown> } }>;
+}
+
+function createContext(
+  automations: StoredAutomation[],
+  runtimeOverrides: Partial<AutomationRuntime> = {}
+): TestContext {
+  const emitted: TestContext['emitted'] = [];
+  const runtime = createRuntime(runtimeOverrides);
+
+  const server = {
+    on: jest.fn(),
+  } as unknown as Server;
+
+  const roomManager = {
+    joinRoom: jest.fn(),
+    leaveRoom: jest.fn(),
+  };
+
+  const eventBroadcaster = {
+    broadcastToUser: jest.fn(
+      async (userId: string, event: { type: string; data: Record<string, unknown> }) => {
+        emitted.push({ target: `user:${userId}`, event });
+      }
+    ),
+    broadcastToRoom: jest.fn(
+      async (room: string, event: { type: string; data: Record<string, unknown> }) => {
+        emitted.push({ target: room, event });
+      }
+    ),
+  } as unknown as EventBroadcaster;
+
+  const handler = new AutomationHandler(
+    server,
+    roomManager as never,
+    eventBroadcaster,
+    {
+      supabase: createSupabase(automations) as never,
+      runtime,
+      startMonitoring: false,
+      setupRealtime: false,
+    }
+  );
+
+  return { handler, runtime, emitted };
+}
+
+describe('AutomationHandler poll loop', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('emits triggered then executed with the real hash when the condition is met', async () => {
+    const { handler, runtime, emitted } = createContext([storedAutomation()]);
+
+    await handler.checkAutomationTriggers();
+
+    expect(runtime.executePersistedAutomation).toHaveBeenCalledTimes(1);
+    expect(runtime.confirmExecution).toHaveBeenCalledTimes(1);
+
+    const types = emitted.map(item => item.event.type);
+    expect(types).toEqual([
+      'automation:triggered',
+      'automation:triggered',
+      'automation:executed',
+      'automation:executed',
+    ]);
+
+    const executed = emitted.find(item => item.event.type === 'automation:executed');
+    expect(executed?.event.data.result).toBe('success');
+    expect(executed?.event.data.transactionHash).toBe(REAL_HASH);
+    expect(executed?.event.data.error).toBeUndefined();
+  });
+
+  it('emits no events when the condition is not met', async () => {
+    const { handler, runtime, emitted } = createContext([storedAutomation()], {
+      evaluatePersistedAutomation: jest.fn(async () => ({
+        met: false,
+        triggerType: 'PRICE',
+        triggerData: { reason: 'below_threshold_not_met' },
+      })),
+    });
+
+    await handler.checkAutomationTriggers();
+
+    expect(runtime.executePersistedAutomation).not.toHaveBeenCalled();
+    expect(emitted).toEqual([]);
+  });
+
+  it('emits executed with the real error and no fake hash on failure', async () => {
+    const { handler, emitted } = createContext([storedAutomation()], {
+      executePersistedAutomation: jest.fn(async () => ({
+        ruleId: AUTOMATION_ID,
+        executionId: 'exec-fail',
+        success: false,
+        timestamp: new Date(),
+        duration: 8,
+        error: new Error('horizon: tx_bad_seq'),
+      })),
+    });
+
+    await handler.checkAutomationTriggers();
+
+    const executed = emitted.find(item => item.event.type === 'automation:executed');
+    expect(executed?.event.data.result).toBe('failed');
+    expect(executed?.event.data.transactionHash).toBeUndefined();
+    expect(executed?.event.data.error).toBe('horizon: tx_bad_seq');
+  });
+
+  it('does not execute the same automation twice when poll cycles overlap', async () => {
+    let release: () => void = () => undefined;
+    const gate = new Promise<void>(resolve => {
+      release = resolve;
+    });
+
+    const { handler, runtime } = createContext([storedAutomation()], {
+      executePersistedAutomation: jest.fn(async () => {
+        await gate;
+        return {
+          ruleId: AUTOMATION_ID,
+          executionId: 'exec-1',
+          success: true,
+          timestamp: new Date(),
+          duration: 50,
+          transactionHash: REAL_HASH,
+        };
+      }),
+    });
+
+    const first = handler.checkAutomationTriggers();
+    const second = handler.checkAutomationTriggers();
+
+    release();
+    await Promise.all([first, second]);
+
+    expect(runtime.executePersistedAutomation).toHaveBeenCalledTimes(1);
+    expect(runtime.tryBeginExecution).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not double-execute when two batches run without the poll lock', async () => {
+    let release: () => void = () => undefined;
+    const gate = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    let started = 0;
+
+    const { handler, runtime } = createContext([storedAutomation()], {
+      executePersistedAutomation: jest.fn(async () => {
+        started += 1;
+        await gate;
+        return {
+          ruleId: AUTOMATION_ID,
+          executionId: 'exec-1',
+          success: true,
+          timestamp: new Date(),
+          duration: 50,
+          transactionHash: REAL_HASH,
+        };
+      }),
+    });
+
+    const automation = storedAutomation();
+    const first = handler.processActiveAutomations([automation]);
+    const second = handler.processActiveAutomations([automation]);
+
+    await Promise.resolve();
+    release();
+    await Promise.all([first, second]);
+
+    expect(started).toBe(1);
+    expect(runtime.executePersistedAutomation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/websocket/src/handlers/automation-handler.ts
+++ b/packages/api/websocket/src/handlers/automation-handler.ts
@@ -1,17 +1,93 @@
 /**
  * Automation Handler
- * 
- * This module handles automation rule events, triggers, executions,
- * and status updates for automated trading operations.
+ *
+ * Polls persisted automations, evaluates real trigger_conditions, and executes
+ * via AutomationService / ExecutionEngine (build → sign → submit).
+ *
+ * Idempotency:
+ * - `isPolling` plus schedule-next-after-complete prevent overlapping ticks.
+ * - Per-automation `pending → executing → submitted → resolved|failed` claims
+ *   (in memory + `automation_execution_attempts`) block duplicate submits.
+ * - A submitted row that already has `transaction_hash` is reused, never resent.
  */
 
+import { randomUUID } from 'crypto';
 import { Server, Socket } from 'socket.io';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import { ExtendedSocket, AutomationTriggeredEvent, AutomationExecutedEvent, AutomationErrorEvent } from '../types/websocket-types';
+import {
+  ExtendedSocket,
+  AutomationTriggeredEvent,
+  AutomationExecutedEvent,
+} from '../types/websocket-types';
 import { RoomManager } from '../services/room-manager';
 import { EventBroadcaster } from '../services/event-broadcaster';
 import { requireAuth } from '../middleware/auth';
 import { config } from '../config';
+import { createDefaultPriceAggregator } from '../services/market-data-source';
+
+export interface StoredAutomation {
+  id: string;
+  user_id: string;
+  wallet_id?: string | null;
+  name?: string | null;
+  status: string;
+  trigger_conditions: unknown;
+  action_config: unknown;
+  last_executed_at?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface TriggerEvaluationResult {
+  met: boolean;
+  triggerType: string;
+  triggerData: Record<string, unknown>;
+}
+
+export interface ExecutionAttempt {
+  id: string;
+  automationId: string;
+  status: 'pending' | 'executing' | 'submitted' | 'resolved' | 'failed';
+  transactionHash?: string;
+  error?: string;
+}
+
+export interface ExecutionResult {
+  ruleId: string;
+  executionId: string;
+  success: boolean;
+  timestamp: Date;
+  duration: number;
+  error?: Error;
+  transactionHash?: string;
+}
+
+/**
+ * Runtime used by the poll loop. Production wires AutomationService;
+ * tests inject a fake so evaluation/execution stay deterministic.
+ */
+export interface AutomationRuntime {
+  evaluatePersistedAutomation(
+    automation: StoredAutomation
+  ): Promise<TriggerEvaluationResult>;
+  executePersistedAutomation(
+    automation: StoredAutomation,
+    attemptId?: string
+  ): Promise<ExecutionResult>;
+  isInFlight(automationId: string): boolean;
+  tryBeginExecution(automationId: string): Promise<ExecutionAttempt | null>;
+  confirmExecution(attemptId: string, transactionHash?: string): Promise<void>;
+  completeExecution(automationId: string): void;
+}
+
+export interface AutomationHandlerOptions {
+  supabase?: SupabaseClient;
+  runtime?: AutomationRuntime;
+  pollIntervalMs?: number;
+  startMonitoring?: boolean;
+  setupRealtime?: boolean;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
 
 /**
  * Automation Handler Class
@@ -21,17 +97,35 @@ export class AutomationHandler {
   private roomManager: RoomManager;
   private eventBroadcaster: EventBroadcaster;
   private supabase: SupabaseClient;
-  private automationSubscriptions = new Map<string, any>();
-  private activeAutomations = new Map<string, any>();
+  private automationSubscriptions = new Map<string, unknown>();
+  private activeAutomations = new Map<string, StoredAutomation & { lastActivity?: number }>();
+  private runtime?: AutomationRuntime;
+  private runtimePromise?: Promise<AutomationRuntime>;
+  private readonly pollIntervalMs: number;
+  private pollTimer: ReturnType<typeof setTimeout> | null = null;
+  private cleanupTimer: ReturnType<typeof setInterval> | null = null;
+  private isPolling = false;
+  private stopped = false;
 
-  constructor(server: Server, roomManager: RoomManager, eventBroadcaster: EventBroadcaster) {
+  constructor(
+    server: Server,
+    roomManager: RoomManager,
+    eventBroadcaster: EventBroadcaster,
+    options: AutomationHandlerOptions = {}
+  ) {
     this.server = server;
     this.roomManager = roomManager;
     this.eventBroadcaster = eventBroadcaster;
-    this.supabase = createClient(config.supabase.url, config.supabase.serviceRoleKey);
+    this.supabase = options.supabase ?? createClient(config.supabase.url, config.supabase.serviceRoleKey);
+    this.runtime = options.runtime;
+    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
     this.setupAutomationHandlers();
-    this.setupSupabaseRealtime();
-    this.startAutomationMonitoring();
+    if (options.setupRealtime !== false) {
+      this.setupSupabaseRealtime();
+    }
+    if (options.startMonitoring !== false) {
+      this.startAutomationMonitoring();
+    }
   }
 
   /**
@@ -111,18 +205,36 @@ export class AutomationHandler {
   }
 
   /**
-   * Start automation monitoring
+   * Start automation monitoring.
+   *
+   * Uses schedule-next-after-complete instead of a raw setInterval so a slow
+   * evaluation cycle cannot overlap the next tick. processActiveAutomations
+   * still has per-automation locks for the case of concurrent callers (tests).
    */
   private startAutomationMonitoring(): void {
-    // Monitor automation triggers every 30 seconds
-    setInterval(() => {
-      this.checkAutomationTriggers();
-    }, 30000);
+    this.schedulePoll();
 
-    // Clean up inactive automations every 5 minutes
-    setInterval(() => {
+    this.cleanupTimer = setInterval(() => {
       this.cleanupInactiveAutomations();
     }, 300000);
+  }
+
+  private schedulePoll(): void {
+    if (this.stopped) {
+      return;
+    }
+
+    this.pollTimer = setTimeout(() => {
+      void this.runPollCycle();
+    }, this.pollIntervalMs);
+  }
+
+  private async runPollCycle(): Promise<void> {
+    try {
+      await this.checkAutomationTriggers();
+    } finally {
+      this.schedulePoll();
+    }
   }
 
   /**
@@ -437,57 +549,23 @@ export class AutomationHandler {
         return;
       }
 
-      const automation = newRecord || oldRecord;
-      const userId = automation.user_id;
+      const automation = (newRecord || oldRecord) as StoredAutomation;
       const automationId = automation.id;
 
-      // Create appropriate event based on change
-      let event: AutomationTriggeredEvent | AutomationExecutedEvent | AutomationErrorEvent | undefined;
-
       if (eventType === 'INSERT') {
-        // New automation created
-        return; // No event needed for creation
-      } else if (eventType === 'UPDATE') {
-        // Check if status changed
-        if (newRecord.status !== oldRecord.status) {
-          if (newRecord.status === 'active') {
-            // Automation activated
-            this.activeAutomations.set(automationId, automation);
-          } else if (newRecord.status === 'paused') {
-            // Automation paused
-            this.activeAutomations.delete(automationId);
-          }
-        }
+        return;
+      }
 
-        // Check if last_executed_at changed (execution occurred)
-        if (newRecord.last_executed_at !== oldRecord.last_executed_at) {
-          event = {
-            id: `automation-executed-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-            timestamp: Date.now(),
-            source: 'galaxy-websocket',
-            type: 'automation:executed',
-            data: {
-              automationId,
-              userId,
-              walletId: automation.wallet_id,
-              result: 'success', // TODO: Determine actual result
-              executedAt: Date.now()
-            }
-          };
+      if (eventType === 'UPDATE' && newRecord.status !== oldRecord.status) {
+        if (newRecord.status === 'active') {
+          this.activeAutomations.set(automationId, automation);
+        } else if (newRecord.status === 'paused') {
+          this.activeAutomations.delete(automationId);
         }
       }
 
-      if (event) {
-        // Broadcast to user-specific room
-        await this.eventBroadcaster.broadcastToUser(userId, event);
-
-        // Broadcast to automation-specific room
-        const automationRoomName = `automation:${automationId}`;
-        await this.eventBroadcaster.broadcastToRoom(automationRoomName, event);
-
-        console.log(`Broadcasted automation ${event.type} for ${automationId}`);
-      }
-
+      // Execution events are emitted by the poll loop after a real
+      // transaction result is known. Do not synthesize them here.
     } catch (error) {
       console.error('Failed to handle automation change:', error);
     }
@@ -496,125 +574,233 @@ export class AutomationHandler {
   /**
    * Check automation triggers
    */
-  private async checkAutomationTriggers(): Promise<void> {
+  async checkAutomationTriggers(): Promise<void> {
+    if (this.isPolling) {
+      console.warn('[automation-handler] skipping overlapping poll cycle');
+      return;
+    }
+
+    this.isPolling = true;
     try {
-      // Get all active automations
       const { data: automations, error } = await this.supabase
         .from('automations')
         .select('*')
         .eq('status', 'active');
 
       if (error || !automations) {
+        if (error) {
+          console.error('Failed to load active automations:', error);
+        }
         return;
       }
 
-      for (const automation of automations) {
-        try {
-          // Check if automation should trigger
-          const shouldTrigger = await this.evaluateTriggerConditions(automation);
-          
-          if (shouldTrigger) {
-            await this.triggerAutomation(automation);
-          }
-        } catch (error) {
-          console.error(`Failed to check triggers for automation ${automation.id}:`, error);
-        }
-      }
+      await this.processActiveAutomations(automations as StoredAutomation[]);
     } catch (error) {
       console.error('Failed to check automation triggers:', error);
+    } finally {
+      this.isPolling = false;
     }
   }
 
   /**
-   * Evaluate trigger conditions for an automation
-   * 
-   * @param automation - Automation object
-   * @returns Promise<boolean> - Whether automation should trigger
+   * Evaluate and execute a batch of automations. Safe to call concurrently:
+   * per-automation claim prevents duplicate submits.
    */
-  private async evaluateTriggerConditions(automation: any): Promise<boolean> {
-    // TODO: Implement actual trigger condition evaluation
-    // This is a placeholder that randomly triggers automations
-    return Math.random() < 0.1; // 10% chance to trigger
-  }
-
-  /**
-   * Trigger an automation
-   * 
-   * @param automation - Automation object
-   */
-  private async triggerAutomation(automation: any): Promise<void> {
-    try {
-      // Create trigger event
-      const event: AutomationTriggeredEvent = {
-        id: `automation-triggered-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-        timestamp: Date.now(),
-        source: 'galaxy-websocket',
-        type: 'automation:triggered',
-        data: {
-          automationId: automation.id,
-          userId: automation.user_id,
-          walletId: automation.wallet_id,
-          triggerCondition: JSON.stringify(automation.trigger_conditions),
-          triggerData: {}
-        }
-      };
-
-      // Broadcast trigger event
-      await this.eventBroadcaster.broadcastToUser(automation.user_id, event);
-      await this.eventBroadcaster.broadcastToRoom(`automation:${automation.id}`, event);
-
-      // Simulate execution
-      setTimeout(async () => {
-        await this.simulateAutomationExecution(automation);
-      }, 1000);
-
-      console.log(`Triggered automation ${automation.id}`);
-
-    } catch (error) {
-      console.error(`Failed to trigger automation ${automation.id}:`, error);
+  async processActiveAutomations(automations: StoredAutomation[]): Promise<void> {
+    for (const automation of automations) {
+      try {
+        await this.processAutomation(automation);
+      } catch (error) {
+        console.error(`Failed to check triggers for automation ${automation.id}:`, error);
+      }
     }
   }
 
-  /**
-   * Simulate automation execution
-   * 
-   * @param automation - Automation object
-   */
-  private async simulateAutomationExecution(automation: any): Promise<void> {
+  private async processAutomation(automation: StoredAutomation): Promise<void> {
+    const runtime = await this.getRuntime();
+
+    if (runtime.isInFlight(automation.id)) {
+      console.info(
+        `[automation ${automation.id}] skip: previous execution still pending/executing`
+      );
+      return;
+    }
+
+    const evaluation = await runtime.evaluatePersistedAutomation(automation);
+    if (!evaluation.met) {
+      return;
+    }
+
+    const attempt = await runtime.tryBeginExecution(automation.id);
+    if (!attempt) {
+      console.warn(
+        `[automation ${automation.id}] skip: could not claim execution lock`
+      );
+      return;
+    }
+
     try {
-      const success = Math.random() > 0.2; // 80% success rate
+      if (attempt.transactionHash) {
+        console.info(
+          `[automation ${automation.id}] recovering submitted hash ${attempt.transactionHash}`
+        );
+        const result = await runtime.executePersistedAutomation(
+          automation,
+          attempt.id
+        );
+        await this.emitExecuted(automation, result);
+        await runtime.confirmExecution(attempt.id, result.transactionHash);
+        return;
+      }
 
-      const event: AutomationExecutedEvent = {
-        id: `automation-executed-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-        timestamp: Date.now(),
-        source: 'galaxy-websocket',
-        type: 'automation:executed',
-        data: {
-          automationId: automation.id,
-          userId: automation.user_id,
-          walletId: automation.wallet_id,
-          result: success ? 'success' : 'failed',
-          executedAt: Date.now(),
-          transactionHash: success ? `tx_${Math.random().toString(36).substr(2, 9)}` : undefined,
-          error: success ? undefined : 'Simulated execution failure'
-        }
-      };
+      await this.emitTriggered(automation, evaluation);
 
-      // Broadcast execution event
-      await this.eventBroadcaster.broadcastToUser(automation.user_id, event);
-      await this.eventBroadcaster.broadcastToRoom(`automation:${automation.id}`, event);
+      const result = await runtime.executePersistedAutomation(automation, attempt.id);
+      await this.emitExecuted(automation, result);
+      await runtime.confirmExecution(attempt.id, result.transactionHash);
 
-      // Update last executed timestamp
       await this.supabase
         .from('automations')
         .update({ last_executed_at: new Date().toISOString() })
         .eq('id', automation.id);
-
-      console.log(`Executed automation ${automation.id} (${success ? 'success' : 'failed'})`);
-
-    } catch (error) {
-      console.error(`Failed to simulate execution for automation ${automation.id}:`, error);
+    } finally {
+      runtime.completeExecution(automation.id);
     }
+  }
+
+  /**
+   * Evaluate trigger conditions for an automation.
+   */
+  async evaluateTriggerConditions(automation: StoredAutomation): Promise<boolean> {
+    const runtime = await this.getRuntime();
+    const evaluation = await runtime.evaluatePersistedAutomation(automation);
+    return evaluation.met;
+  }
+
+  private async emitTriggered(
+    automation: StoredAutomation,
+    evaluation: TriggerEvaluationResult
+  ): Promise<void> {
+    const event: AutomationTriggeredEvent = {
+      id: randomUUID(),
+      timestamp: Date.now(),
+      source: 'galaxy-websocket',
+      type: 'automation:triggered',
+      data: {
+        automationId: automation.id,
+        userId: automation.user_id,
+        walletId: automation.wallet_id ?? '',
+        triggerCondition: JSON.stringify(automation.trigger_conditions),
+        triggerData: evaluation.triggerData,
+      },
+    };
+
+    await this.eventBroadcaster.broadcastToUser(automation.user_id, event);
+    await this.eventBroadcaster.broadcastToRoom(`automation:${automation.id}`, event);
+    console.info(`[automation ${automation.id}] emitted automation:triggered`);
+  }
+
+  private async emitExecuted(
+    automation: StoredAutomation,
+    result: ExecutionResult
+  ): Promise<void> {
+    const event: AutomationExecutedEvent = {
+      id: randomUUID(),
+      timestamp: Date.now(),
+      source: 'galaxy-websocket',
+      type: 'automation:executed',
+      data: {
+        automationId: automation.id,
+        userId: automation.user_id,
+        walletId: automation.wallet_id ?? '',
+        result: result.success ? 'success' : 'failed',
+        executedAt: Date.now(),
+        transactionHash: result.success ? result.transactionHash : undefined,
+        error: result.success
+          ? undefined
+          : result.error?.message ?? 'Automation execution failed',
+      },
+    };
+
+    await this.eventBroadcaster.broadcastToUser(automation.user_id, event);
+    await this.eventBroadcaster.broadcastToRoom(`automation:${automation.id}`, event);
+    console.info(
+      `[automation ${automation.id}] emitted automation:executed ` +
+        `success=${result.success}` +
+        (result.transactionHash ? ` hash=${result.transactionHash}` : '') +
+        (result.error ? ` error=${result.error.message}` : '')
+    );
+  }
+
+  private async getRuntime(): Promise<AutomationRuntime> {
+    if (this.runtime) {
+      return this.runtime;
+    }
+
+    if (!this.runtimePromise) {
+      this.runtimePromise = this.createDefaultRuntime();
+    }
+
+    this.runtime = await this.runtimePromise;
+    return this.runtime;
+  }
+
+  private async createDefaultRuntime(): Promise<AutomationRuntime> {
+    const moduleName = '@galaxy-kj/core-automation';
+    const { AutomationService } = (await import(moduleName)) as {
+      AutomationService: new (config: {
+        network: {
+          type: 'PUBLIC' | 'TESTNET';
+          horizonUrl: string;
+          networkPassphrase: string;
+        };
+        sourceSecret?: string;
+        oracle?: {
+          getAggregatedPrices: (
+            symbols: string[]
+          ) => Promise<Array<{ symbol: string; price: number }>>;
+        };
+      }) => AutomationRuntime;
+    };
+
+    const isMainnet = config.stellar.network === 'mainnet';
+    let oracle:
+      | {
+          getAggregatedPrices: (
+            symbols: string[]
+          ) => Promise<Array<{ symbol: string; price: number }>>;
+        }
+      | undefined;
+
+    try {
+      const aggregator = await createDefaultPriceAggregator();
+      oracle = {
+        getAggregatedPrices: async (symbols: string[]) =>
+          Promise.all(
+            symbols.map(async symbol => {
+              const snapshot = await aggregator.getAggregatedPrice(symbol);
+              return { symbol, price: snapshot.price };
+            })
+          ),
+      };
+    } catch (error) {
+      console.warn(
+        '[automation-handler] price oracle unavailable; price triggers will not fire',
+        error
+      );
+    }
+
+    return new AutomationService({
+      network: {
+        type: isMainnet ? 'PUBLIC' : 'TESTNET',
+        horizonUrl: config.stellar.horizonUrl,
+        networkPassphrase: isMainnet
+          ? 'Public Global Stellar Network ; September 2015'
+          : 'Test SDF Network ; September 2015',
+      },
+      sourceSecret: process.env.AUTOMATION_SOURCE_SECRET || '',
+      oracle,
+    });
   }
 
   /**
@@ -625,7 +811,7 @@ export class AutomationHandler {
     const oneHourAgo = Date.now() - 3600000;
     
     for (const [automationId, automation] of this.activeAutomations.entries()) {
-      if (automation.lastActivity < oneHourAgo) {
+      if (automation.lastActivity !== undefined && automation.lastActivity < oneHourAgo) {
         this.activeAutomations.delete(automationId);
       }
     }
@@ -674,10 +860,18 @@ export class AutomationHandler {
    * Cleanup automation handler
    */
   public cleanup(): void {
-    // Unsubscribe from Supabase real-time
+    this.stopped = true;
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
+
     this.supabase.removeAllChannels();
-    
-    // Clear local data
+
     this.automationSubscriptions.clear();
     this.activeAutomations.clear();
   }

--- a/packages/core/automation/index.ts
+++ b/packages/core/automation/index.ts
@@ -18,5 +18,27 @@ export type { PriceTriggerConfig } from './src/triggers/price-trigger.js';
 export { EventTrigger } from './src/triggers/event-trigger.js';
 export type { EventFilter, EventTriggerOptions } from './src/triggers/event-trigger.js';
 
+export { VolumeTrigger, DefaultHorizonFetcher } from './src/triggers/volume-trigger.js';
+export type {
+  VolumeTrackConfig,
+  VolumeCheckResult,
+  VolumeTriggerOptions,
+  HorizonFetcher,
+} from './src/triggers/volume-trigger.js';
+
+export {
+  TriggerEvaluator,
+  parseActionConfig,
+  createDefaultTriggerEvaluator,
+} from './src/triggers/trigger-evaluator.js';
+export type {
+  TriggerEvaluatorDeps,
+  PriceTriggerLike,
+  VolumeTriggerLike,
+} from './src/triggers/trigger-evaluator.js';
+
+export { ExecutionAttemptRegistry } from './src/services/execution-attempt-registry.js';
+export type { AttemptStoreClient } from './src/services/execution-attempt-registry.js';
+
 import { AutomationService } from './src/services/automation.service.js';
 export default AutomationService;

--- a/packages/core/automation/jest.config.cjs
+++ b/packages/core/automation/jest.config.cjs
@@ -5,10 +5,12 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': ['ts-jest', {
       tsconfig: './tsconfig.test.json',
+      diagnostics: false,
     }],
   },
   moduleNameMapper: {
     '^@galaxy-kj/core-oracles$': '<rootDir>/../oracles/src/index.ts',
+    '^@galaxy-kj/core-stellar-sdk$': '<rootDir>/../stellar-sdk/src/index.ts',
     '^@galaxy-kj/core-stellar-sdk/soroban$': '<rootDir>/../stellar-sdk/src/soroban/index.ts',
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },

--- a/packages/core/automation/src/services/automation.service.ts
+++ b/packages/core/automation/src/services/automation.service.ts
@@ -11,14 +11,24 @@ import {
   AutomationMetrics,
   PriceConditionContext,
   PriceTriggerCondition,
+  StoredAutomation,
+  TriggerEvaluationResult,
   TriggerType,
   StellarNetwork,
+  ExecutionAttempt,
 } from '../types/automation-types.js';
 import { CronManager } from '../utils/cron-manager.js';
 import { ConditionEvaluator } from '../utils/condition-evaluator.js';
 import { ExecutionEngine } from '../utils/execution-engine.js';
 import { OracleAggregator } from '@galaxy-kj/core-oracles';
 import { supabaseClient } from '@galaxy-kj/core-stellar-sdk';
+import { PriceTrigger } from '../triggers/price-trigger.js';
+import { VolumeTrigger } from '../triggers/volume-trigger.js';
+import {
+  TriggerEvaluator,
+  parseActionConfig,
+} from '../triggers/trigger-evaluator.js';
+import { ExecutionAttemptRegistry } from './execution-attempt-registry.js';
 
 export interface AutomationServiceConfig {
   network?: StellarNetwork;
@@ -26,14 +36,17 @@ export interface AutomationServiceConfig {
   maxConcurrentExecutions?: number;
   executionTimeout?: number;
   enableMetrics?: boolean;
-  oracle?: OracleAggregator;
+  oracle?: Pick<OracleAggregator, 'getAggregatedPrices'>;
+  triggerEvaluator?: TriggerEvaluator;
+  attemptRegistry?: ExecutionAttemptRegistry;
+  volumeTrigger?: VolumeTrigger;
 }
 
 export class AutomationService extends EventEmitter {
   private cronManager: CronManager;
   private conditionEvaluator: ConditionEvaluator;
   private executionEngine: ExecutionEngine;
-  private oracle?: OracleAggregator;
+  private oracle?: Pick<OracleAggregator, 'getAggregatedPrices'>;
   private rules: Map<string, AutomationRule> = new Map();
   private metrics: Map<string, AutomationMetrics> = new Map();
   private activeExecutions: Set<string> = new Set();
@@ -48,6 +61,8 @@ export class AutomationService extends EventEmitter {
   private activeTimeouts: Map<string, NodeJS.Timeout> = new Map();
   private priceMonitorInterval?: NodeJS.Timeout;
   private supabase = supabaseClient;
+  private triggerEvaluator: TriggerEvaluator;
+  private attemptRegistry: ExecutionAttemptRegistry;
 
   constructor(config: AutomationServiceConfig = {}) {
     super();
@@ -73,6 +88,20 @@ export class AutomationService extends EventEmitter {
       this.network,
       this.config.sourceSecret
     );
+    this.attemptRegistry =
+      config.attemptRegistry ??
+      new ExecutionAttemptRegistry(this.supabase as never);
+    this.triggerEvaluator =
+      config.triggerEvaluator ??
+      new TriggerEvaluator({
+        priceTrigger: this.oracle
+          ? new PriceTrigger(this.oracle as OracleAggregator)
+          : undefined,
+        volumeTrigger:
+          config.volumeTrigger ??
+          new VolumeTrigger({ horizonUrl: this.network.horizonUrl }),
+        conditionEvaluator: this.conditionEvaluator,
+      });
 
     this.setupEventHandlers();
   }
@@ -487,6 +516,185 @@ export class AutomationService extends EventEmitter {
   }
 
   /**
+   * Evaluate persisted trigger_conditions using PriceTrigger / VolumeTrigger /
+   * ConditionEvaluator. Never uses randomness — unmet conditions return false.
+   */
+  async evaluatePersistedAutomation(
+    automation: StoredAutomation
+  ): Promise<TriggerEvaluationResult> {
+    const baseContext: ExecutionContext = {
+      ruleId: automation.id,
+      userId: automation.user_id,
+      timestamp: new Date(),
+      stellarData: {
+        networkPassphrase: this.network.networkPassphrase,
+      },
+      customData: isRecord(automation.metadata) ? automation.metadata : undefined,
+    };
+
+    const context = await this.attachLivePricesFromConditions(
+      automation.trigger_conditions,
+      baseContext
+    );
+
+    return this.triggerEvaluator.evaluateStored(automation, context);
+  }
+
+  isInFlight(automationId: string): boolean {
+    return this.attemptRegistry.isInFlight(automationId);
+  }
+
+  async tryBeginExecution(
+    automationId: string
+  ): Promise<ExecutionAttempt | null> {
+    return this.attemptRegistry.tryClaim(automationId);
+  }
+
+  completeExecution(automationId: string): void {
+    this.attemptRegistry.release(automationId);
+  }
+
+  async confirmExecution(
+    attemptId: string,
+    transactionHash?: string
+  ): Promise<void> {
+    const attempt = this.attemptRegistry.get(attemptId);
+    if (!attempt || attempt.status === 'failed' || attempt.status === 'resolved') {
+      return;
+    }
+
+    await this.attemptRegistry.markResolved(attemptId, transactionHash);
+  }
+
+  /**
+   * Build, sign, and submit the automation action via ExecutionEngine.
+   * Does not re-evaluate triggers — the caller must have already done that.
+   * Reuses a submitted transaction hash instead of sending a second tx.
+   */
+  async executePersistedAutomation(
+    automation: StoredAutomation,
+    attemptId?: string
+  ): Promise<ExecutionResult> {
+    const inFlight = attemptId
+      ? this.attemptRegistry.get(attemptId)
+      : this.attemptRegistry.getInFlightAttempt(automation.id);
+
+    if (inFlight?.transactionHash) {
+      console.info(
+        `[automation ${automation.id}] skipping submit; reuse hash ${inFlight.transactionHash}`
+      );
+      return {
+        ruleId: automation.id,
+        executionId: inFlight.id,
+        success: true,
+        timestamp: new Date(),
+        duration: 0,
+        transactionHash: inFlight.transactionHash,
+      };
+    }
+
+    const resolvedAttemptId = inFlight?.id ?? attemptId;
+    if (resolvedAttemptId) {
+      await this.attemptRegistry.markExecuting(resolvedAttemptId);
+    }
+
+    try {
+      const { executionType, executionConfig } = parseActionConfig(
+        automation.action_config
+      );
+
+      const context: ExecutionContext = {
+        ruleId: automation.id,
+        userId: automation.user_id,
+        timestamp: new Date(),
+        stellarData: {
+          networkPassphrase: this.network.networkPassphrase,
+        },
+        customData: {
+          walletId: automation.wallet_id,
+          attemptId: resolvedAttemptId,
+        },
+      };
+
+      const executionPromise = this.executionEngine.execute(
+        executionType,
+        executionConfig,
+        context
+      );
+
+      const timeoutPromise = new Promise<ExecutionResult>((_, reject) => {
+        setTimeout(() => {
+          reject(new Error('Execution timeout'));
+        }, this.config.executionTimeout);
+      });
+
+      const result = await Promise.race([executionPromise, timeoutPromise]);
+      const transactionHash = result.transactionHash ?? extractHash(result.result);
+
+      if (resolvedAttemptId && transactionHash) {
+        await this.attemptRegistry.markSubmitted(resolvedAttemptId, transactionHash);
+      }
+
+      if (resolvedAttemptId && !result.success) {
+        await this.attemptRegistry.markFailed(
+          resolvedAttemptId,
+          result.error?.message ?? 'execution_failed'
+        );
+      } else if (resolvedAttemptId && result.success && !transactionHash) {
+        await this.attemptRegistry.markResolved(resolvedAttemptId);
+      }
+
+      return {
+        ...result,
+        ruleId: automation.id,
+        transactionHash,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'execution_error';
+      if (resolvedAttemptId) {
+        await this.attemptRegistry.markFailed(resolvedAttemptId, message);
+      }
+
+      return {
+        ruleId: automation.id,
+        executionId: resolvedAttemptId ?? `exec_${automation.id}_${Date.now()}`,
+        success: false,
+        timestamp: new Date(),
+        duration: 0,
+        error: error instanceof Error ? error : new Error(message),
+      };
+    }
+  }
+
+  private async attachLivePricesFromConditions(
+    triggerConditions: unknown,
+    context: ExecutionContext
+  ): Promise<ExecutionContext> {
+    if (!this.oracle || context.priceContext) {
+      return context;
+    }
+
+    const assets = collectAssetsFromUnknown(triggerConditions);
+    if (assets.length === 0) {
+      return context;
+    }
+
+    const aggregatedPrices = await this.oracle.getAggregatedPrices(assets);
+    return {
+      ...context,
+      priceContext: {
+        prices: Object.fromEntries(
+          aggregatedPrices.map((price: { symbol: string; price: number }) => [
+            price.symbol,
+            price.price,
+          ])
+        ),
+        timestamp: Date.now(),
+      },
+    };
+  }
+
+  /**
    * Get Stellar account info
    */
   async getAccountInfo(publicKey?: string): Promise<any> {
@@ -749,3 +957,46 @@ export class AutomationService extends EventEmitter {
 }
 
 export default AutomationService;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function extractHash(result: unknown): string | undefined {
+  if (!isRecord(result) || typeof result.hash !== 'string' || result.hash.length === 0) {
+    return undefined;
+  }
+  return result.hash;
+}
+
+function collectAssetsFromUnknown(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap(collectAssetsFromUnknown);
+  }
+
+  if (!isRecord(value)) {
+    return [];
+  }
+
+  const assets: string[] = [];
+  if (typeof value.asset === 'string') {
+    assets.push(value.asset);
+  }
+  if (typeof value.assetIn === 'string') {
+    assets.push(value.assetIn);
+  }
+  if (typeof value.assetOut === 'string') {
+    assets.push(value.assetOut);
+  }
+  if (typeof value.quoteAsset === 'string') {
+    assets.push(value.quoteAsset);
+  }
+  if (Array.isArray(value.conditions)) {
+    assets.push(...value.conditions.flatMap(collectAssetsFromUnknown));
+  }
+  if (Array.isArray(value.groups)) {
+    assets.push(...value.groups.flatMap(collectAssetsFromUnknown));
+  }
+
+  return Array.from(new Set(assets));
+}

--- a/packages/core/automation/src/services/execution-attempt-registry.ts
+++ b/packages/core/automation/src/services/execution-attempt-registry.ts
@@ -1,0 +1,300 @@
+/**
+ * Execution-attempt registry.
+ *
+ * Idempotency / locking (why this exists):
+ * - In-memory `inFlightByAutomation` blocks overlapping poll cycles in this process
+ *   from triggering the same automation twice.
+ * - Persisted rows in `automation_execution_attempts` survive crashes. A unique
+ *   partial index allows only one open (pending|executing|submitted) attempt per
+ *   automation. If an attempt already has a `transaction_hash`, retries MUST NOT
+ *   submit another transaction — they reuse the stored hash.
+ */
+
+import { randomUUID } from 'crypto';
+import {
+  ExecutionAttempt,
+  ExecutionAttemptStatus,
+} from '../types/automation-types.js';
+
+const OPEN_STATUSES: ExecutionAttemptStatus[] = [
+  'pending',
+  'executing',
+  'submitted',
+];
+
+export interface AttemptStoreClient {
+  from: (table: string) => {
+    insert?: (rows: unknown) => PromiseLike<{ error?: { message: string } | null }>;
+    update?: (values: unknown) => {
+      eq: (
+        column: string,
+        value: string
+      ) => PromiseLike<{ error?: { message: string } | null }>;
+    };
+    select?: (columns: string) => {
+      eq: (column: string, value: string) => {
+        in: (column: string, values: string[]) => {
+          order: (
+            column: string,
+            options: { ascending: boolean }
+          ) => {
+            limit: (count: number) => PromiseLike<{
+              data: Array<Record<string, unknown>> | null;
+              error?: { message: string } | null;
+            }>;
+          };
+        };
+      };
+    };
+  };
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function rowToAttempt(row: Record<string, unknown>): ExecutionAttempt {
+  return {
+    id: String(row.id),
+    automationId: String(row.automation_id),
+    status: row.status as ExecutionAttemptStatus,
+    transactionHash:
+      typeof row.transaction_hash === 'string' ? row.transaction_hash : undefined,
+    error: typeof row.error === 'string' ? row.error : undefined,
+    createdAt: String(row.created_at ?? nowIso()),
+    updatedAt: String(row.updated_at ?? nowIso()),
+  };
+}
+
+export class ExecutionAttemptRegistry {
+  private readonly memory = new Map<string, ExecutionAttempt>();
+  private readonly inFlightByAutomation = new Map<string, string>();
+
+  constructor(private readonly supabase?: AttemptStoreClient) {}
+
+  isInFlight(automationId: string): boolean {
+    return this.inFlightByAutomation.has(automationId);
+  }
+
+  get(attemptId: string): ExecutionAttempt | undefined {
+    return this.memory.get(attemptId);
+  }
+
+  getInFlightAttempt(automationId: string): ExecutionAttempt | undefined {
+    const attemptId = this.inFlightByAutomation.get(automationId);
+    return attemptId ? this.memory.get(attemptId) : undefined;
+  }
+
+  /**
+   * Atomically claim the right to execute this automation.
+   * Returns null when another cycle (or an open persisted attempt without a
+   * completed resolution) already owns it.
+   */
+  async tryClaim(automationId: string): Promise<ExecutionAttempt | null> {
+    if (this.inFlightByAutomation.has(automationId)) {
+      console.warn(
+        `[automation ${automationId}] skip claim: already in-flight (pending/executing)`
+      );
+      return null;
+    }
+
+    // Reserve the slot synchronously so overlapping poll ticks cannot both
+    // pass the in-flight check before the first await.
+    this.inFlightByAutomation.set(automationId, 'claiming');
+
+    try {
+      const open = await this.findOpenAttempt(automationId);
+      if (open) {
+        this.memory.set(open.id, open);
+        this.inFlightByAutomation.set(automationId, open.id);
+        console.info(
+          `[automation ${automationId}] reattached open attempt ${open.id} status=${open.status}`
+        );
+        return open;
+      }
+
+      const attempt: ExecutionAttempt = {
+        id: randomUUID(),
+        automationId,
+        status: 'pending',
+        createdAt: nowIso(),
+        updatedAt: nowIso(),
+      };
+
+      this.memory.set(attempt.id, attempt);
+      this.inFlightByAutomation.set(automationId, attempt.id);
+      const persisted = await this.persistInsert(attempt);
+      if (!persisted) {
+        this.memory.delete(attempt.id);
+        this.inFlightByAutomation.delete(automationId);
+        console.warn(
+          `[automation ${automationId}] skip claim: persisted open attempt already exists`
+        );
+        return null;
+      }
+
+      console.info(
+        `[automation ${automationId}] state pending (attempt ${attempt.id})`
+      );
+      return attempt;
+    } catch (error) {
+      this.inFlightByAutomation.delete(automationId);
+      throw error;
+    }
+  }
+
+  async markExecuting(attemptId: string): Promise<ExecutionAttempt> {
+    return this.transition(attemptId, 'executing');
+  }
+
+  async markSubmitted(
+    attemptId: string,
+    transactionHash: string
+  ): Promise<ExecutionAttempt> {
+    return this.transition(attemptId, 'submitted', { transactionHash });
+  }
+
+  async markResolved(
+    attemptId: string,
+    transactionHash?: string
+  ): Promise<ExecutionAttempt> {
+    return this.transition(attemptId, 'resolved', { transactionHash });
+  }
+
+  async markFailed(attemptId: string, error: string): Promise<ExecutionAttempt> {
+    return this.transition(attemptId, 'failed', { error });
+  }
+
+  release(automationId: string): void {
+    this.inFlightByAutomation.delete(automationId);
+  }
+
+  private async transition(
+    attemptId: string,
+    status: ExecutionAttemptStatus,
+    extra: { transactionHash?: string; error?: string } = {}
+  ): Promise<ExecutionAttempt> {
+    const current = this.memory.get(attemptId);
+    if (!current) {
+      throw new Error(`Execution attempt not found: ${attemptId}`);
+    }
+
+    const next: ExecutionAttempt = {
+      ...current,
+      status,
+      transactionHash: extra.transactionHash ?? current.transactionHash,
+      error: extra.error,
+      updatedAt: nowIso(),
+    };
+    this.memory.set(attemptId, next);
+    await this.persistUpdate(next);
+
+    const automationId = next.automationId;
+    console.info(
+      `[automation ${automationId}] state ${status} (attempt ${attemptId})` +
+        (next.transactionHash ? ` hash=${next.transactionHash}` : '') +
+        (next.error ? ` error=${next.error}` : '')
+    );
+
+    return next;
+  }
+
+  private async findOpenAttempt(
+    automationId: string
+  ): Promise<ExecutionAttempt | undefined> {
+    for (const attempt of this.memory.values()) {
+      if (
+        attempt.automationId === automationId &&
+        OPEN_STATUSES.includes(attempt.status)
+      ) {
+        return attempt;
+      }
+    }
+
+    try {
+      const table = this.supabase?.from('automation_execution_attempts');
+      if (!table?.select) {
+        return undefined;
+      }
+
+      const { data, error } = await table
+        .select('*')
+        .eq('automation_id', automationId)
+        .in('status', OPEN_STATUSES)
+        .order('created_at', { ascending: false })
+        .limit(1);
+
+      if (error || !data || data.length === 0) {
+        return undefined;
+      }
+
+      return rowToAttempt(data[0]);
+    } catch (error) {
+      console.warn(
+        `[automation ${automationId}] failed to load open attempts:`,
+        error
+      );
+      return undefined;
+    }
+  }
+
+  private async persistInsert(attempt: ExecutionAttempt): Promise<boolean> {
+    try {
+      const table = this.supabase?.from('automation_execution_attempts');
+      if (!table?.insert) {
+        return true;
+      }
+
+      const { error } = await table.insert([
+        {
+          id: attempt.id,
+          automation_id: attempt.automationId,
+          status: attempt.status,
+          transaction_hash: attempt.transactionHash ?? null,
+          error: attempt.error ?? null,
+          created_at: attempt.createdAt,
+          updated_at: attempt.updatedAt,
+        },
+      ]);
+
+      if (error) {
+        console.warn(
+          `[automation ${attempt.automationId}] persist insert failed:`,
+          error.message
+        );
+        return false;
+      }
+
+      return true;
+    } catch (error) {
+      console.warn(
+        `[automation ${attempt.automationId}] persist insert failed:`,
+        error
+      );
+      return true;
+    }
+  }
+
+  private async persistUpdate(attempt: ExecutionAttempt): Promise<void> {
+    try {
+      const table = this.supabase?.from('automation_execution_attempts');
+      if (!table?.update) {
+        return;
+      }
+
+      const builder = table.update({
+        status: attempt.status,
+        transaction_hash: attempt.transactionHash ?? null,
+        error: attempt.error ?? null,
+        updated_at: attempt.updatedAt,
+      });
+
+      await builder.eq('id', attempt.id);
+    } catch (error) {
+      console.warn(
+        `[automation ${attempt.automationId}] persist update failed:`,
+        error
+      );
+    }
+  }
+}

--- a/packages/core/automation/src/test/execution-attempt-registry.test.ts
+++ b/packages/core/automation/src/test/execution-attempt-registry.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview Unit tests for ExecutionAttemptRegistry
+ */
+
+import { ExecutionAttemptRegistry } from '../services/execution-attempt-registry.js';
+
+describe('ExecutionAttemptRegistry', () => {
+  let registry: ExecutionAttemptRegistry;
+
+  beforeEach(() => {
+    registry = new ExecutionAttemptRegistry();
+  });
+
+  it('claims an automation once and rejects a concurrent claim', async () => {
+    const first = await registry.tryClaim('auto-1');
+    const second = await registry.tryClaim('auto-1');
+
+    expect(first).not.toBeNull();
+    expect(first?.status).toBe('pending');
+    expect(second).toBeNull();
+    expect(registry.isInFlight('auto-1')).toBe(true);
+  });
+
+  it('allows overlapping tryClaim races to serialize on in-flight state', async () => {
+    const [a, b] = await Promise.all([
+      registry.tryClaim('auto-2'),
+      registry.tryClaim('auto-2'),
+    ]);
+
+    const claimed = [a, b].filter(Boolean);
+    expect(claimed).toHaveLength(1);
+  });
+
+  it('does not resubmit after a hash is recorded', async () => {
+    const attempt = await registry.tryClaim('auto-3');
+    expect(attempt).not.toBeNull();
+
+    await registry.markExecuting(attempt!.id);
+    await registry.markSubmitted(attempt!.id, 'abc123hash');
+
+    const reused = registry.get(attempt!.id);
+    expect(reused?.transactionHash).toBe('abc123hash');
+    expect(reused?.status).toBe('submitted');
+  });
+
+  it('releases in-flight so a later cycle can claim after resolve', async () => {
+    const attempt = await registry.tryClaim('auto-4');
+    await registry.markExecuting(attempt!.id);
+    await registry.markResolved(attempt!.id, 'hash-4');
+    registry.release('auto-4');
+
+    expect(registry.isInFlight('auto-4')).toBe(false);
+
+    const next = await registry.tryClaim('auto-4');
+    expect(next).not.toBeNull();
+    expect(next?.id).not.toBe(attempt!.id);
+  });
+});

--- a/packages/core/automation/src/test/persisted-execution.test.ts
+++ b/packages/core/automation/src/test/persisted-execution.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @fileoverview Persisted evaluate + execute tests for AutomationService
+ */
+
+jest.mock('@galaxy-kj/core-stellar-sdk', () => ({
+  supabaseClient: {
+    from: jest.fn().mockReturnValue({
+      insert: jest.fn().mockResolvedValue({ error: null }),
+    }),
+  },
+}));
+
+jest.mock('@galaxy-kj/core-oracles', () => ({
+  OracleAggregator: class OracleAggregator {},
+}));
+
+import { AutomationService } from '../services/automation.service.js';
+import { ExecutionAttemptRegistry } from '../services/execution-attempt-registry.js';
+import { TriggerEvaluator } from '../triggers/trigger-evaluator.js';
+import { ExecutionEngine } from '../utils/execution-engine.js';
+import { CronManager } from '../utils/cron-manager.js';
+import { ConditionEvaluator } from '../utils/condition-evaluator.js';
+import {
+  StoredAutomation,
+  StellarNetwork,
+} from '../types/automation-types.js';
+
+jest.mock('../utils/cron-manager');
+jest.mock('../utils/condition-evaluator');
+jest.mock('../utils/execution-engine');
+
+const testNetwork: StellarNetwork = {
+  type: 'TESTNET',
+  horizonUrl: 'https://horizon-testnet.stellar.org',
+  networkPassphrase: 'Test SDF Network ; September 2015',
+};
+
+function storedAutomation(
+  overrides: Partial<StoredAutomation> = {}
+): StoredAutomation {
+  return {
+    id: 'auto-1',
+    user_id: 'user-1',
+    wallet_id: 'wallet-1',
+    name: 'Price swap',
+    status: 'active',
+    trigger_conditions: {
+      type: 'price',
+      assetIn: 'XLM',
+      assetOut: 'USDC',
+      condition: 'below',
+      threshold: '0.10',
+    },
+    action_config: {
+      executionType: 'STELLAR_PAYMENT',
+      paymentConfig: {
+        destination: 'GDESTINATION',
+        asset: {},
+        amount: '5',
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('AutomationService persisted evaluate/execute', () => {
+  let mockExecutionEngine: jest.Mocked<ExecutionEngine>;
+  let priceEvaluate: jest.Mock;
+  let service: AutomationService;
+  let registry: ExecutionAttemptRegistry;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (CronManager as jest.MockedClass<typeof CronManager>).mockImplementation(
+      () =>
+        ({
+          scheduleJob: jest.fn(),
+          startJob: jest.fn(),
+          stopJob: jest.fn(),
+          removeJob: jest.fn(),
+          validateExpression: jest.fn().mockReturnValue(true),
+          destroy: jest.fn(),
+        }) as unknown as CronManager
+    );
+
+    (
+      ConditionEvaluator as jest.MockedClass<typeof ConditionEvaluator>
+    ).mockImplementation(
+      () =>
+        ({
+          evaluateConditionGroup: jest.fn().mockResolvedValue(true),
+          validateConditionGroup: jest.fn().mockReturnValue({ valid: true }),
+        }) as unknown as ConditionEvaluator
+    );
+
+    mockExecutionEngine = {
+      execute: jest.fn().mockResolvedValue({
+        ruleId: 'auto-1',
+        executionId: 'exec-1',
+        success: true,
+        timestamp: new Date(),
+        duration: 25,
+        transactionHash: 'real-horizon-hash',
+        result: { hash: 'real-horizon-hash' },
+      }),
+      updateNetwork: jest.fn(),
+      getAccountInfo: jest.fn(),
+      getStatus: jest.fn(),
+    } as unknown as jest.Mocked<ExecutionEngine>;
+
+    (ExecutionEngine as jest.MockedClass<typeof ExecutionEngine>).mockImplementation(
+      () => mockExecutionEngine
+    );
+
+    priceEvaluate = jest.fn().mockResolvedValue(true);
+    registry = new ExecutionAttemptRegistry();
+
+    service = new AutomationService({
+      network: testNetwork,
+      sourceSecret: 'SSECRET',
+      attemptRegistry: registry,
+      triggerEvaluator: new TriggerEvaluator({
+        priceTrigger: { evaluate: priceEvaluate },
+      }),
+    });
+  });
+
+  afterEach(async () => {
+    await service.shutdown();
+  });
+
+  it('evaluatePersistedAutomation is deterministic and uses PriceTrigger', async () => {
+    const met = await service.evaluatePersistedAutomation(storedAutomation());
+    expect(met.met).toBe(true);
+    expect(priceEvaluate).toHaveBeenCalledTimes(1);
+
+    priceEvaluate.mockResolvedValue(false);
+    const unmet = await service.evaluatePersistedAutomation(storedAutomation());
+    expect(unmet.met).toBe(false);
+  });
+
+  it('executePersistedAutomation returns the real transaction hash', async () => {
+    const attempt = await service.tryBeginExecution('auto-1');
+    const result = await service.executePersistedAutomation(
+      storedAutomation(),
+      attempt!.id
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.transactionHash).toBe('real-horizon-hash');
+    expect(mockExecutionEngine.execute).toHaveBeenCalledTimes(1);
+    expect(registry.get(attempt!.id)?.status).toBe('submitted');
+  });
+
+  it('does not submit again when an attempt already has a hash', async () => {
+    const attempt = await service.tryBeginExecution('auto-1');
+    await registry.markSubmitted(attempt!.id, 'already-sent-hash');
+
+    const result = await service.executePersistedAutomation(
+      storedAutomation(),
+      attempt!.id
+    );
+
+    expect(result.transactionHash).toBe('already-sent-hash');
+    expect(mockExecutionEngine.execute).not.toHaveBeenCalled();
+    expect(registry.get(attempt!.id)?.status).toBe('submitted');
+
+    await service.confirmExecution(attempt!.id, result.transactionHash);
+    expect(registry.get(attempt!.id)?.status).toBe('resolved');
+  });
+
+  it('returns the real engine error without a fake hash', async () => {
+    mockExecutionEngine.execute.mockResolvedValue({
+      ruleId: 'auto-1',
+      executionId: 'exec-fail',
+      success: false,
+      timestamp: new Date(),
+      duration: 10,
+      error: new Error('horizon: op_underfunded'),
+    });
+
+    const attempt = await service.tryBeginExecution('auto-1');
+    const result = await service.executePersistedAutomation(
+      storedAutomation(),
+      attempt!.id
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.transactionHash).toBeUndefined();
+    expect(result.error?.message).toBe('horizon: op_underfunded');
+  });
+
+  it('rejects a second in-flight claim for the same automation', async () => {
+    const first = await service.tryBeginExecution('auto-1');
+    const second = await service.tryBeginExecution('auto-1');
+
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+  });
+});

--- a/packages/core/automation/src/test/trigger-evaluator.test.ts
+++ b/packages/core/automation/src/test/trigger-evaluator.test.ts
@@ -1,0 +1,177 @@
+/**
+ * @fileoverview Unit tests for TriggerEvaluator
+ */
+
+import { TriggerEvaluator, parseActionConfig } from '../triggers/trigger-evaluator.js';
+import {
+  ConditionLogic,
+  ConditionOperator,
+  ExecutionContext,
+  ExecutionType,
+} from '../types/automation-types.js';
+import type { PriceTriggerLike, VolumeTriggerLike } from '../triggers/trigger-evaluator.js';
+
+function createContext(overrides: Partial<ExecutionContext> = {}): ExecutionContext {
+  return {
+    ruleId: 'auto-1',
+    userId: 'user-1',
+    timestamp: new Date('2026-08-24T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('TriggerEvaluator', () => {
+  let priceTrigger: jest.Mocked<PriceTriggerLike>;
+  let volumeTrigger: jest.Mocked<VolumeTriggerLike>;
+  let evaluator: TriggerEvaluator;
+
+  beforeEach(() => {
+    priceTrigger = { evaluate: jest.fn() };
+    volumeTrigger = {
+      check: jest.fn().mockResolvedValue({
+        triggered: false,
+        volume24h: 0,
+        threshold: 0,
+        tradeCount: 0,
+        checkedAt: '2026-08-24T00:00:00.000Z',
+      }),
+    };
+    evaluator = new TriggerEvaluator({ priceTrigger, volumeTrigger });
+  });
+
+  it('returns false when trigger_conditions are missing', async () => {
+    const result = await evaluator.evaluate(null);
+    expect(result.met).toBe(false);
+    expect(priceTrigger.evaluate).not.toHaveBeenCalled();
+  });
+
+  it('evaluates a price trigger via PriceTrigger and returns true when met', async () => {
+    priceTrigger.evaluate.mockResolvedValue(true);
+
+    const result = await evaluator.evaluate({
+      type: 'price',
+      assetIn: 'XLM',
+      assetOut: 'USDC',
+      condition: 'below',
+      threshold: '0.10',
+    });
+
+    expect(result.met).toBe(true);
+    expect(result.triggerType).toBe('PRICE');
+    expect(priceTrigger.evaluate).toHaveBeenCalledWith({
+      assetIn: 'XLM',
+      assetOut: 'USDC',
+      condition: 'below',
+      threshold: '0.10',
+    });
+  });
+
+  it('returns false when price conditions are not met', async () => {
+    priceTrigger.evaluate.mockResolvedValue(false);
+
+    const result = await evaluator.evaluate({
+      type: 'price',
+      assetIn: 'XLM',
+      assetOut: 'USDC',
+      condition: 'above',
+      threshold: '1',
+    });
+
+    expect(result.met).toBe(false);
+  });
+
+  it('evaluates a volume trigger via VolumeTrigger', async () => {
+    volumeTrigger.check.mockResolvedValue({
+      triggered: true,
+      volume24h: 750000,
+      threshold: 500000,
+      tradeCount: 12,
+      checkedAt: '2026-08-24T00:00:00.000Z',
+    });
+
+    const result = await evaluator.evaluate({
+      type: 'volume',
+      poolId: 'pool-1',
+      threshold24h: '500000',
+    });
+
+    expect(result.met).toBe(true);
+    expect(result.triggerData.volume24h).toBe(750000);
+    expect(volumeTrigger.check).toHaveBeenCalledWith({
+      poolId: 'pool-1',
+      threshold24h: '500000',
+    });
+  });
+
+  it('never fires event triggers on the poll path', async () => {
+    const result = await evaluator.evaluate({
+      type: 'event',
+      contractId: 'C' + 'A'.repeat(55),
+      topics: ['swap'],
+    });
+
+    expect(result.met).toBe(false);
+    expect(result.triggerData.reason).toBe('event_triggers_are_push_based');
+  });
+
+  it('evaluates condition groups deterministically', async () => {
+    const result = await evaluator.evaluate(
+      {
+        logic: ConditionLogic.AND,
+        conditions: [
+          {
+            id: 'c1',
+            field: 'marketData.XLM.priceUSD',
+            operator: ConditionOperator.LESS_THAN,
+            value: 0.2,
+          },
+        ],
+      },
+      createContext({
+        marketData: { XLM: { priceUSD: 0.1 } },
+      })
+    );
+
+    expect(result.met).toBe(true);
+  });
+
+  it('returns false for a condition group that is not satisfied', async () => {
+    const result = await evaluator.evaluate(
+      {
+        logic: ConditionLogic.AND,
+        conditions: [
+          {
+            id: 'c1',
+            field: 'marketData.XLM.priceUSD',
+            operator: ConditionOperator.GREATER_THAN,
+            value: 1,
+          },
+        ],
+      },
+      createContext({
+        marketData: { XLM: { priceUSD: 0.1 } },
+      })
+    );
+
+    expect(result.met).toBe(false);
+  });
+});
+
+describe('parseActionConfig', () => {
+  it('infers STELLAR_PAYMENT from paymentConfig', () => {
+    const parsed = parseActionConfig({
+      paymentConfig: {
+        destination: 'GDEST',
+        asset: {},
+        amount: '10',
+      },
+    });
+
+    expect(parsed.executionType).toBe(ExecutionType.STELLAR_PAYMENT);
+    expect(parsed.executionConfig.paymentConfig?.amount).toBe('10');
+  });
+
+  it('throws when action_config cannot be mapped', () => {
+    expect(() => parseActionConfig({})).toThrow('Unable to determine execution type');
+  });
+});

--- a/packages/core/automation/src/triggers/price-trigger.ts
+++ b/packages/core/automation/src/triggers/price-trigger.ts
@@ -14,7 +14,7 @@ export interface PriceTriggerConfig {
 }
 
 export class PriceTrigger {
-  constructor(private readonly oracle: OracleAggregator) {}
+  constructor(private readonly oracle: Pick<OracleAggregator, 'getAggregatedPrices'>) {}
 
   /**
    * Query OracleAggregator for the asset pair rate and evaluate the condition.

--- a/packages/core/automation/src/triggers/trigger-evaluator.ts
+++ b/packages/core/automation/src/triggers/trigger-evaluator.ts
@@ -1,0 +1,394 @@
+/**
+ * Deterministic dispatcher over persisted `trigger_conditions`.
+ *
+ * Reuses PriceTrigger, VolumeTrigger, and ConditionEvaluator — it does not
+ * reimplement comparison or market-data logic. Event triggers are push-based
+ * (EventTrigger.startListening); the poll path therefore returns false.
+ */
+
+import {
+  ConditionGroup,
+  ConditionLogic,
+  ConditionOperator,
+  ExecutionContext,
+  ExecutionType,
+  ExecutionConfig,
+  StoredAutomation,
+  TriggerEvaluationResult,
+  TriggerType,
+} from '../types/automation-types.js';
+import { PriceTriggerConfig } from './price-trigger.js';
+import {
+  VolumeTrigger,
+  VolumeCheckResult,
+  VolumeTrackConfig,
+} from './volume-trigger.js';
+import { ConditionEvaluator } from '../utils/condition-evaluator.js';
+
+export interface PriceTriggerLike {
+  evaluate(config: PriceTriggerConfig): Promise<boolean>;
+}
+
+export interface VolumeTriggerLike {
+  check(config: VolumeTrackConfig): Promise<VolumeCheckResult>;
+}
+
+export interface TriggerEvaluatorDeps {
+  priceTrigger?: PriceTriggerLike;
+  volumeTrigger?: VolumeTriggerLike;
+  conditionEvaluator?: ConditionEvaluator;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+export class TriggerEvaluator {
+  private readonly priceTrigger?: PriceTriggerLike;
+  private readonly volumeTrigger?: VolumeTriggerLike;
+  private readonly conditionEvaluator: ConditionEvaluator;
+
+  constructor(deps: TriggerEvaluatorDeps = {}) {
+    this.priceTrigger = deps.priceTrigger;
+    this.volumeTrigger = deps.volumeTrigger;
+    this.conditionEvaluator = deps.conditionEvaluator ?? new ConditionEvaluator();
+  }
+
+  async evaluate(
+    triggerConditions: unknown,
+    context?: ExecutionContext
+  ): Promise<TriggerEvaluationResult> {
+    if (triggerConditions === undefined || triggerConditions === null) {
+      return {
+        met: false,
+        triggerType: 'unknown',
+        triggerData: { reason: 'missing_trigger_conditions' },
+      };
+    }
+
+    if (typeof triggerConditions === 'string') {
+      try {
+        return this.evaluate(JSON.parse(triggerConditions), context);
+      } catch {
+        return {
+          met: false,
+          triggerType: 'unknown',
+          triggerData: { reason: 'invalid_json_trigger_conditions' },
+        };
+      }
+    }
+
+    const parsed = this.normalize(triggerConditions);
+
+    try {
+      switch (parsed.kind) {
+        case 'price':
+          return this.evaluatePrice(parsed.config);
+        case 'volume':
+          return this.evaluateVolume(parsed.config);
+        case 'event':
+          return {
+            met: false,
+            triggerType: TriggerType.EVENT,
+            triggerData: {
+              reason: 'event_triggers_are_push_based',
+              contractId: parsed.contractId,
+              topics: parsed.topics,
+            },
+          };
+        case 'conditionGroup':
+          return this.evaluateConditionGroup(parsed.group, context);
+        default:
+          return {
+            met: false,
+            triggerType: 'unknown',
+            triggerData: { reason: 'unrecognized_trigger_conditions' },
+          };
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'trigger_evaluation_failed';
+      console.error('[TriggerEvaluator] evaluation failed:', message);
+      return {
+        met: false,
+        triggerType: parsed.kind,
+        triggerData: { reason: message },
+      };
+    }
+  }
+
+  async evaluateStored(
+    automation: StoredAutomation,
+    context?: ExecutionContext
+  ): Promise<TriggerEvaluationResult> {
+    return this.evaluate(automation.trigger_conditions, context);
+  }
+
+  private async evaluatePrice(
+    config: PriceTriggerConfig
+  ): Promise<TriggerEvaluationResult> {
+    if (!this.priceTrigger) {
+      console.warn(
+        '[TriggerEvaluator] price trigger skipped: PriceTrigger is not configured'
+      );
+      return {
+        met: false,
+        triggerType: TriggerType.PRICE,
+        triggerData: { reason: 'price_trigger_not_configured', ...config },
+      };
+    }
+
+    const met = await this.priceTrigger.evaluate(config);
+    return {
+      met,
+      triggerType: TriggerType.PRICE,
+      triggerData: { ...config },
+    };
+  }
+
+  private async evaluateVolume(
+    config: VolumeTrackConfig
+  ): Promise<TriggerEvaluationResult> {
+    if (!this.volumeTrigger) {
+      console.warn(
+        '[TriggerEvaluator] volume trigger skipped: VolumeTrigger is not configured'
+      );
+      return {
+        met: false,
+        triggerType: TriggerType.VOLUME,
+        triggerData: { reason: 'volume_trigger_not_configured', ...config },
+      };
+    }
+
+    const result = await this.volumeTrigger.check(config);
+    return {
+      met: result.triggered,
+      triggerType: TriggerType.VOLUME,
+      triggerData: {
+        poolId: config.poolId,
+        threshold24h: config.threshold24h,
+        volume24h: result.volume24h,
+        tradeCount: result.tradeCount,
+        checkedAt: result.checkedAt,
+      },
+    };
+  }
+
+  private async evaluateConditionGroup(
+    group: ConditionGroup,
+    context?: ExecutionContext
+  ): Promise<TriggerEvaluationResult> {
+    if (!context) {
+      return {
+        met: false,
+        triggerType: TriggerType.CUSTOM,
+        triggerData: { reason: 'missing_execution_context' },
+      };
+    }
+
+    const met = await this.conditionEvaluator.evaluateConditionGroup(group, context);
+    return {
+      met,
+      triggerType: TriggerType.CUSTOM,
+      triggerData: { logic: group.logic },
+    };
+  }
+
+  private normalize(
+    value: unknown
+  ):
+    | { kind: 'price'; config: PriceTriggerConfig }
+    | { kind: 'volume'; config: VolumeTrackConfig }
+    | { kind: 'event'; contractId: string; topics: string[] }
+    | { kind: 'conditionGroup'; group: ConditionGroup }
+    | { kind: 'unknown' } {
+    if (Array.isArray(value)) {
+      return {
+        kind: 'conditionGroup',
+        group: {
+          logic: ConditionLogic.AND,
+          conditions: value as ConditionGroup['conditions'],
+        },
+      };
+    }
+
+    if (!isRecord(value)) {
+      return { kind: 'unknown' };
+    }
+
+    const typeHint = asString(value.type) ?? asString(value.triggerType);
+
+    if (this.isPriceConfig(value, typeHint)) {
+      return {
+        kind: 'price',
+        config: {
+          assetIn: String(value.assetIn ?? value.asset),
+          assetOut: String(value.assetOut ?? value.quoteAsset ?? 'USD'),
+          condition: this.toPriceCondition(value),
+          threshold: String(value.threshold ?? value.value),
+        },
+      };
+    }
+
+    if (this.isVolumeConfig(value, typeHint)) {
+      return {
+        kind: 'volume',
+        config: {
+          poolId: String(value.poolId),
+          threshold24h: String(value.threshold24h ?? value.threshold),
+        },
+      };
+    }
+
+    if (this.isEventConfig(value, typeHint)) {
+      return {
+        kind: 'event',
+        contractId: String(value.contractId),
+        topics: Array.isArray(value.topics)
+          ? value.topics.map(topic => String(topic))
+          : [],
+      };
+    }
+
+    if (this.isConditionGroup(value)) {
+      return { kind: 'conditionGroup', group: value as unknown as ConditionGroup };
+    }
+
+    if (isRecord(value.trigger_conditions)) {
+      return this.normalize(value.trigger_conditions);
+    }
+
+    if (isRecord(value.conditionGroup)) {
+      return this.normalize(value.conditionGroup);
+    }
+
+    return { kind: 'unknown' };
+  }
+
+  private isPriceConfig(
+    value: Record<string, unknown>,
+    typeHint?: string
+  ): boolean {
+    const typed =
+      typeHint?.toLowerCase() === 'price' || typeHint === TriggerType.PRICE;
+    const hasPair =
+      (typeof value.assetIn === 'string' || typeof value.asset === 'string') &&
+      (value.threshold !== undefined || value.value !== undefined);
+    return typed || (hasPair && (typeof value.condition === 'string' || typeof value.operator === 'string'));
+  }
+
+  private isVolumeConfig(
+    value: Record<string, unknown>,
+    typeHint?: string
+  ): boolean {
+    const typed =
+      typeHint?.toLowerCase() === 'volume' || typeHint === TriggerType.VOLUME;
+    return typed || (typeof value.poolId === 'string' && value.threshold24h !== undefined);
+  }
+
+  private isEventConfig(
+    value: Record<string, unknown>,
+    typeHint?: string
+  ): boolean {
+    const typed =
+      typeHint?.toLowerCase() === 'event' || typeHint === TriggerType.EVENT;
+    return typed || (typeof value.contractId === 'string' && Array.isArray(value.topics));
+  }
+
+  private isConditionGroup(value: Record<string, unknown>): boolean {
+    return (
+      typeof value.logic === 'string' &&
+      (Array.isArray(value.conditions) || Array.isArray(value.groups))
+    );
+  }
+
+  private toPriceCondition(value: Record<string, unknown>): PriceTriggerConfig['condition'] {
+    const raw = asString(value.condition)?.toLowerCase();
+    if (raw === 'above' || raw === 'below') {
+      return raw;
+    }
+
+    const operator = asString(value.operator);
+    if (
+      operator === ConditionOperator.LESS_THAN ||
+      operator === ConditionOperator.LESS_THAN_OR_EQUAL ||
+      operator === 'LT' ||
+      operator === 'LTE'
+    ) {
+      return 'below';
+    }
+
+    return 'above';
+  }
+}
+
+export function parseActionConfig(actionConfig: unknown): {
+  executionType: ExecutionType;
+  executionConfig: ExecutionConfig;
+} {
+  if (!isRecord(actionConfig)) {
+    throw new Error('action_config must be an object');
+  }
+
+  const nested = isRecord(actionConfig.executionConfig)
+    ? actionConfig.executionConfig
+    : actionConfig;
+
+  const executionConfig: ExecutionConfig = {
+    paymentConfig: nested.paymentConfig as ExecutionConfig['paymentConfig'],
+    swapConfig: nested.swapConfig as ExecutionConfig['swapConfig'],
+    contractConfig: nested.contractConfig as ExecutionConfig['contractConfig'],
+    tradeConfig: nested.tradeConfig as ExecutionConfig['tradeConfig'],
+    webhookUrl: asString(nested.webhookUrl),
+    webhookHeaders: isRecord(nested.webhookHeaders)
+      ? (nested.webhookHeaders as Record<string, string>)
+      : undefined,
+    notificationConfig: nested.notificationConfig as ExecutionConfig['notificationConfig'],
+    retryAttempts:
+      typeof nested.retryAttempts === 'number' ? nested.retryAttempts : undefined,
+    retryDelay: typeof nested.retryDelay === 'number' ? nested.retryDelay : undefined,
+    baseFee: asString(nested.baseFee),
+    timeout: typeof nested.timeout === 'number' ? nested.timeout : undefined,
+    memo: asString(nested.memo),
+    memoType: nested.memoType as ExecutionConfig['memoType'],
+  };
+
+  const typeHint = asString(actionConfig.executionType) ?? asString(actionConfig.type);
+  const executionType = parseExecutionType(typeHint, executionConfig);
+
+  return { executionType, executionConfig };
+}
+
+function parseExecutionType(
+  typeHint: string | undefined,
+  config: ExecutionConfig
+): ExecutionType {
+  const normalized = typeHint?.toUpperCase();
+  const values = Object.values(ExecutionType) as string[];
+  if (normalized && values.includes(normalized)) {
+    return normalized as ExecutionType;
+  }
+
+  if (config.paymentConfig) return ExecutionType.STELLAR_PAYMENT;
+  if (config.swapConfig) return ExecutionType.STELLAR_SWAP;
+  if (config.contractConfig) return ExecutionType.STELLAR_CONTRACT;
+  if (config.tradeConfig) return ExecutionType.DEX_TRADE;
+  if (config.webhookUrl) return ExecutionType.WEBHOOK;
+  if (config.notificationConfig) return ExecutionType.NOTIFICATION;
+
+  throw new Error('Unable to determine execution type from action_config');
+}
+
+export function createDefaultTriggerEvaluator(
+  deps: TriggerEvaluatorDeps & { horizonUrl?: string } = {}
+): TriggerEvaluator {
+  return new TriggerEvaluator({
+    priceTrigger: deps.priceTrigger,
+    volumeTrigger:
+      deps.volumeTrigger ?? new VolumeTrigger({ horizonUrl: deps.horizonUrl }),
+    conditionEvaluator: deps.conditionEvaluator,
+  });
+}

--- a/packages/core/automation/src/types/automation-types.ts
+++ b/packages/core/automation/src/types/automation-types.ts
@@ -258,3 +258,45 @@ export interface StellarNetwork {
   horizonUrl: string;
   networkPassphrase: string;
 }
+
+/**
+ * Row shape persisted in `public.automations`.
+ * `trigger_conditions` and `action_config` are JSONB and therefore untyped at rest.
+ */
+export interface StoredAutomation {
+  id: string;
+  user_id: string;
+  wallet_id?: string | null;
+  name?: string | null;
+  description?: string | null;
+  status: string;
+  trigger_conditions: unknown;
+  action_config: unknown;
+  last_executed_at?: string | null;
+  created_at?: string;
+  updated_at?: string;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface TriggerEvaluationResult {
+  met: boolean;
+  triggerType: string;
+  triggerData: Record<string, unknown>;
+}
+
+export type ExecutionAttemptStatus =
+  | 'pending'
+  | 'executing'
+  | 'submitted'
+  | 'resolved'
+  | 'failed';
+
+export interface ExecutionAttempt {
+  id: string;
+  automationId: string;
+  status: ExecutionAttemptStatus;
+  transactionHash?: string;
+  error?: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/packages/core/automation/src/utils/execution-engine.ts
+++ b/packages/core/automation/src/utils/execution-engine.ts
@@ -9,6 +9,19 @@ import {
   StellarNetwork,
 } from '../types/automation-types.js';
 
+function extractTransactionHash(result: unknown): string | undefined {
+  if (!result || typeof result !== 'object') {
+    return undefined;
+  }
+
+  if (!('hash' in result)) {
+    return undefined;
+  }
+
+  const hash = (result as { hash: unknown }).hash;
+  return typeof hash === 'string' && hash.length > 0 ? hash : undefined;
+}
+
 export class ExecutionEngine {
   private server: StellarSdk.Horizon.Server;
   private sourceKeypair?: StellarSdk.Keypair;
@@ -85,6 +98,7 @@ export class ExecutionEngine {
         }
 
         const duration = Date.now() - startTime;
+        const transactionHash = extractTransactionHash(result);
 
         return {
           ruleId: context.ruleId,
@@ -93,6 +107,7 @@ export class ExecutionEngine {
           timestamp: new Date(),
           duration,
           result,
+          transactionHash,
           retryCount,
         };
       } catch (error) {

--- a/packages/core/automation/tsconfig.test.json
+++ b/packages/core/automation/tsconfig.test.json
@@ -9,7 +9,12 @@
     "skipLibCheck": true,
     "declaration": false,
     "outDir": "./dist-test",
-    "baseUrl": "."
+    "baseUrl": ".",
+    "paths": {
+      "@galaxy-kj/core-oracles": ["../oracles/src/index.ts"],
+      "@galaxy-kj/core-stellar-sdk": ["../stellar-sdk/src/index.ts"],
+      "@galaxy-kj/core-stellar-sdk/*": ["../stellar-sdk/src/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/supabase/migrations/20260824000000_automation_execution_attempts.sql
+++ b/supabase/migrations/20260824000000_automation_execution_attempts.sql
@@ -1,0 +1,30 @@
+-- Execution attempt log for automation transactions.
+-- One open attempt per automation prevents duplicate submits across poll cycles
+-- and process restarts. A row with transaction_hash must never be resent.
+
+CREATE TYPE public.automation_execution_attempt_status AS ENUM (
+  'pending',
+  'executing',
+  'submitted',
+  'resolved',
+  'failed'
+);
+
+CREATE TABLE public.automation_execution_attempts (
+  id UUID PRIMARY KEY,
+  automation_id UUID NOT NULL REFERENCES public.automations(id) ON DELETE CASCADE,
+  status public.automation_execution_attempt_status NOT NULL DEFAULT 'pending',
+  transaction_hash TEXT,
+  error TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_automation_execution_attempts_automation_id
+  ON public.automation_execution_attempts (automation_id, created_at DESC);
+
+CREATE UNIQUE INDEX idx_automation_execution_attempts_open
+  ON public.automation_execution_attempts (automation_id)
+  WHERE status IN ('pending', 'executing', 'submitted');
+
+ALTER TABLE public.automation_execution_attempts ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
# Pull Request

## 📋 Description

`AutomationHandler` already no longer invents triggers or transaction hashes. The WebSocket poll loop evaluates persisted `trigger_conditions` through the real `@galaxy-kj/core-automation` evaluators (`PriceTrigger`, `VolumeTrigger`, `ConditionEvaluator`) and submits actions via `ExecutionEngine.execute()` on Horizon.
Synthetic `Math.random()` evaluation, fake `tx_…` hashes, and the latency `setTimeout` were removed. Polling is single-flight (`isPolling` + schedule-next-after-complete). Per-automation idempotency uses an in-memory claim plus `automation_execution_attempts` (partial unique index on open rows) so overlapping ticks and crash recovery cannot double-submit. A stored `transaction_hash` is reused, never resent.
Websocket event names and payload shapes (`automation:triggered`, `automation:executed`) are unchanged; only the data is now real (Horizon hash or authentic error).


## 🔗 Related Issues

Closes #383 

## 🧪 Testing

- [x ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [x ] All tests passing locally

Local run (23 passed / 0 failed):
- `@galaxy-kj/core-automation` — 18 passed (`trigger-evaluator`, `execution-attempt-registry`, `persisted-execution`)
- `@galaxy-kj/api-websocket` — 5 passed (`automation-handler`)
Covered: condition met → triggered + executed with real hash; condition not met → no events; execution failure → real error, no fake hash; overlapping poll cycles → no duplicate execute; concurrent `processActiveAutomations` → single claim.

## 📚 Documentation Updates (Required)

<!-- ⚠️ IMPORTANT: Update all relevant documentation before merging -->

- [ ] Updated `docs/AI.md` with new patterns/examples
- [ ] Updated API reference in relevant package README
- [ ] Added/updated code examples
- [ ] Updated ARCHITECTURE.md (if architecture changed)
- [ x] Added inline JSDoc/TSDoc comments
- [ ] Updated ROADMAP.md progress (mark issue as completed)

Code comments cover `TriggerEvaluator` (reuse, not reimplement), `ExecutionAttemptRegistry` (why memory + unique index), and handler poll/lock behavior. Package README / AI.md / ROADMAP / examples were **not** updated in this change set and should be done before merge if the project requires it.

### Documentation Checklist by Component:

#### If you modified `packages/core/stellar-sdk/`:
- [ ] Updated `packages/core/stellar-sdk/README.md`
- [ ] Added examples to `docs/examples/stellar-sdk/`
- [ ] Updated type definitions documentation

*Not modified.*

#### If you modified `packages/core/invisible-wallet/`:
- [ ] Updated `packages/core/invisible-wallet/README.md`
- [ ] Added security notes to `docs/SECURITY.md`
- [ ] Updated wallet flow diagrams in `docs/ARCHITECTURE.md`

*Not modified.*

#### If you modified `packages/core/automation/`:
- [ ] Updated `packages/core/automation/README.md`
- [ ] Added automation examples to `docs/examples/automation/`
- [ ] Updated trigger/action types in docs

*Code + tests + public exports updated. README / examples / type docs still pending.*

#### If you modified `packages/core/defi-protocols/`:
- [ ] Updated `packages/core/defi-protocols/README.md`
- [ ] Added protocol integration guide
- [ ] Updated DeFi architecture section in `docs/ARCHITECTURE.md`

*Not modified.*

#### If you modified `packages/core/oracles/`:
- [ ] Updated `packages/core/oracles/README.md`
- [ ] Added oracle source documentation
- [ ] Updated price feed examples

*Not modified (reused `OracleAggregator` / `PriceTrigger` only).*

#### If you modified `packages/contracts/`:
- [ ] Added Rust documentation comments (///)
- [ ] Updated contract README with deployment instructions
- [ ] Added contract interaction examples

*Not modified.*

#### If you modified `tools/cli/`:
- [ ] Updated CLI command documentation
- [ ] Added command examples to README
- [ ] Updated help text in command definitions

*Not modified.*

## 🤖 AI-Friendly Documentation

<!-- Help AI assistants understand your changes -->

### New Files Created

packages/core/automation/src/triggers/trigger-evaluator.ts Deterministic dispatcher over persisted trigger_conditions; reuses PriceTrigger, VolumeTrigger, ConditionEvaluator. Also exports parseActionConfig.

packages/core/automation/src/services/execution-attempt-registry.ts Two-tier idempotency: sync in-memory claim + persisted automation_execution_attempts rows.

packages/core/automation/src/test/trigger-evaluator.test.ts Unit tests for price/volume/event/condition-group evaluation and parseActionConfig.

packages/core/automation/src/test/execution-attempt-registry.test.ts Claim, concurrent claim, hash reuse, release-after-resolve.

packages/core/automation/src/test/persisted-execution.test.ts AutomationService evaluate/execute/idempotency against a mocked ExecutionEngine.

packages/api/websocket/src/tests/handlers/automation-handler.test.ts Poll-loop events, no-op when unmet, real errors, overlapping cycles.

supabase/migrations/20260824000000_automation_execution_attempts.sql Table + partial unique index on one open attempt per automation.

### Key Functions/Classes Added

```typescript
class TriggerEvaluator {
  constructor(deps?: TriggerEvaluatorDeps);
  evaluate(triggerConditions: unknown, context?: ExecutionContext): Promise<TriggerEvaluationResult>;
  evaluateStored(automation: StoredAutomation, context?: ExecutionContext): Promise<TriggerEvaluationResult>;
}
function parseActionConfig(actionConfig: unknown): {
  executionType: ExecutionType;
  executionConfig: ExecutionConfig;
};
class ExecutionAttemptRegistry {
  isInFlight(automationId: string): boolean;
  tryClaim(automationId: string): Promise<ExecutionAttempt | null>;
  markExecuting(attemptId: string): Promise<ExecutionAttempt>;
  markSubmitted(attemptId: string, transactionHash: string): Promise<ExecutionAttempt>;
  markResolved(attemptId: string, transactionHash?: string): Promise<ExecutionAttempt>;
  markFailed(attemptId: string, error: string): Promise<ExecutionAttempt>;
  release(automationId: string): void;
}
// AutomationService
evaluatePersistedAutomation(automation: StoredAutomation): Promise<TriggerEvaluationResult>;
isInFlight(automationId: string): boolean;
tryBeginExecution(automationId: string): Promise<ExecutionAttempt | null>;
executePersistedAutomation(automation: StoredAutomation, attemptId?: string): Promise<ExecutionResult>;
confirmExecution(attemptId: string, transactionHash?: string): Promise<void>;
completeExecution(automationId: string): void;
// AutomationHandler
checkAutomationTriggers(): Promise<void>;           // single-flight poll
processActiveAutomations(automations: StoredAutomation[]): Promise<void>;
evaluateTriggerConditions(automation: StoredAutomation): Promise<boolean>;
```

### Patterns Used

Reuse, don’t fork: poll-path evaluation dispatches to existing trigger classes; do not add a second price/volume comparator in the websocket package.
Evaluate then execute: automation:triggered only after a real met === true and a successful claim; automation:executed only after Horizon/engine returns. Never setTimeout to fake latency.

Two-tier idempotency: reserve the automation id synchronously in memory before any await; persist pending → executing → submitted (hash written immediately after submit). If transaction_hash exists, reuse it — do not call submitTransaction again. Mark resolved only after the websocket emit (confirmExecution).

Single-flight polling: isPolling + schedule next tick after the previous cycle completes. Per-automation tryClaim still protects concurrent processActiveAutomations callers.

Deterministic miss: unknown, missing, or event-type conditions on the poll path return false (events are push-based via EventTrigger.startListening).

Handler depends on AutomationRuntime: inject a fake in tests; production lazily constructs AutomationService. Keep automation:triggered / automation:executed payload fields stable.

## 📸 Screenshots (if applicable)

N/A (backend / websocket; no UI).

## ⚠️ Breaking Changes

Event names and payload schemas are unchanged. Behavior change (intentional): clients no longer receive random false-positive triggers or explorer-invalid tx_… hashes. Supabase realtime no longer synthesizes automation:executed on last_executed_at updates.

- [ x] No breaking changes
- [ ] Breaking changes documented in CHANGELOG.md

## 🔄 Deployment Notes

1.Apply Supabase migration supabase/migrations/20260824000000_automation_execution_attempts.sql before deploying the new websocket process (unique open-attempt index is required for crash-safe claims).

2.Set AUTOMATION_SOURCE_SECRET (and existing Stellar/Horizon env) so ExecutionEngine can sign. Without a keypair, chain actions fail with the real NO_SOURCE_KEYPAIR / Horizon error instead of a fake success.

3.Rolling restart is safe: in-flight rows with a hash will be reattached and not resent.

## ✅ Final Checklist

- [ x] Code follows project style guidelines
- [x ] Self-review completed
- [x ] No console.log or debug code left
- [x ] Error handling implemented
- [x ] Performance considered
- [x ] Security reviewed
- [ ] Documentation updated (required)
- [ ] ROADMAP.md updated with progress

---

**By submitting this PR, I confirm that**:
- ✅ I have updated all relevant documentation
- ✅ AI.md includes new patterns from my changes
- ✅ Examples are provided for new features
- ✅ The documentation is accurate and helpful for AI assistants and developers
