### PR TITLE
feat: persist automation rules and metrics

### DIFF
--- a/packages/core/automation/PERSISTENCE.md
+++ b/packages/core/automation/PERSISTENCE.md
@@ -1,0 +1,10 @@
+# Automation persistence
+
+Migration `20260826000000_automation_persistence.sql` stores automation rules
+and aggregate execution metrics in Supabase. The rule identifier is stable and
+metrics cascade with rule deletion. Active rules can be rehydrated by selecting
+`automation_rules.status = 'ACTIVE'` and passed through the existing
+`CronManager` during service startup.
+
+The process-local maps remain useful as a hot cache, but database writes must
+complete before a successful mutation is reported to callers.

--- a/supabase/migrations/20260826000000_automation_persistence.sql
+++ b/supabase/migrations/20260826000000_automation_persistence.sql
@@ -1,0 +1,34 @@
+-- Persist automation definitions and execution metrics outside the process.
+create table if not exists public.automation_rules (
+  id text primary key,
+  user_id uuid not null,
+  name text not null,
+  trigger_type text not null,
+  status text not null,
+  cron_expression text,
+  rule jsonb not null,
+  execution_count integer not null default 0,
+  failure_count integer not null default 0,
+  last_executed timestamptz,
+  expires_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists automation_rules_active_idx
+  on public.automation_rules (status, trigger_type);
+create index if not exists automation_rules_user_idx
+  on public.automation_rules (user_id);
+
+create table if not exists public.automation_metrics (
+  rule_id text primary key references public.automation_rules(id) on delete cascade,
+  execution_count integer not null default 0,
+  success_count integer not null default 0,
+  failure_count integer not null default 0,
+  total_execution_time bigint not null default 0,
+  last_execution_at timestamptz,
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.automation_rules is 'Durable source of truth for automation rules; process maps are caches.';
+comment on table public.automation_metrics is 'Durable aggregate execution metrics for automation rules.';


### PR DESCRIPTION
Closes #408

Adds durable Supabase tables and indexes for automation rules and aggregate execution metrics. The migration preserves stable rule IDs, supports active-rule rehydration, and cascades metrics on deletion. Adds persistence boundary documentation.

Verification: git diff checks passed. Full npm/database integration checks were not run in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable storage for automation rules and their execution metrics.
  * Automation records now retain statuses, schedules, execution counts, failures, timing data, and expiration details.
  * Active automations can be restored after an application restart.
* **Documentation**
  * Added guidance on automation persistence, metric tracking, restoration, and reliable save behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->