### PR TITLE
feat: fetch and cache SDEX liquidity stats

### DIFF
--- a/packages/core/defi-protocols/__tests__/protocols/sdex-protocol.test.ts
+++ b/packages/core/defi-protocols/__tests__/protocols/sdex-protocol.test.ts
@@ -154,11 +154,23 @@ describe('SdexProtocol – basics', () => {
     expect(horizonMock.ledgers).toHaveBeenCalledTimes(1);
   });
 
-  it('returns placeholder getStats()', async () => {
+  it('reports aggregate liquidity-pool depth in getStats()', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        _embedded: {
+          records: [
+            { reserves: [{ amount: '12.5000000' }, { amount: '7.5000000' }] },
+          ],
+        },
+      }),
+    } as Response);
+
     const stats = await protocol.getStats();
-    expect(stats.tvl).toBe('0');
-    expect(stats.totalSupply).toBe('0');
+    expect(stats.tvl).toBe('20.0000000');
+    expect(stats.totalSupply).toBe('20.0000000');
     expect(stats.timestamp).toBeInstanceOf(Date);
+    fetchMock.mockRestore();
   });
 
   it('throws when calling methods before initialize()', async () => {

--- a/packages/core/defi-protocols/__tests__/protocols/sdex-protocol.test.ts
+++ b/packages/core/defi-protocols/__tests__/protocols/sdex-protocol.test.ts
@@ -173,6 +173,50 @@ describe('SdexProtocol – basics', () => {
     fetchMock.mockRestore();
   });
 
+  it('uses the short-lived stats cache for repeated reads', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ _embedded: { records: [{ reserves: [{ amount: '4' }] }] } }),
+    } as Response);
+
+    await protocol.getStats();
+    await protocol.getStats();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    fetchMock.mockRestore();
+  });
+
+  it('follows liquidity-pool pagination and tolerates missing reserve arrays', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          _embedded: { records: [{ reserves: [{ amount: '2' }] }, {}] },
+          _links: { next: { href: 'https://horizon.example/page-2' } },
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ _embedded: { records: [{ reserves: [{ amount: '3' }] }] } }),
+      } as Response);
+
+    const stats = await protocol.getStats();
+
+    expect(stats.tvl).toBe('5.0000000');
+    expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://horizon.example/page-2');
+    fetchMock.mockRestore();
+  });
+
+  it('propagates a failed liquidity-pool response', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 503,
+    } as Response);
+
+    await expect(protocol.getStats()).rejects.toThrow(/liquidity_pools returned 503/i);
+    fetchMock.mockRestore();
+  });
+
   it('throws when calling methods before initialize()', async () => {
     const uninit = new SdexProtocol(mockConfig);
     await expect(uninit.getSwapQuote(XLM, USDC, '10')).rejects.toThrow(/not initialized/i);

--- a/packages/core/defi-protocols/src/protocols/sdex/sdex-protocol.ts
+++ b/packages/core/defi-protocols/src/protocols/sdex/sdex-protocol.ts
@@ -58,6 +58,8 @@ import {
  * @extends BaseProtocol
  */
 export class SdexProtocol extends BaseProtocol {
+  private static readonly STATS_CACHE_TTL_MS = 30_000;
+  private statsCache?: { value: ProtocolStats; expiresAt: number };
   /**
    * @param config - Protocol configuration. `contractAddresses` may be empty
    *   because SDEX is a native Stellar feature — no smart-contract addresses
@@ -98,14 +100,51 @@ export class SdexProtocol extends BaseProtocol {
 
   public async getStats(): Promise<ProtocolStats> {
     this.ensureInitialized();
-    // SDEX stats are network-wide; surface placeholder values.
-    return {
-      totalSupply: '0',
-      totalBorrow: '0',
-      tvl: '0',
-      utilizationRate: 0,
-      timestamp: new Date(),
-    };
+    if (this.statsCache && Date.now() < this.statsCache.expiresAt) {
+      return this.statsCache.value;
+    }
+
+    try {
+      const records = await this.fetchAllLiquidityPools();
+      const depth = records.reduce((total, pool) => {
+        const reserves = Array.isArray(pool.reserves) ? pool.reserves : [];
+        return total.plus(reserves.reduce(
+          (sum, reserve) => sum.plus(String(reserve.amount ?? '0')),
+          new BigNumber(0),
+        ));
+      }, new BigNumber(0));
+
+      const value: ProtocolStats = {
+        // Horizon exposes reserve amounts, not a universal USD oracle. Report
+        // aggregate reserve depth honestly rather than returning fake zeros.
+        totalSupply: depth.toFixed(7),
+        tvl: depth.toFixed(7),
+        // SDEX has no lending market by definition.
+        totalBorrow: '0',
+        utilizationRate: 0,
+        timestamp: new Date(),
+      };
+      this.statsCache = { value, expiresAt: Date.now() + SdexProtocol.STATS_CACHE_TTL_MS };
+      return value;
+    } catch (error) {
+      this.handleError(error, 'getStats');
+    }
+  }
+
+  private async fetchAllLiquidityPools(): Promise<Array<{ reserves?: Array<{ amount?: string }> }>> {
+    const records: Array<{ reserves?: Array<{ amount?: string }> }> = [];
+    let nextUrl: string | undefined = `${this.config.network.horizonUrl.replace(/\/$/, '')}/liquidity_pools?limit=200`;
+    while (nextUrl) {
+      const response = await fetch(nextUrl);
+      if (!response.ok) throw new Error(`Horizon liquidity_pools returned ${response.status}`);
+      const page = await response.json() as {
+        _embedded?: { records?: Array<{ reserves?: Array<{ amount?: string }> }> };
+        _links?: { next?: { href?: string } };
+      };
+      records.push(...(page._embedded?.records ?? []));
+      nextUrl = page._links?.next?.href;
+    }
+    return records;
   }
 
   // ─── Unsupported lending operations ───────────────────────────────────────

--- a/packages/core/defi-protocols/src/protocols/sdex/sdex-stats.test.ts
+++ b/packages/core/defi-protocols/src/protocols/sdex/sdex-stats.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+describe('SDEX statistics contract', () => {
+  it('documents the structural non-lending fields', () => {
+    const stats = { totalBorrow: '0', utilizationRate: 0 };
+    expect(stats.totalBorrow).toBe('0');
+    expect(stats.utilizationRate).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #409

Replaces hardcoded SDEX statistics with paginated Horizon liquidity-pool reserve aggregation and a 30-second in-memory cache. Reports reserve depth honestly, documents that borrow/utilization are structurally not applicable, and propagates Horizon failures.

Verification: git diff checks passed. Full npm tests were not run because dependencies are not installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SDEX statistics now report aggregate liquidity-pool reserves as total supply and TVL instead of placeholder zero values.
  * Statistics are cached for 30 seconds to provide timely data while reducing unnecessary requests.

* **Bug Fixes**
  * Improved handling of paginated liquidity-pool data and failed data requests.

* **Tests**
  * Added coverage for liquidity depth and non-lending statistics, including zero borrowing and utilization values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->