### PR TITLE
Integrate Aquarius protocol adapter with pool discovery and reward cl…

### DIFF
--- a/packages/core/defi-protocols/__tests__/protocols/aquarius-protocol.test.ts
+++ b/packages/core/defi-protocols/__tests__/protocols/aquarius-protocol.test.ts
@@ -1,0 +1,124 @@
+import { AquariusProtocol } from '../../src/protocols/aquarius/aquarius-protocol.js';
+import { ProtocolConfig, ProtocolType, Asset } from '../../src/types/defi-types.js';
+import { SdexProtocol } from '../../src/protocols/sdex/sdex-protocol.js';
+import { Operation, TransactionBuilder, BASE_FEE, Keypair } from '@stellar/stellar-sdk';
+
+jest.mock('@stellar/stellar-sdk', () => {
+  const original = jest.requireActual('@stellar/stellar-sdk');
+  return {
+    ...original,
+    Operation: {
+      ...original.Operation,
+      claimClaimableBalance: jest.fn().mockImplementation((opts) => original.Operation.claimClaimableBalance(opts))
+    }
+  };
+});
+
+global.fetch = jest.fn();
+
+describe('AquariusProtocol', () => {
+  let protocol: AquariusProtocol;
+  const mockConfig: ProtocolConfig = {
+    protocolId: 'aquarius',
+    name: 'Aquarius',
+    network: {
+      network: 'testnet',
+      passphrase: 'Test SDF Network ; September 2015',
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+      sorobanRpcUrl: 'https://soroban-testnet.stellar.org'
+    },
+    contractAddresses: {},
+    metadata: {}
+  };
+
+  beforeEach(() => {
+    protocol = new AquariusProtocol(mockConfig);
+    jest.clearAllMocks();
+  });
+
+  describe('Initialization', () => {
+    it('should initialize successfully', async () => {
+      // Mock horizon server ledgers call
+      const mockCall = jest.fn().mockResolvedValue({});
+      const mockLimit = jest.fn().mockReturnValue({ call: mockCall });
+      (protocol as any).horizonServer.ledgers = jest.fn().mockReturnValue({ limit: mockLimit });
+      
+      await expect(protocol.initialize()).resolves.not.toThrow();
+      expect(protocol.isInitialized()).toBe(true);
+    });
+
+    it('should return correct protocol type', () => {
+      expect(protocol.type).toBe(ProtocolType.DEX);
+    });
+  });
+
+  describe('getIncentivizedPools', () => {
+    it('should query Aquarius API', async () => {
+      (protocol as any).initialized = true;
+      const mockPools = [{ pool_id: 'pool1' }];
+      (fetch as unknown as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockPools
+      });
+
+      const pools = await protocol.getIncentivizedPools();
+      expect(pools).toEqual(mockPools);
+      expect(fetch).toHaveBeenCalledWith('https://amm-api.aquarius.network/pools');
+    });
+
+    it('should throw on API error', async () => {
+      (protocol as any).initialized = true;
+      (fetch as unknown as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Not Found'
+      });
+
+      await expect(protocol.getIncentivizedPools()).rejects.toThrow('Failed to fetch Aquarius pools: Not Found');
+    });
+  });
+
+  describe('claimRewards', () => {
+    const mockWallet = 'GDFV6WBXVLJPV3LDOS45SR7MK4ZWTVULJ3P7HQ77CXCVHSA5G2C46PI4';
+    const mockPrivateKey = 'SBISGP3Y7V62ZUPUBAEFUNRIL2O5A7HRVNFGFHDSZYTQ6XNCSQYFF3RK';
+    
+    beforeEach(() => {
+      (protocol as any).initialized = true;
+      
+      // Mock horizon server for submitting tx
+      (protocol as any).horizonServer.loadAccount = jest.fn().mockResolvedValue({
+        accountId: () => mockWallet,
+        sequenceNumber: () => '1',
+        incrementSequenceNumber: jest.fn()
+      });
+      (protocol as any).horizonServer.submitTransaction = jest.fn().mockResolvedValue({
+        hash: 'testhash',
+        successful: true,
+        ledger: 100
+      });
+    });
+
+    it('should require balanceIds', async () => {
+      await expect(protocol.claimRewards(mockWallet, mockPrivateKey, [])).rejects.toThrow('No balance IDs provided');
+    });
+
+    it('should build and submit claim transaction', async () => {
+      
+      const result = await protocol.claimRewards(mockWallet, mockPrivateKey, ['000000000000000000000000000000000000000000000000000000000000000000000001', '000000000000000000000000000000000000000000000000000000000000000000000002']);
+      
+      expect(result.status).toBe('success');
+      expect(result.hash).toBe('testhash');
+      expect(result.ledger).toBe(100);
+      expect(Operation.claimClaimableBalance).toHaveBeenCalledTimes(2);
+      expect(Operation.claimClaimableBalance).toHaveBeenCalledWith({ balanceId: '000000000000000000000000000000000000000000000000000000000000000000000001' });
+      expect(Operation.claimClaimableBalance).toHaveBeenCalledWith({ balanceId: '000000000000000000000000000000000000000000000000000000000000000000000002' });
+    });
+
+    it('should return unsigned transaction if no private key', async () => {
+      const result = await protocol.claimRewards(mockWallet, '', ['000000000000000000000000000000000000000000000000000000000000000000000001']);
+      
+      expect(result.status).toBe('pending');
+      expect(result.hash).toBeDefined();
+      expect(result.metadata?.operation).toBe('claimRewards');
+    });
+  });
+});

--- a/packages/core/defi-protocols/__tests__/services/dex-aggregator.test.ts
+++ b/packages/core/defi-protocols/__tests__/services/dex-aggregator.test.ts
@@ -282,8 +282,8 @@ describe('DexAggregator (services/dex-aggregator.ts)', () => {
 
       expect(factory.createProtocol).toHaveBeenCalledTimes(1);
       const cfg = factory.createProtocol.mock.calls[0][0];
-      expect(cfg.protocolId).toBe('sdex');
-      expect(cfg.name).toBe('Stellar DEX');
+      expect(cfg.protocolId).toBe('aquarius');
+      expect(cfg.name).toBe('Aquarius');
     });
 
     it('dispatches a split with Aquarius + Soroswap and applies correct venue configs', async () => {
@@ -307,7 +307,7 @@ describe('DexAggregator (services/dex-aggregator.ts)', () => {
 
       expect(proto.swap).toHaveBeenCalledTimes(2);
       const venueConfigs = factory.createProtocol.mock.calls.map((c) => c[0].protocolId);
-      expect(venueConfigs).toEqual(['soroswap', 'sdex']);
+      expect(venueConfigs).toEqual(['soroswap', 'aquarius']);
     });
   });
 

--- a/packages/core/defi-protocols/src/index.ts
+++ b/packages/core/defi-protocols/src/index.ts
@@ -42,6 +42,7 @@ export type {
 export * from './protocols/blend/index.js';
 export * from './protocols/soroswap/index.js';
 export * from './protocols/sdex/index.js';
+export * from './protocols/aquarius/index.js';
 
 // Services
 export { ProtocolFactory, getProtocolFactory } from './services/protocol-factory.js';

--- a/packages/core/defi-protocols/src/protocols/aquarius/aquarius-protocol.ts
+++ b/packages/core/defi-protocols/src/protocols/aquarius/aquarius-protocol.ts
@@ -1,0 +1,80 @@
+/**
+ * @fileoverview Aquarius Protocol implementation
+ * @description Aquarius DEX adapter with reward claiming
+ */
+
+import { Asset, TransactionResult, ProtocolConfig, ProtocolType } from '../../types/defi-types.js';
+import { SdexProtocol } from '../sdex/sdex-protocol.js';
+import { Operation, TransactionBuilder, BASE_FEE, Keypair } from '@stellar/stellar-sdk';
+import { InvalidOperationError } from '../../errors/index.js';
+
+export class AquariusProtocol extends SdexProtocol {
+  private readonly baseUrl = 'https://amm-api.aquarius.network';
+
+  constructor(config: ProtocolConfig) {
+    super(config);
+  }
+
+  protected getProtocolType(): ProtocolType {
+    return ProtocolType.DEX;
+  }
+
+  public async getIncentivizedPools(): Promise<any> {
+    this.ensureInitialized();
+    const res = await fetch(`${this.baseUrl}/pools`);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch Aquarius pools: ${res.statusText}`);
+    }
+    return res.json();
+  }
+
+  public async claimRewards(
+    walletAddress: string,
+    privateKey: string,
+    balanceIds: string[]
+  ): Promise<TransactionResult> {
+    this.ensureInitialized();
+    this.validateAddress(walletAddress);
+
+    if (!balanceIds || balanceIds.length === 0) {
+      throw new Error('No balance IDs provided for claiming rewards');
+    }
+
+    try {
+      const sourceKeypair = privateKey ? Keypair.fromSecret(privateKey) : undefined;
+      const account = await this.horizonServer.loadAccount(walletAddress);
+
+      let txBuilder = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      });
+
+      for (const balanceId of balanceIds) {
+        txBuilder = txBuilder.addOperation(
+          Operation.claimClaimableBalance({ balanceId })
+        );
+      }
+
+      const transaction = txBuilder.setTimeout(180).build();
+
+      if (!sourceKeypair) {
+        return this.buildTransactionResult(transaction.toXDR(), 'pending', 0, {
+          operation: 'claimRewards',
+          protocol: 'aquarius'
+        });
+      }
+
+      transaction.sign(sourceKeypair);
+      const res = await this.horizonServer.submitTransaction(transaction);
+
+      return this.buildTransactionResult(
+        res.hash,
+        res.successful ? 'success' : 'failed',
+        res.ledger,
+        { operation: 'claimRewards', protocol: 'aquarius' }
+      );
+    } catch (error) {
+      this.handleError(error, 'claimRewards');
+    }
+  }
+}

--- a/packages/core/defi-protocols/src/protocols/aquarius/aquarius-registration.ts
+++ b/packages/core/defi-protocols/src/protocols/aquarius/aquarius-registration.ts
@@ -1,0 +1,14 @@
+/**
+ * @fileoverview Aquarius Protocol factory registration
+ */
+
+import { getProtocolFactory } from '../../services/protocol-factory.js';
+import { AquariusProtocol } from './aquarius-protocol.js';
+
+export function registerAquariusProtocol(): void {
+  const factory = getProtocolFactory();
+  factory.register('aquarius', AquariusProtocol as any);
+}
+
+// Auto-register when module is imported
+registerAquariusProtocol();

--- a/packages/core/defi-protocols/src/protocols/aquarius/aquarius-types.ts
+++ b/packages/core/defi-protocols/src/protocols/aquarius/aquarius-types.ts
@@ -1,0 +1,9 @@
+import { Asset } from '../../types/defi-types.js';
+
+export interface AquariusPool {
+  pool_id: string;
+  name: string;
+  asset_a: Asset;
+  asset_b: Asset;
+  fee_tier: number;
+}

--- a/packages/core/defi-protocols/src/protocols/aquarius/index.ts
+++ b/packages/core/defi-protocols/src/protocols/aquarius/index.ts
@@ -1,0 +1,3 @@
+export * from './aquarius-protocol.js';
+export * from './aquarius-registration.js';
+export * from './aquarius-types.js';

--- a/packages/core/defi-protocols/src/services/dex-aggregator.ts
+++ b/packages/core/defi-protocols/src/services/dex-aggregator.ts
@@ -137,9 +137,7 @@ export class DexAggregator implements IDexAggregator {
       case 'sdex':
         return { ...this.baseConfig, protocolId: 'sdex', name: 'Stellar DEX' };
       case 'aquarius':
-        // Aquarius AMM orders settle through the Stellar DEX order book,
-        // so execution uses the SDEX path-payment protocol.
-        return { ...this.baseConfig, protocolId: 'sdex', name: 'Stellar DEX' };
+        return { ...this.baseConfig, protocolId: 'aquarius', name: 'Aquarius' };
       case 'soroswap':
       default:
         return { ...this.baseConfig, protocolId: 'soroswap' };


### PR DESCRIPTION
Closes #365

## What changed

Adds an AquariusProtocol adapter (extending SdexProtocol) implementing IDefiProtocol, enabling:
- Discovery of Aquarius-supported pools via `getIncentivizedPools()`
- AQUA reward claiming via `claimRewards()`, using Stellar's native claimClaimableBalance operation
- Routing of Aquarius-venue trades through the new adapter in the aggregator, rather than the generic SDEX adapter

## Files added/modified

Added:
- `packages/core/defi-protocols/src/protocols/aquarius/aquarius-types.ts`
- `packages/core/defi-protocols/src/protocols/aquarius/aquarius-protocol.ts`
- `packages/core/defi-protocols/src/protocols/aquarius/aquarius-registration.ts`
- `packages/core/defi-protocols/src/protocols/aquarius/index.ts`
- `packages/core/defi-protocols/__tests__/protocols/aquarius-protocol.test.ts`

Modified:
- `packages/core/defi-protocols/src/index.ts` (barrel export for the new protocol module)
- `packages/core/defi-protocols/src/services/dex-aggregator.ts` (routes `aquarius` venue to its own protocolId instead of falling back to `sdex`)
- `packages/core/defi-protocols/__tests__/services/dex-aggregator.test.ts` (two existing tests asserted the old placeholder behavior where Aquarius executed through the generic SDEX adapter; updated to assert the new dedicated Aquarius routing per this issue's requirements)

## Security & rollback notes

- Reward claiming only reads pool/reward state via a public Aquarius API endpoint and performs claims through Stellar's standard `claimClaimableBalance` operation, the same signing/custody path already used by other protocol adapters. No new custody or signing logic introduced.
- Aggregator routing change is isolated to a single switch-case branch in `dex-aggregator.ts`; reverting to the old `sdex` fallback for the `aquarius` case is a one-line change if needed.
- No new endpoints, database tables, or persistence introduced.

